### PR TITLE
fix(review): address Copilot/Gemini comments from PRs #104 #108 #109 #110

### DIFF
--- a/src/clients/openproject_client.py
+++ b/src/clients/openproject_client.py
@@ -1735,7 +1735,13 @@ class OpenProjectClient:
         return self.custom_fields.remove_custom_field(name, cf_type=cf_type)
 
     def ensure_origin_custom_fields(self) -> dict[str, list[dict[str, Any]]]:
-        """Ensure origin mapping CFs exist for WP, Project, User, TimeEntry.
+        """Ensure origin mapping CFs exist for WorkPackage / User / TimeEntry.
+
+        Project custom fields are intentionally skipped on this OpenProject
+        instance; project origin metadata is persisted via
+        ``upsert_project_origin_attributes`` / ``upsert_project_attribute``
+        instead. The returned dict still has a ``project`` key but it is
+        always an empty list.
 
         Thin delegator over ``self.custom_fields.ensure_origin_custom_fields``.
         """

--- a/src/clients/openproject_custom_field_service.py
+++ b/src/clients/openproject_custom_field_service.py
@@ -34,6 +34,7 @@ keeps thin delegators for the same method names so existing call sites
 
 from __future__ import annotations
 
+import json
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -46,7 +47,7 @@ if TYPE_CHECKING:
 class OpenProjectCustomFieldService:
     """Read/write helpers for OpenProject CustomField records."""
 
-    # Cache duration for ``get_custom_fields`` (seconds).
+    # Cache duration for ``get_all`` (seconds).
     CACHE_TTL_SECONDS: int = 300
 
     def __init__(self, client: OpenProjectClient) -> None:
@@ -86,13 +87,14 @@ class OpenProjectCustomFieldService:
             cf_id = int(cf.get("id", 0) or 0) if isinstance(cf, dict) else None
             if cf_id:
                 return cf_id
-        except Exception:
+        except RecordNotFoundError:
             self._logger.info("CF '%s' not found; will create (format=%s)", name, field_format)
 
         escaped = escape_ruby_single_quoted(name)
+        escaped_format = escape_ruby_single_quoted(field_format)
         script = (
             f"cf = CustomField.find_by(type: 'WorkPackageCustomField', name: '{escaped}'); "
-            f"if !cf; cf = CustomField.new(name: '{escaped}', field_format: '{field_format}', "
+            f"if !cf; cf = CustomField.new(name: '{escaped}', field_format: '{escaped_format}', "
             f"is_required: false, is_for_all: false, type: 'WorkPackageCustomField'); cf.save; end; cf.id"
         )
         result = self._client.execute_query(script)
@@ -119,13 +121,18 @@ class OpenProjectCustomFieldService:
         if not project_ids:
             return
         project_ids_str = ", ".join(str(pid) for pid in sorted(project_ids))
+        # ``find_by(id:)`` returns nil instead of raising when the CF was
+        # already removed, so the rest of the script can no-op gracefully
+        # rather than failing the whole call.
         script = (
-            f"cf = CustomField.find({cf_id})\n"
-            f"[{project_ids_str}].each do |pid|\n"
-            f"  begin\n"
-            f"    project = Project.find(pid)\n"
-            f"    CustomFieldsProject.find_or_create_by!(custom_field: cf, project: project)\n"
-            f"  rescue ActiveRecord::RecordNotFound\n"
+            f"cf = CustomField.find_by(id: {cf_id})\n"
+            f"if cf\n"
+            f"  [{project_ids_str}].each do |pid|\n"
+            f"    begin\n"
+            f"      project = Project.find(pid)\n"
+            f"      CustomFieldsProject.find_or_create_by!(custom_field: cf, project: project)\n"
+            f"    rescue ActiveRecord::RecordNotFound\n"
+            f"    end\n"
             f"  end\n"
             f"end\n"
             f"true"
@@ -134,8 +141,8 @@ class OpenProjectCustomFieldService:
             self._client.execute_query(script)
             display = cf_name or str(cf_id)
             self._logger.info("Enabled %s CF for %d projects", display, len(project_ids))
-        except Exception:
-            self._logger.warning("Failed to enable CF for some projects")
+        except Exception as e:
+            self._logger.warning("Failed to enable CF for some projects: %s", e)
 
     # ── lookup ────────────────────────────────────────────────────────────
 
@@ -199,7 +206,10 @@ class OpenProjectCustomFieldService:
         """
         current_time = time.time()
 
