### PR TITLE
Architecture phase 2a: extract OpenProjectCustomFieldService

### DIFF
--- a/src/clients/openproject_client.py
+++ b/src/clients/openproject_client.py
@@ -190,8 +190,9 @@ class OpenProjectClient:
         self._users_cache: list[dict[str, Any]] | None = None
         self._users_cache_time: float | None = None
         self._users_by_email_cache: dict[str, dict[str, Any]] = {}
-        self._custom_fields_cache: list[dict[str, Any]] | None = None
-        self._custom_fields_cache_time: float = 0.0
+        # ``_custom_fields_cache`` and ``_custom_fields_cache_time`` moved into
+        # ``OpenProjectCustomFieldService`` (see ``self.custom_fields`` below,
+        # initialised after the dependent clients are wired up).
 
         # Get config values
         op_config = config.openproject_config
@@ -315,6 +316,13 @@ class OpenProjectClient:
 
         self.batch_size = batch_size
         self.parallel_workers = max_workers
+
+        # Composed services (Phase 2 of ADR-002 — splitting the god-class along
+        # functional seams). Backward-compat: same-named methods on
+        # OpenProjectClient delegate to the corresponding service.
+        from src.clients.openproject_custom_field_service import OpenProjectCustomFieldService
+
+        self.custom_fields = OpenProjectCustomFieldService(self)
 
         logger.success(
             "OpenProjectClient initialized for host %s, container %s",
@@ -1784,39 +1792,11 @@ class OpenProjectClient:
     def ensure_wp_custom_field_id(self, name: str, field_format: str = "text") -> int:
         """Ensure a WorkPackageCustomField exists, returning its ID.
 
-        Unlike :py:meth:`ensure_work_package_custom_field` (which uses
-        ``is_for_all: true`` and returns the full CF dict), this variant
-        creates the CF with ``is_for_all: false`` so the caller can then
-        selectively enable it on specific projects via
-        :py:meth:`enable_custom_field_for_projects`. Returns just the ID.
-
-        Migration components that need per-project CF enablement
-        (Labels, AffectsVersions, StoryPoints, Sprint/Epic, etc.) call this.
-
-        Args:
-            name: Custom field display name
-            field_format: Rails field format (string, text, int, float, etc.)
-
-        Returns:
-            Custom field ID, or 0 if creation failed.
-
+        Thin delegator over ``self.custom_fields.ensure_wp_custom_field_id``;
+        see :py:class:`~src.clients.openproject_custom_field_service.OpenProjectCustomFieldService`
+        for the full docstring.
         """
-        try:
-            cf = self.get_custom_field_by_name(name)
-            cf_id = int(cf.get("id", 0) or 0) if isinstance(cf, dict) else None
-            if cf_id:
-                return cf_id
-        except Exception:
-            self.logger.info("CF '%s' not found; will create (format=%s)", name, field_format)
-
-        escaped = escape_ruby_single_quoted(name)
-        script = (
-            f"cf = CustomField.find_by(type: 'WorkPackageCustomField', name: '{escaped}'); "
-            f"if !cf; cf = CustomField.new(name: '{escaped}', field_format: '{field_format}', "
-            f"is_required: false, is_for_all: false, type: 'WorkPackageCustomField'); cf.save; end; cf.id"
-        )
-        result = self.execute_query(script)
-        return int(result) if result else 0
+        return self.custom_fields.ensure_wp_custom_field_id(name, field_format)
 
     def enable_custom_field_for_projects(
         self,
@@ -1826,36 +1806,9 @@ class OpenProjectClient:
     ) -> None:
         """Enable a custom field for specific projects only.
 
-        Pairs with :py:meth:`ensure_wp_custom_field_id` (which creates the
-        CF with ``is_for_all: false``). Idempotent: uses ``find_or_create_by!``
-        on the join table.
-
-        Args:
-            cf_id: Custom field ID
-            project_ids: Set of project IDs to enable the field for
-            cf_name: Optional display name for logging
-
+        Thin delegator over ``self.custom_fields.enable_custom_field_for_projects``.
         """
-        if not project_ids:
-            return
-        project_ids_str = ", ".join(str(pid) for pid in sorted(project_ids))
-        script = (
-            f"cf = CustomField.find({cf_id})\n"
-            f"[{project_ids_str}].each do |pid|\n"
-            f"  begin\n"
-            f"    project = Project.find(pid)\n"
-            f"    CustomFieldsProject.find_or_create_by!(custom_field: cf, project: project)\n"
-            f"  rescue ActiveRecord::RecordNotFound\n"
-            f"  end\n"
-            f"end\n"
-            f"true"
-        )
-        try:
-            self.execute_query(script)
-            display = cf_name or str(cf_id)
-            self.logger.info("Enabled %s CF for %d projects", display, len(project_ids))
-        except Exception:
-            self.logger.warning("Failed to enable CF for some projects")
+        self.custom_fields.enable_custom_field_for_projects(cf_id, project_ids, cf_name=cf_name)
 
     def remove_custom_field(self, name: str, *, cf_type: str | None = None) -> dict[str, int]:
         """Remove CustomField records matching the provided name/type."""
@@ -4627,107 +4580,23 @@ J2O_DATA
     def get_custom_field_by_name(self, name: str) -> dict[str, Any]:
         """Find a custom field by name.
 
-        Args:
-            name: The name of the custom field to find
-
-        Returns:
-            The custom field
-
-        Raises:
-            RecordNotFoundError: If custom field with given name is not found
-
+        Thin delegator over ``self.custom_fields.get_by_name``.
         """
-        return self.find_record("CustomField", {"name": name})
+        return self.custom_fields.get_by_name(name)
 
     def get_custom_field_id_by_name(self, name: str) -> int:
         """Find a custom field ID by name.
 
-        Args:
-            name: The name of the custom field to find
-
-        Returns:
-            The custom field ID
-
-        Raises:
-            RecordNotFoundError: If custom field with given name is not found
-            QueryExecutionError: If query fails
-
+        Thin delegator over ``self.custom_fields.get_id_by_name``.
         """
-        try:
-            result = self.execute_query(f"CustomField.where(name: '{escape_ruby_single_quoted(name)}').first&.id")
-
-            # Handle nil value from Ruby
-            if result is None:
-                msg = f"Custom field '{name}' not found"
-                raise RecordNotFoundError(msg)
-
-            # Handle integer result
-            if isinstance(result, int):
-                return result
-
-            # Try to convert string to int
-            if isinstance(result, str):
-                try:
-                    return int(result)
-                except ValueError:
-                    msg = f"Invalid ID format: {result}"
-                    raise QueryExecutionError(msg) from None
-
-            msg = f"Unexpected result type: {type(result)}"
-            raise QueryExecutionError(msg)
-
-        except RecordNotFoundError:
-            raise  # Re-raise RecordNotFoundError
-        except Exception as e:
-            msg = "Error getting custom field ID."
-            raise QueryExecutionError(msg) from e
+        return self.custom_fields.get_id_by_name(name)
 
     def get_custom_fields(self, *, force_refresh: bool = False) -> list[dict[str, Any]]:
-        """Get all custom fields from OpenProject.
+        """Get all custom fields from OpenProject (cached for 5 minutes).
 
-        Args:
-            force_refresh: If True, force refresh from server, ignoring cache
-
-        Returns:
-            List of custom field dictionaries
-
-        Raises:
-            QueryExecutionError: If query execution fails
-
+        Thin delegator over ``self.custom_fields.get_all``.
         """
-        current_time = time.time()
-        cache_timeout = 300  # 5 minutes
-
-        # Check cache first (unless force refresh)
-        if (
-            not force_refresh
-            and self._custom_fields_cache
-            and (current_time - self._custom_fields_cache_time) < cache_timeout
-        ):
-            logger.debug(
-                "Using cached custom fields (age: %.1fs)",
-                current_time - self._custom_fields_cache_time,
-            )
-            return self._custom_fields_cache
-
-        try:
-            # Centralized execution path
-            file_path = self._generate_unique_temp_filename("custom_fields")
-            custom_fields = self.execute_large_query_to_json_file(
-                "CustomField.all",
-                container_file=file_path,
-                timeout=90,
-            )
-
-            # Update cache
-            self._custom_fields_cache = custom_fields or []
-            self._custom_fields_cache_time = current_time
-
-            return custom_fields if isinstance(custom_fields, list) else []
-
-        except Exception as e:
-            msg = "Failed to get custom fields."
-            raise QueryExecutionError(msg) from e
+        return self.custom_fields.get_all(force_refresh=force_refresh)
 
     def get_statuses(self) -> list[dict[str, Any]]:
         """Get all statuses from OpenProject.

--- a/src/clients/openproject_custom_field_service.py
+++ b/src/clients/openproject_custom_field_service.py
@@ -1,0 +1,211 @@
+"""Custom-field operations against an OpenProject instance.
+
+First slice of the Phase 2 split of ``OpenProjectClient`` (ADR-002 phase 2):
+the simpler, mostly self-contained custom-field helpers move here. The
+heavier methods (``ensure_work_package_custom_field``, ``ensure_custom_field``,
+``remove_custom_field``, ``ensure_origin_custom_fields``,
+``ensure_j2o_provenance_custom_fields``, ``delete_all_custom_fields``,
+``bulk_set_wp_custom_field_values``, ``batch_get_custom_fields_by_names``)
+will follow in subsequent PRs.
+
+Design note
+-----------
+
+The service holds a back-reference to its parent ``OpenProjectClient`` so it
+can reuse the script-execution machinery (``execute_query``, ``find_record``,
+``execute_large_query_to_json_file``, ``_generate_unique_temp_filename``)
+rather than duplicating it. ``OpenProjectClient`` exposes the service via
+``self.custom_fields`` and keeps thin delegators for the same method names
+so existing call sites (migrations, tests) work unchanged.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from src.clients.exceptions import QueryExecutionError, RecordNotFoundError
+
+if TYPE_CHECKING:
+    from src.clients.openproject_client import OpenProjectClient
+
+
+class OpenProjectCustomFieldService:
+    """Read/write helpers for OpenProject CustomField records."""
+
+    # Cache duration for ``get_custom_fields`` (seconds).
+    CACHE_TTL_SECONDS: int = 300
+
+    def __init__(self, client: OpenProjectClient) -> None:
+        self._client = client
+        self._logger = client.logger
+        self._cache: list[dict[str, Any]] | None = None
+        self._cache_time: float = 0.0
+
+    # ── creation / enablement ─────────────────────────────────────────────
+
+    def ensure_wp_custom_field_id(self, name: str, field_format: str = "text") -> int:
+        """Ensure a WorkPackageCustomField exists, returning its ID.
+
+        Unlike :py:meth:`OpenProjectClient.ensure_work_package_custom_field`
+        (which uses ``is_for_all: true`` and returns the full CF dict), this
+        variant creates the CF with ``is_for_all: false`` so the caller can
+        then selectively enable it on specific projects via
+        :py:meth:`enable_custom_field_for_projects`. Returns just the ID.
+
+        Migration components that need per-project CF enablement (Labels,
+        AffectsVersions, StoryPoints, Sprint/Epic, etc.) call this.
+
+        Args:
+            name: Custom field display name
+            field_format: Rails field format (string, text, int, float, etc.)
+
+        Returns:
+            Custom field ID, or 0 if creation failed.
+
+        """
+        # Lazy import avoids the openproject_client ↔ this-module import cycle
+        # at module load time.
+        from src.clients.openproject_client import escape_ruby_single_quoted
+
+        try:
+            cf = self.get_by_name(name)
+            cf_id = int(cf.get("id", 0) or 0) if isinstance(cf, dict) else None
+            if cf_id:
+                return cf_id
+        except Exception:
+            self._logger.info("CF '%s' not found; will create (format=%s)", name, field_format)
+
+        escaped = escape_ruby_single_quoted(name)
+        script = (
+            f"cf = CustomField.find_by(type: 'WorkPackageCustomField', name: '{escaped}'); "
+            f"if !cf; cf = CustomField.new(name: '{escaped}', field_format: '{field_format}', "
+            f"is_required: false, is_for_all: false, type: 'WorkPackageCustomField'); cf.save; end; cf.id"
+        )
+        result = self._client.execute_query(script)
+        return int(result) if result else 0
+
+    def enable_custom_field_for_projects(
+        self,
+        cf_id: int,
+        project_ids: set[int],
+        cf_name: str | None = None,
+    ) -> None:
+        """Enable a custom field for specific projects only.
+
+        Pairs with :py:meth:`ensure_wp_custom_field_id` (which creates the CF
+        with ``is_for_all: false``). Idempotent: uses ``find_or_create_by!``
+        on the join table.
+
+        Args:
+            cf_id: Custom field ID
+            project_ids: Set of project IDs to enable the field for
+            cf_name: Optional display name for logging
+
+        """
+        if not project_ids:
+            return
+        project_ids_str = ", ".join(str(pid) for pid in sorted(project_ids))
+        script = (
+            f"cf = CustomField.find({cf_id})\n"
+            f"[{project_ids_str}].each do |pid|\n"
+            f"  begin\n"
+            f"    project = Project.find(pid)\n"
+            f"    CustomFieldsProject.find_or_create_by!(custom_field: cf, project: project)\n"
+            f"  rescue ActiveRecord::RecordNotFound\n"
+            f"  end\n"
+            f"end\n"
+            f"true"
+        )
+        try:
+            self._client.execute_query(script)
+            display = cf_name or str(cf_id)
+            self._logger.info("Enabled %s CF for %d projects", display, len(project_ids))
+        except Exception:
+            self._logger.warning("Failed to enable CF for some projects")
+
+    # ── lookup ────────────────────────────────────────────────────────────
+
+    def get_by_name(self, name: str) -> dict[str, Any]:
+        """Find a custom field by name.
+
+        Raises:
+            RecordNotFoundError: If custom field with given name is not found
+
+        """
+        return self._client.find_record("CustomField", {"name": name})
+
+    def get_id_by_name(self, name: str) -> int:
+        """Find a custom field ID by name.
+
+        Raises:
+            RecordNotFoundError: If custom field with given name is not found
+            QueryExecutionError: If query fails
+
+        """
+        # Lazy import avoids the import cycle at module load time.
+        from src.clients.openproject_client import escape_ruby_single_quoted
+
+        try:
+            result = self._client.execute_query(
+                f"CustomField.where(name: '{escape_ruby_single_quoted(name)}').first&.id",
+            )
+
+            if result is None:
+                msg = f"Custom field '{name}' not found"
+                raise RecordNotFoundError(msg)
+
+            if isinstance(result, int):
+                return result
+
+            if isinstance(result, str):
+                try:
+                    return int(result)
+                except ValueError:
+                    msg = f"Invalid ID format: {result}"
+                    raise QueryExecutionError(msg) from None
+
+            msg = f"Unexpected result type: {type(result)}"
+            raise QueryExecutionError(msg)
+
+        except RecordNotFoundError:
+            raise
+        except Exception as e:
+            msg = "Error getting custom field ID."
+            raise QueryExecutionError(msg) from e
+
+    def get_all(self, *, force_refresh: bool = False) -> list[dict[str, Any]]:
+        """Get all custom fields from OpenProject (with a 5-minute cache).
+
+        Args:
+            force_refresh: If True, bypass the cache and refresh from the server.
+
+        Raises:
+            QueryExecutionError: If query execution fails
+
+        """
+        current_time = time.time()
+
+        if not force_refresh and self._cache and (current_time - self._cache_time) < self.CACHE_TTL_SECONDS:
+            self._logger.debug(
+                "Using cached custom fields (age: %.1fs)",
+                current_time - self._cache_time,
+            )
+            return self._cache
+
+        try:
+            file_path = self._client._generate_unique_temp_filename("custom_fields")
+            custom_fields = self._client.execute_large_query_to_json_file(
+                "CustomField.all",
+                container_file=file_path,
+                timeout=90,
+            )
+
+            self._cache = custom_fields or []
+            self._cache_time = current_time
+
+            return custom_fields if isinstance(custom_fields, list) else []
+
+        except Exception as e:
+            msg = "Failed to get custom fields."
+            raise QueryExecutionError(msg) from e

--- a/tests/unit/test_custom_field_project_enablement.py
+++ b/tests/unit/test_custom_field_project_enablement.py
@@ -23,11 +23,12 @@ class TestSelectiveProjectEnablementVerification:
     def test_base_ensure_wp_custom_field_uses_is_for_all_false(self):
         """Verify the shared CF-creation helper uses is_for_all: false.
 
-        ``BaseMigration._ensure_wp_custom_field`` is now a thin delegator over
-        ``OpenProjectClient.ensure_wp_custom_field_id`` (Phase 1.3 of ADR-002),
-        so the Ruby script — and the ``is_for_all: false`` invariant — lives
-        on the client. CF-creating migrations still call
-        ``self._ensure_wp_custom_field(...)``; the delegator routes through.
+        ``BaseMigration._ensure_wp_custom_field`` and
+        ``OpenProjectClient.ensure_wp_custom_field_id`` are both thin
+        delegators over
+        ``OpenProjectCustomFieldService.ensure_wp_custom_field_id``
+        (Phase 2a of ADR-002). The Ruby script — and the
+        ``is_for_all: false`` invariant — lives on the service.
 
         Reads the source file directly because conftest.py monkeypatches
         ``OpenProjectClient`` on the module, replacing the class with a
@@ -35,15 +36,16 @@ class TestSelectiveProjectEnablementVerification:
         """
         from pathlib import Path
 
-        src_path = Path(__file__).resolve().parents[2] / "src" / "clients" / "openproject_client.py"
+        src_path = Path(__file__).resolve().parents[2] / "src" / "clients" / "openproject_custom_field_service.py"
         text = src_path.read_text(encoding="utf-8")
 
         method_start = text.find("def ensure_wp_custom_field_id(")
-        assert method_start != -1, "OpenProjectClient.ensure_wp_custom_field_id not found"
+        assert method_start != -1, "OpenProjectCustomFieldService.ensure_wp_custom_field_id not found"
         method_end = text.find("\n    def ", method_start + 1)
         method_source = text[method_start:method_end]
         assert "is_for_all: false" in method_source, (
-            "OpenProjectClient.ensure_wp_custom_field_id should use is_for_all: false for selective project enablement"
+            "OpenProjectCustomFieldService.ensure_wp_custom_field_id should use "
+            "is_for_all: false for selective project enablement"
         )
 
     def test_all_cf_migrations_use_shared_ensure_method(self):

--- a/tests/unit/test_journal_deduplication.py
+++ b/tests/unit/test_journal_deduplication.py
@@ -362,25 +362,27 @@ class TestCustomFieldProjectEnablement:
         """Verify custom fields now use is_for_all: false.
 
         FIX VERIFIED: Custom fields are created with selective enablement.
-        After Phase 1.3 of ADR-002 the Ruby script lives on
-        ``OpenProjectClient.ensure_wp_custom_field_id``; ``BaseMigration``'s
-        ``_ensure_wp_custom_field`` is a thin delegator over it.
+        After Phase 2a of ADR-002 the Ruby script lives in
+        ``OpenProjectCustomFieldService.ensure_wp_custom_field_id`` (own
+        module). ``OpenProjectClient.ensure_wp_custom_field_id`` and
+        ``BaseMigration._ensure_wp_custom_field`` are thin delegators over it.
 
         Reads the source file directly because conftest.py monkeypatches
         ``OpenProjectClient`` on the module.
         """
         from pathlib import Path
 
-        src_path = Path(__file__).resolve().parents[2] / "src" / "clients" / "openproject_client.py"
+        src_path = Path(__file__).resolve().parents[2] / "src" / "clients" / "openproject_custom_field_service.py"
         text = src_path.read_text(encoding="utf-8")
 
         method_start = text.find("def ensure_wp_custom_field_id(")
-        assert method_start != -1, "OpenProjectClient.ensure_wp_custom_field_id not found"
+        assert method_start != -1, "OpenProjectCustomFieldService.ensure_wp_custom_field_id not found"
         method_end = text.find("\n    def ", method_start + 1)
         method_source = text[method_start:method_end]
 
         assert "is_for_all: false" in method_source, (
-            "OpenProjectClient.ensure_wp_custom_field_id should use is_for_all: false for selective project enablement"
+            "OpenProjectCustomFieldService.ensure_wp_custom_field_id should use "
+            "is_for_all: false for selective project enablement"
         )
 
     def test_custom_field_has_enable_method(self):


### PR DESCRIPTION
## Summary

- First slice of the Phase 2 split of the 7,266-line god-class \`OpenProjectClient\`: move 5 custom-field methods into a focused \`OpenProjectCustomFieldService\` class in its own module.
- \`openproject_client.py\`: **7,342 → 7,211 LOC** (-131). New \`openproject_custom_field_service.py\`: 211 LOC.
- No behaviour change.

## Changes

### `src/clients/openproject_custom_field_service.py` (new, 211 LOC)

`OpenProjectCustomFieldService` holds a back-reference to its parent `OpenProjectClient` and reuses the script-execution machinery (`execute_query`, `find_record`, `execute_large_query_to_json_file`, `_generate_unique_temp_filename`) rather than duplicating it.

Methods (with their public names on the service):

| Old (on OpenProjectClient) | New (on OpenProjectCustomFieldService) |
| --- | --- |
| `ensure_wp_custom_field_id` | `ensure_wp_custom_field_id` (kept) |
| `enable_custom_field_for_projects` | `enable_custom_field_for_projects` (kept) |
| `get_custom_field_by_name` | `get_by_name` (renamed for namespace) |
| `get_custom_field_id_by_name` | `get_id_by_name` (renamed for namespace) |
| `get_custom_fields` | `get_all` (renamed for namespace) |

The previously-instance `_custom_fields_cache` / `_custom_fields_cache_time` state moves with `get_all` onto the service. The 300-second cache duration is now a `CACHE_TTL_SECONDS` class constant instead of a magic number embedded in the method.

`escape_ruby_single_quoted` is imported lazily inside the two methods that need it, avoiding the `openproject_client ↔ openproject_custom_field_service` import cycle at module load time.

### `src/clients/openproject_client.py` (-131 LOC)

`__init__` now constructs `self.custom_fields = OpenProjectCustomFieldService(self)`. The five same-named methods become one-line delegators so existing call sites work unchanged:

```python
def ensure_wp_custom_field_id(self, name, field_format="text"):
    return self.custom_fields.ensure_wp_custom_field_id(name, field_format)
```

The instance state (`_custom_fields_cache` / `_custom_fields_cache_time`) is removed from `OpenProjectClient.__init__` since it lives on the service now.

### Tests

The two `inspect`-style tests pinning `is_for_all: false` (one in `test_custom_field_project_enablement.py`, one in `test_journal_deduplication.py`) are repointed to read `openproject_custom_field_service.py` instead. Same robust file-search approach (the conftest monkeypatch on `OpenProjectClient` still rules out using `inspect.getsource` on the class).

The 8 migration unit tests with their own `DummyOp` classes (added in #108) keep working unchanged because their `ensure_wp_custom_field_id` and `enable_custom_field_for_projects` methods are still hit via the OpenProjectClient delegators.

## What's deferred

The remaining **8 CF methods** stay on `OpenProjectClient` for now:
- `ensure_work_package_custom_field` (uses `is_for_all=true`)
- `ensure_custom_field` (generic, parametric `cf_type`)
- `remove_custom_field`
- `ensure_origin_custom_fields`
- `ensure_j2o_provenance_custom_fields` (provenance domain — may end up in its own service)
- `delete_all_custom_fields`
- `bulk_set_wp_custom_field_values`
- `batch_get_custom_fields_by_names`

These move into the service in **Phase 2b**. The same pattern (lazy imports, back-reference to client, delegator stubs on the client) will repeat. After that, **Phase 2c onwards** extract other functional services: `OpenProjectRailsRunner`, `OpenProjectFileTransfer`, `OpenProjectUserService`, `OpenProjectProjectService`, `OpenProjectWorkPackageService`. Splitting `jira_client.py` (2,852 LOC) follows the same pattern.

## Type of Change

- [x] Refactoring (no functional changes)

## Testing

- [x] Unit tests pass — `pytest tests/unit/` → **937 passed**
- [x] Mypy — `mypy src/` → clean on 98 source files
- [x] Ruff — `ruff check .` and `ruff format --check .` clean

## Checklist

- [x] My code follows the project's coding style
- [x] All new and existing tests pass
- [x] No security implications

## Related

Phase 2a of [ADR-002](docs/adr/ADR-002-target-architecture.md) — the systematic split of the two god-clients (`openproject_client.py` 7,266 LOC, `jira_client.py` 2,852 LOC) along functional seams.