-        if not force_refresh and self._cache and (current_time - self._cache_time) < self.CACHE_TTL_SECONDS:
+        # ``self._cache is not None`` (rather than ``self._cache``) so that an
+        # empty list — i.e. a server with zero custom fields — is still served
+        # from cache within the TTL instead of re-running the Rails query.
+        if not force_refresh and self._cache is not None and (current_time - self._cache_time) < self.CACHE_TTL_SECONDS:
             self._logger.debug(
                 "Using cached custom fields (age: %.1fs)",
                 current_time - self._cache_time,
@@ -247,7 +257,7 @@ class OpenProjectCustomFieldService:
             result = self._client.execute_json_query(ruby)
             if isinstance(result, dict) and result.get("id"):
                 return result
-            msg = "Failed ensuring WorkPackage custom field"
+            msg = f"Failed ensuring WorkPackage custom field '{name}' (format={field_format})"
             raise QueryExecutionError(msg)
         except Exception as e:
             msg = f"Failed to ensure custom field '{name}': {e}"
@@ -331,13 +341,11 @@ class OpenProjectCustomFieldService:
 
     def remove_custom_field(self, name: str, *, cf_type: str | None = None) -> dict[str, int]:
         """Remove CustomField records matching the provided name/type."""
-        import json as _json
-
         # Use ensure_ascii=False to output UTF-8 directly, avoiding \uXXXX escapes
-        name_literal = _json.dumps(name, ensure_ascii=False)
+        name_literal = json.dumps(name, ensure_ascii=False)
         type_filter = ""
         if cf_type:
-            type_literal = _json.dumps(cf_type, ensure_ascii=False)
+            type_literal = json.dumps(cf_type, ensure_ascii=False)
             type_filter = f"scope = scope.where(type: {type_literal})\n"
 
         ruby = (
@@ -464,8 +472,6 @@ class OpenProjectCustomFieldService:
             Dict with ``success`` (bool), ``updated`` (int), ``failed`` (int).
 
         """
-        import json as _json
-
         if not cf_values:
             return {"success": True, "updated": 0, "failed": 0}
 
@@ -480,7 +486,7 @@ class OpenProjectCustomFieldService:
 
         # Use ensure_ascii=False to keep UTF-8 literal; <<-'X' heredoc prevents
         # \u escape interpretation by Ruby.
-        data_json = _json.dumps(data, ensure_ascii=False)
+        data_json = json.dumps(data, ensure_ascii=False)
         script = f"""
           require 'json'
           data = JSON.parse(<<-'J2O_DATA'

--- a/src/utils/json_store.py
+++ b/src/utils/json_store.py
@@ -51,7 +51,8 @@ class JsonStore:
     def save(self, data: Any, filename: Path | str) -> Path:
         """Write ``data`` as pretty-printed JSON to ``base_dir / filename``.
 
-        Creates parent directories as needed. Returns the resolved path.
+        Creates parent directories as needed. Returns the path the data was
+        written to (``base_dir / filename``, not ``Path.resolve()``-resolved).
         """
         filepath = self.base_dir / Path(filename)
         filepath.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Bundled follow-up addressing **16 unresolved review threads** on the already-merged architecture PRs (#104, #108, #109, #110). None are functional regressions — they're robustness, security, and clarity items reviewers flagged.

## Changes

### Robustness / security

- **\`enable_custom_field_for_projects\`** (Copilot, #108): Ruby script now uses \`CustomField.find_by(id:)\` instead of \`find\` — graceful no-op when the CF was already removed instead of an \`ActiveRecord::RecordNotFound\`. Also logs the exception body (\`%s\`) on the warning path.
- **\`ensure_wp_custom_field_id\`** (Copilot #108 + Gemini #109): \`field_format\` now passes through \`escape_ruby_single_quoted\` before interpolation. It can come from \`customfields_generic_migration\` mappings, so a stray \`'\` would have broken the script and was a Ruby-injection footgun. Matches what \`ensure_work_package_custom_field\` / \`ensure_custom_field\` already do.
- **\`ensure_wp_custom_field_id\`** (Gemini #108): narrow \`except Exception\` to \`except RecordNotFoundError\` around \`get_by_name\` — the documented not-found path. Other errors now propagate.
- **\`get_all\`** (Copilot #109): cache check uses \`self._cache is not None\` instead of truthiness so an empty list (server with zero CFs) is still served from cache within the TTL instead of re-running the Rails query on every call.

### Clarity / consistency

- **\`OpenProjectCustomFieldService\` imports** (4× Gemini #110): drop the \`import json as _json\` per-method aliases; promote \`import json\` to module-level imports. PEP 8 + matches rest of codebase.
- **\`ensure_work_package_custom_field\`** (Copilot #110): error message on the unexpected-result branch now includes \`name\` and \`field_format\`. Easier to diagnose.
- **\`CACHE_TTL_SECONDS\` comment** (Copilot #109): refer to \`get_all\` instead of the legacy \`get_custom_fields\`.
- **\`ensure_origin_custom_fields\` delegator docstring** (Copilot #110): call out that Project CFs are intentionally skipped (project origin metadata persists via \`upsert_project_origin_attributes\` instead). Implementation already correct; only the docstring was misleading.
- **\`JsonStore.save\` docstring** (Copilot #104): drop the "resolved path" wording — the implementation returns \`base_dir / filename\` (not \`Path.resolve()\`-resolved).

## Acknowledged but not addressed in this PR

- **\`EntityCache._record_hit\` / \`_record_miss\` thread-safety** (Copilot #104): already fixed in PR #104 commit 708781a (Gemini flagged the same race independently). Just needed thread resolution, not new code.
- **\`execute_large_query_to_json_file\` encoding kwarg** (Gemini #109): the suggestion proposed adding \`encoding="utf-8"\` to the call site, but the called method doesn't take that parameter. Skipping the suggestion.

## Type of Change

- [x] Bug fix (security tightening, robustness, log fidelity)
- [x] Documentation update

## Testing

- [x] \`pytest tests/unit\` → **937 passed**
- [x] \`mypy src/\` → clean
- [x] \`ruff check\` + \`ruff format --check\` → clean

## Process note

Going forward I'll wait for the Copilot review pass to land on each PR before merging, so this kind of rollup PR isn't needed again. The previous PRs were merged via \`gh pr merge --admin\` while Copilot was still queuing its review.