### PR TITLE
Architecture phase 2c: extract OpenProjectProvenanceService

### DIFF
--- a/src/clients/openproject_client.py
+++ b/src/clients/openproject_client.py
@@ -321,8 +321,10 @@ class OpenProjectClient:
         # functional seams). Backward-compat: same-named methods on
         # OpenProjectClient delegate to the corresponding service.
         from src.clients.openproject_custom_field_service import OpenProjectCustomFieldService
+        from src.clients.openproject_provenance_service import OpenProjectProvenanceService
 
         self.custom_fields = OpenProjectCustomFieldService(self)
+        self.provenance = OpenProjectProvenanceService(self)
 
         logger.success(
             "OpenProjectClient initialized for host %s, container %s",
@@ -1750,124 +1752,32 @@ class OpenProjectClient:
     # =========================================================================
     # J2O Provenance Registry
     # =========================================================================
-    # For entities that cannot have custom fields directly (Groups, Types,
-    # Statuses), we use a special "J2O Migration" project to store provenance
-    # data as work packages. This allows restoration of ALL mappings from OP
-    # alone without requiring local mapping files.
+    # The full implementation lives in
+    # ``src.clients.openproject_provenance_service.OpenProjectProvenanceService``
+    # (Phase 2c of ADR-002). The methods below are thin delegators kept for
+    # backward compatibility with existing call sites.
     # =========================================================================
-
-    J2O_MIGRATION_PROJECT_IDENTIFIER = "j2o-migration-provenance"
-    J2O_MIGRATION_PROJECT_NAME = "J2O Migration Provenance"
-
-    # Entity types tracked in provenance registry (those without direct CF support)
-    # Note: company and account also create OP Projects but from Tempo sources
-    # custom_field and link_type track CF creation for Jira→OP field mapping
-    J2O_PROVENANCE_ENTITY_TYPES = (
-        "project",
-        "group",
-        "type",
-        "status",
-        "company",
-        "account",
-        "custom_field",
-        "link_type",
-    )
 
     def ensure_j2o_migration_project(self) -> int:
         """Ensure the J2O Migration Provenance project exists.
 
-        This project stores provenance data for entities that cannot have
-        custom fields attached directly (groups, types, statuses, projects).
-
-        Returns:
-            OpenProject project ID for the J2O Migration project
-
+        Thin delegator over ``self.provenance.ensure_migration_project``.
         """
-        return self.ensure_reporting_project(
-            identifier=self.J2O_MIGRATION_PROJECT_IDENTIFIER,
-            name=self.J2O_MIGRATION_PROJECT_NAME,
-        )
+        return self.provenance.ensure_migration_project()
 
     def ensure_j2o_provenance_types(self, project_id: int) -> dict[str, int]:
         """Ensure work package types exist for each provenance entity type.
 
-        Creates types like 'J2O Project Mapping', 'J2O Group Mapping', etc.
-
-        Args:
-            project_id: The J2O Migration project ID
-
-        Returns:
-            Dict mapping entity type to OP type ID
-
+        Thin delegator over ``self.provenance.ensure_provenance_types``.
         """
-        type_ids: dict[str, int] = {}
-
-        for entity_type in self.J2O_PROVENANCE_ENTITY_TYPES:
-            type_name = f"J2O {entity_type.title()} Mapping"
-
-            script = (
-                "begin\n"
-                f"  type_name = '{type_name}'\n"
-                f"  project_id = {project_id}\n"
-                "  wp_type = Type.find_by(name: type_name)\n"
-                "  unless wp_type\n"
-                "    wp_type = Type.create!(name: type_name, is_default: false, is_milestone: false)\n"
-                "  end\n"
-                "  project = Project.find(project_id)\n"
-                "  unless project.types.include?(wp_type)\n"
-                "    project.types << wp_type\n"
-                "  end\n"
-                "  { id: wp_type.id, name: wp_type.name }\n"
-                "rescue => e\n"
-                "  { error: e.message }\n"
-                "end\n"
-            )
-
-            try:
-                result = self.execute_json_query(script)
-                if isinstance(result, dict) and result.get("id"):
-                    type_ids[entity_type] = int(result["id"])
-                    self.logger.debug("Ensured J2O type '%s' with ID %d", type_name, type_ids[entity_type])
-                elif isinstance(result, dict) and result.get("error"):
-                    self.logger.warning("Failed to ensure J2O type '%s': %s", type_name, result["error"])
-            except Exception as e:
-                self.logger.warning("Error ensuring J2O type '%s': %s", type_name, e)
-
-        return type_ids
+        return self.provenance.ensure_provenance_types(project_id)
 
     def ensure_j2o_provenance_custom_fields(self) -> dict[str, int]:
         """Ensure custom fields for OP entity ID mapping exist.
 
-        Creates fields like 'J2O OP Project ID', 'J2O OP Group ID', etc.
-
-        Returns:
-            Dict mapping field name to CF ID
-
+        Thin delegator over ``self.provenance.ensure_provenance_custom_fields``.
         """
-        cf_ids: dict[str, int] = {}
-
-        # Fields for mapping to OP entity IDs
-        cf_specs = [
-            ("J2O OP Project ID", "int"),
-            ("J2O OP Group ID", "int"),
-            ("J2O OP Type ID", "int"),
-            ("J2O OP Status ID", "int"),
-            ("J2O OP Company ID", "int"),  # Tempo Company → OP Project ID
-            ("J2O OP Account ID", "int"),  # Tempo Account → OP Project ID
-            ("J2O OP Custom_field ID", "int"),  # Jira CF ID → OP CustomField ID
-            ("J2O OP Link_type ID", "int"),  # Jira Link Type ID → OP CustomField ID
-            ("J2O Entity Type", "string"),  # Entity type for filtering
-        ]
-
-        for name, fmt in cf_specs:
-            try:
-                result = self.ensure_custom_field(name, field_format=fmt, cf_type="WorkPackageCustomField")
-                if isinstance(result, dict) and result.get("id"):
-                    cf_ids[name] = int(result["id"])
-            except Exception as e:
-                self.logger.warning("Failed ensuring provenance CF '%s': %s", name, e)
-
-        return cf_ids
+        return self.provenance.ensure_provenance_custom_fields()
 
     def record_entity_provenance(
         self,
@@ -1880,211 +1790,22 @@ class OpenProjectClient:
     ) -> dict[str, Any]:
         """Record provenance for an entity that cannot have custom fields.
 
-        Creates or updates a work package in the J2O Migration project that
-        stores the Jira→OP mapping for entities like projects, groups, types,
-        and statuses.
-
-        Args:
-            entity_type: One of 'project', 'group', 'type', 'status'
-            jira_key: The Jira entity key/identifier
-            jira_id: The Jira entity ID (optional)
-            op_entity_id: The OpenProject entity ID
-            jira_name: The Jira entity name (optional)
-
-        Returns:
-            Dict with created/updated work package info
-
+        Thin delegator over ``self.provenance.record_entity``.
         """
-        if entity_type not in self.J2O_PROVENANCE_ENTITY_TYPES:
-            msg = f"Invalid entity type: {entity_type}. Must be one of {self.J2O_PROVENANCE_ENTITY_TYPES}"
-            raise ValueError(msg)
-
-        # Ensure infrastructure exists (cached after first call)
-        if not hasattr(self, "_j2o_provenance_cache"):
-            self._j2o_provenance_cache = {
-                "project_id": self.ensure_j2o_migration_project(),
-                "type_ids": None,
-                "cf_ids": None,
-            }
-            self._j2o_provenance_cache["type_ids"] = self.ensure_j2o_provenance_types(
-                self._j2o_provenance_cache["project_id"],
-            )
-            self._j2o_provenance_cache["cf_ids"] = self.ensure_j2o_provenance_custom_fields()
-        project_id = self._j2o_provenance_cache["project_id"]
-        type_ids = self._j2o_provenance_cache["type_ids"]
-        cf_ids = self._j2o_provenance_cache["cf_ids"]
-
-        type_id = type_ids.get(entity_type)
-        if not type_id:
-            msg = f"Failed to get type ID for {entity_type}"
-            raise QueryExecutionError(msg)
-
-        # Build work package subject (unique identifier for this mapping)
-        subject = f"{entity_type.upper()}: {jira_key}"
-        if jira_name:
-            subject = f"{subject} ({jira_name})"
-
-        # Get CF IDs for the mapping fields
-        cf_op_id_field = f"J2O OP {entity_type.title()} ID"
-        cf_op_id = cf_ids.get(cf_op_id_field)
-        cf_entity_type_id = cf_ids.get("J2O Entity Type")
-
-        script = (
-            "begin\n"
-            f"  project = Project.find({project_id})\n"
-            f"  wp_type = Type.find({type_id})\n"
-            f"  subject = '{escape_ruby_single_quoted(subject)}'\n"
-            "  status = Status.default || Status.first\n"
-            "  priority = IssuePriority.default || IssuePriority.first\n"
-            "  # Find existing or create new\n"
-            f"  wp = project.work_packages.where(type_id: {type_id}).find_by(subject: subject)\n"
-            "  created = false\n"
-            "  if wp.nil?\n"
-            "    wp = WorkPackage.new(\n"
-            "      project: project,\n"
-            "      type: wp_type,\n"
-            "      subject: subject,\n"
-            "      status: status,\n"
-            "      priority: priority,\n"
-            "      author: User.admin.first || User.first\n"
-            "    )\n"
-            "    created = true\n"
-            "  end\n"
-            "  # Set custom field values\n"
-            "  cf_values = {}\n"
-            f"  cf_values[{cf_op_id}] = {op_entity_id} if {cf_op_id}\n"
-            if cf_op_id
-            else f"  cf_values[{cf_entity_type_id}] = '{entity_type}' if {cf_entity_type_id}\n"
-            if cf_entity_type_id
-            else ""
-            "  wp.custom_field_values = cf_values if cf_values.any?\n"
-            "  wp.save!\n"
-            "  { success: true, id: wp.id, subject: wp.subject, created: created }\n"
-            "rescue => e\n"
-            "  { success: false, error: e.message, backtrace: e.backtrace.first(3) }\n"
-            "end\n"
+        return self.provenance.record_entity(
+            entity_type=entity_type,
+            jira_key=jira_key,
+            jira_id=jira_id,
+            op_entity_id=op_entity_id,
+            jira_name=jira_name,
         )
-
-        try:
-            result = self.execute_json_query(script)
-            if isinstance(result, dict):
-                if result.get("success"):
-                    action = "Created" if result.get("created") else "Updated"
-                    self.logger.debug(
-                        "%s provenance WP for %s '%s' → OP ID %d",
-                        action,
-                        entity_type,
-                        jira_key,
-                        op_entity_id,
-                    )
-                return result
-            return {"success": False, "error": f"Unexpected result: {result}"}
-        except Exception as e:
-            return {"success": False, "error": str(e)}
 
     def restore_entity_mappings_from_provenance(self, entity_type: str) -> dict[str, dict[str, Any]]:
         """Restore entity mappings from provenance work packages.
 
-        Queries the J2O Migration project for work packages of the specified
-        entity type and reconstructs the Jira→OP mapping.
-
-        Args:
-            entity_type: One of 'project', 'group', 'type', 'status'
-
-        Returns:
-            Dict mapping Jira key to mapping data
-
+        Thin delegator over ``self.provenance.restore_entity_mappings``.
         """
-        if entity_type not in self.J2O_PROVENANCE_ENTITY_TYPES:
-            msg = f"Invalid entity type: {entity_type}. Must be one of {self.J2O_PROVENANCE_ENTITY_TYPES}"
-            raise ValueError(msg)
-
-        # Get the project and type IDs (may not exist if never recorded)
-        try:
-            project_result = self.get_project_by_identifier(self.J2O_MIGRATION_PROJECT_IDENTIFIER)
-            if not project_result or not project_result.get("id"):
-                self.logger.info("J2O Migration project not found - no provenance data available")
-                return {}
-            project_id = int(project_result["id"])
-        except Exception:
-            self.logger.debug("J2O Migration project not found")
-            return {}
-
-        # Find the type for this entity
-        type_name = f"J2O {entity_type.title()} Mapping"
-        cf_op_id_field = f"J2O OP {entity_type.title()} ID"
-
-        script = (
-            "begin\n"
-            f"  project = Project.find({project_id})\n"
-            f"  wp_type = Type.find_by(name: '{type_name}')\n"
-            "  return [].to_json unless wp_type\n"
-            f"  cf_op_id = CustomField.find_by(name: '{cf_op_id_field}', type: 'WorkPackageCustomField')\n"
-            "  cf_entity_type = CustomField.find_by(name: 'J2O Entity Type', type: 'WorkPackageCustomField')\n"
-            "  # Also get J2O Origin fields for full provenance\n"
-            "  cf_origin_key = CustomField.find_by(name: 'J2O Origin Key', type: 'WorkPackageCustomField')\n"
-            "  cf_origin_id = CustomField.find_by(name: 'J2O Origin ID', type: 'WorkPackageCustomField')\n"
-            "  cf_origin_system = CustomField.find_by(name: 'J2O Origin System', type: 'WorkPackageCustomField')\n"
-            f"  wps = project.work_packages.where(type_id: wp_type.id)\n"
-            "  wps.map do |wp|\n"
-            "    {\n"
-            "      id: wp.id,\n"
-            "      subject: wp.subject,\n"
-            "      op_entity_id: (cf_op_id ? wp.custom_value_for(cf_op_id)&.value&.to_i : nil),\n"
-            "      entity_type: (cf_entity_type ? wp.custom_value_for(cf_entity_type)&.value : nil),\n"
-            "      j2o_origin_key: (cf_origin_key ? wp.custom_value_for(cf_origin_key)&.value : nil),\n"
-            "      j2o_origin_id: (cf_origin_id ? wp.custom_value_for(cf_origin_id)&.value : nil),\n"
-            "      j2o_origin_system: (cf_origin_system ? wp.custom_value_for(cf_origin_system)&.value : nil)\n"
-            "    }\n"
-            "  end\n"
-            "rescue => e\n"
-            "  { error: e.message }\n"
-            "end\n"
-        )
-
-        try:
-            result = self.execute_json_query(script)
-            if isinstance(result, dict) and result.get("error"):
-                self.logger.warning("Error restoring %s mappings: %s", entity_type, result["error"])
-                return {}
-
-            if not isinstance(result, list):
-                return {}
-
-            # Build mapping from subject parsing and CF values
-            mappings: dict[str, dict[str, Any]] = {}
-            for wp in result:
-                # Parse subject to extract Jira key: "TYPE: jira-key (name)" or "TYPE: jira-key"
-                subject = wp.get("subject", "")
-                prefix = f"{entity_type.upper()}: "
-                if subject.startswith(prefix):
-                    rest = subject[len(prefix) :]
-                    # Handle "(name)" suffix
-                    if " (" in rest and rest.endswith(")"):
-                        jira_key = rest.split(" (")[0]
-                        jira_name = rest.split(" (")[1].rstrip(")")
-                    else:
-                        jira_key = rest
-                        jira_name = None
-
-                    mappings[jira_key] = {
-                        "jira_key": jira_key,
-                        "jira_name": jira_name,
-                        "openproject_id": wp.get("op_entity_id"),
-                        "matched_by": "j2o_provenance",
-                        "j2o_origin_key": wp.get("j2o_origin_key"),
-                        "j2o_origin_id": wp.get("j2o_origin_id"),
-                        "j2o_origin_system": wp.get("j2o_origin_system"),
-                        "restored_from_op": True,
-                        "provenance_wp_id": wp.get("id"),
-                    }
-
-            self.logger.info("Restored %d %s mappings from provenance", len(mappings), entity_type)
-            return mappings
-
-        except Exception as e:
-            self.logger.warning("Failed to restore %s mappings from provenance: %s", entity_type, e)
-            return {}
+        return self.provenance.restore_entity_mappings(entity_type)
 
     def bulk_record_entity_provenance(
         self,
@@ -2093,102 +1814,9 @@ class OpenProjectClient:
     ) -> dict[str, Any]:
         """Bulk record provenance for multiple entities.
 
-        Args:
-            entity_type: One of 'project', 'group', 'type', 'status'
-            mappings: List of dicts with keys: jira_key, jira_id (optional),
-                     op_entity_id, jira_name (optional)
-
-        Returns:
-            Dict with success count, failed count, errors
-
+        Thin delegator over ``self.provenance.bulk_record_entities``.
         """
-        if entity_type not in self.J2O_PROVENANCE_ENTITY_TYPES:
-            msg = f"Invalid entity type: {entity_type}. Must be one of {self.J2O_PROVENANCE_ENTITY_TYPES}"
-            raise ValueError(msg)
-
-        if not mappings:
-            return {"success": 0, "failed": 0, "errors": []}
-
-        # Ensure infrastructure exists (once for all)
-        project_id = self.ensure_j2o_migration_project()
-        type_ids = self.ensure_j2o_provenance_types(project_id)
-        cf_ids = self.ensure_j2o_provenance_custom_fields()
-
-        type_id = type_ids.get(entity_type)
-        if not type_id:
-            return {"success": 0, "failed": len(mappings), "errors": [f"No type ID for {entity_type}"]}
-
-        cf_op_id_field = f"J2O OP {entity_type.title()} ID"
-        cf_op_id = cf_ids.get(cf_op_id_field)
-        cf_entity_type_id = cf_ids.get("J2O Entity Type")
-
-        # Build Ruby array of mappings
-        ruby_mappings = []
-        for m in mappings:
-            jira_key = m.get("jira_key", "")
-            jira_name = m.get("jira_name", "")
-            op_entity_id = m.get("op_entity_id") or m.get("openproject_id")
-            if jira_key and op_entity_id:
-                subject = f"{entity_type.upper()}: {jira_key}"
-                if jira_name:
-                    subject = f"{subject} ({jira_name})"
-                ruby_mappings.append(
-                    f"  {{ subject: '{escape_ruby_single_quoted(subject)}', op_entity_id: {op_entity_id} }}",
-                )
-
-        if not ruby_mappings:
-            return {"success": 0, "failed": 0, "errors": []}
-
-        script = (
-            "begin\n"
-            f"  project = Project.find({project_id})\n"
-            f"  wp_type = Type.find({type_id})\n"
-            "  status = Status.default || Status.first\n"
-            "  priority = IssuePriority.default || IssuePriority.first\n"
-            "  author = User.admin.first || User.first\n"
-            f"  cf_op_id = {cf_op_id or 'nil'}\n"
-            f"  cf_entity_type_id = {cf_entity_type_id or 'nil'}\n"
-            "  mappings = [\n" + ",\n".join(ruby_mappings) + "\n  ]\n"
-            "  success = 0\n"
-            "  failed = 0\n"
-            "  errors = []\n"
-            "  mappings.each do |m|\n"
-            "    begin\n"
-            "      wp = project.work_packages.where(type_id: wp_type.id).find_by(subject: m[:subject])\n"
-            "      if wp.nil?\n"
-            "        wp = WorkPackage.new(\n"
-            "          project: project,\n"
-            "          type: wp_type,\n"
-            "          subject: m[:subject],\n"
-            "          status: status,\n"
-            "          priority: priority,\n"
-            "          author: author\n"
-            "        )\n"
-            "      end\n"
-            "      cf_values = {}\n"
-            "      cf_values[cf_op_id] = m[:op_entity_id] if cf_op_id\n"
-            f"      cf_values[cf_entity_type_id] = '{entity_type}' if cf_entity_type_id\n"
-            "      wp.custom_field_values = cf_values if cf_values.any?\n"
-            "      wp.save!\n"
-            "      success += 1\n"
-            "    rescue => e\n"
-            "      failed += 1\n"
-            '      errors << "#{m[:subject]}: #{e.message}"\n'
-            "    end\n"
-            "  end\n"
-            "  { success: success, failed: failed, errors: errors.first(10) }\n"
-            "rescue => e\n"
-            "  { success: 0, failed: mappings.size, errors: [e.message] }\n"
-            "end\n"
-        )
-
-        try:
-            result = self.execute_json_query(script)
-            if isinstance(result, dict):
-                return result
-            return {"success": 0, "failed": len(mappings), "errors": [f"Unexpected result: {result}"]}
-        except Exception as e:
-            return {"success": 0, "failed": len(mappings), "errors": [str(e)]}
+        return self.provenance.bulk_record_entities(entity_type, mappings)
 
     def get_roles(self) -> list[dict[str, Any]]:
         """Return OpenProject roles (id, name, builtin flag)."""

--- a/src/clients/openproject_provenance_service.py
+++ b/src/clients/openproject_provenance_service.py
@@ -1,0 +1,467 @@
+"""J2O Migration Provenance — store Jira→OP entity mappings as work packages.
+
+For OpenProject entity types that cannot have custom fields attached
+directly (groups, types, statuses) plus the OP entities we want a
+durable record for (projects, custom fields, link types, Tempo companies
+and accounts), j2o uses a special "J2O Migration Provenance" project
+whose work packages encode the Jira→OP mapping. This lets the migration
+restore state from OpenProject alone, without depending on local mapping
+JSON files.
+
+Phase 2c of ADR-002 split this subsystem out of the 7,000-line
+``OpenProjectClient`` god-class into a focused service. The service
+holds a back-reference to the client for script execution
+(``execute_query``, ``execute_json_query``, ``ensure_reporting_project``,
+``get_project_by_identifier``, ``ensure_custom_field`` — the latter via
+``self._client.custom_fields.ensure_custom_field``). The lazy
+infrastructure cache (``_cache``: project_id + type_ids + cf_ids) lives
+here too.
+
+``OpenProjectClient`` exposes the service via ``self.provenance`` and
+keeps thin delegators for the same method names so existing call sites
+work unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.clients.exceptions import QueryExecutionError
+
+if TYPE_CHECKING:
+    from src.clients.openproject_client import OpenProjectClient
+
+
+class OpenProjectProvenanceService:
+    """Manages the J2O Migration Provenance project, types, CFs, and records."""
+
+    PROJECT_IDENTIFIER: str = "j2o-migration-provenance"
+    PROJECT_NAME: str = "J2O Migration Provenance"
+
+    # Entity types tracked in the provenance registry. Note:
+    # - ``company`` and ``account`` create OP Projects but originate from Tempo.
+    # - ``custom_field`` and ``link_type`` track CF creation for Jira→OP field mapping.
+    ENTITY_TYPES: tuple[str, ...] = (
+        "project",
+        "group",
+        "type",
+        "status",
+        "company",
+        "account",
+        "custom_field",
+        "link_type",
+    )
+
+    def __init__(self, client: OpenProjectClient) -> None:
+        self._client = client
+        self._logger = client.logger
+        # Lazy-init: populated on first record_entity_provenance call.
+        self._cache: dict[str, Any] | None = None
+
+    # ── infrastructure ensurance ──────────────────────────────────────────
+
+    def ensure_migration_project(self) -> int:
+        """Ensure the J2O Migration Provenance project exists.
+
+        Returns the OpenProject project ID.
+        """
+        return self._client.ensure_reporting_project(
+            identifier=self.PROJECT_IDENTIFIER,
+            name=self.PROJECT_NAME,
+        )
+
+    def ensure_provenance_types(self, project_id: int) -> dict[str, int]:
+        """Ensure WorkPackage types exist for each provenance entity type.
+
+        Creates types like ``J2O Project Mapping``, ``J2O Group Mapping``, etc.
+
+        Args:
+            project_id: The J2O Migration project ID
+
+        Returns:
+            Dict mapping entity type to OP type ID
+
+        """
+        type_ids: dict[str, int] = {}
+
+        for entity_type in self.ENTITY_TYPES:
+            type_name = f"J2O {entity_type.title()} Mapping"
+
+            script = (
+                "begin\n"
+                f"  type_name = '{type_name}'\n"
+                f"  project_id = {project_id}\n"
+                "  wp_type = Type.find_by(name: type_name)\n"
+                "  unless wp_type\n"
+                "    wp_type = Type.create!(name: type_name, is_default: false, is_milestone: false)\n"
+                "  end\n"
+                "  project = Project.find(project_id)\n"
+                "  unless project.types.include?(wp_type)\n"
+                "    project.types << wp_type\n"
+                "  end\n"
+                "  { id: wp_type.id, name: wp_type.name }\n"
+                "rescue => e\n"
+                "  { error: e.message }\n"
+                "end\n"
+            )
+
+            try:
+                result = self._client.execute_json_query(script)
+                if isinstance(result, dict) and result.get("id"):
+                    type_ids[entity_type] = int(result["id"])
+                    self._logger.debug("Ensured J2O type '%s' with ID %d", type_name, type_ids[entity_type])
+                elif isinstance(result, dict) and result.get("error"):
+                    self._logger.warning("Failed to ensure J2O type '%s': %s", type_name, result["error"])
+            except Exception as e:
+                self._logger.warning("Error ensuring J2O type '%s': %s", type_name, e)
+
+        return type_ids
+
+    def ensure_provenance_custom_fields(self) -> dict[str, int]:
+        """Ensure custom fields for OP entity ID mapping exist.
+
+        Creates CFs like ``J2O OP Project ID``, ``J2O OP Group ID``, etc.,
+        plus a generic ``J2O Entity Type`` filtering CF.
+
+        Returns:
+            Dict mapping CF name to its CF ID.
+
+        """
+        cf_ids: dict[str, int] = {}
+
+        # Fields for mapping to OP entity IDs
+        cf_specs = [
+            ("J2O OP Project ID", "int"),
+            ("J2O OP Group ID", "int"),
+            ("J2O OP Type ID", "int"),
+            ("J2O OP Status ID", "int"),
+            ("J2O OP Company ID", "int"),  # Tempo Company → OP Project ID
+            ("J2O OP Account ID", "int"),  # Tempo Account → OP Project ID
+            ("J2O OP Custom_field ID", "int"),  # Jira CF ID → OP CustomField ID
+            ("J2O OP Link_type ID", "int"),  # Jira Link Type ID → OP CustomField ID
+            ("J2O Entity Type", "string"),  # Entity type for filtering
+        ]
+
+        for name, fmt in cf_specs:
+            try:
+                result = self._client.custom_fields.ensure_custom_field(
+                    name,
+                    field_format=fmt,
+                    cf_type="WorkPackageCustomField",
+                )
+                if isinstance(result, dict) and result.get("id"):
+                    cf_ids[name] = int(result["id"])
+            except Exception as e:
+                self._logger.warning("Failed ensuring provenance CF '%s': %s", name, e)
+
+        return cf_ids
+
+    # ── recording / restoring ─────────────────────────────────────────────
+
+    def record_entity(
+        self,
+        *,
+        entity_type: str,
+        jira_key: str,
+        jira_id: str | None = None,
+        op_entity_id: int,
+        jira_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Record provenance for an entity by creating/updating a work package.
+
+        Lazy-initialises the project / types / CFs the first time it's called.
+        """
+        # Lazy import avoids the openproject_client ↔ this-module import cycle.
+        from src.clients.openproject_client import escape_ruby_single_quoted
+
+        if entity_type not in self.ENTITY_TYPES:
+            msg = f"Invalid entity type: {entity_type}. Must be one of {self.ENTITY_TYPES}"
+            raise ValueError(msg)
+
+        # Ensure infrastructure exists (cached after first call)
+        if self._cache is None:
+            project_id = self.ensure_migration_project()
+            self._cache = {
+                "project_id": project_id,
+                "type_ids": self.ensure_provenance_types(project_id),
+                "cf_ids": self.ensure_provenance_custom_fields(),
+            }
+        project_id = self._cache["project_id"]
+        type_ids = self._cache["type_ids"]
+        cf_ids = self._cache["cf_ids"]
+
+        type_id = type_ids.get(entity_type)
+        if not type_id:
+            msg = f"Failed to get type ID for {entity_type}"
+            raise QueryExecutionError(msg)
+
+        # Build work package subject (unique identifier for this mapping)
+        subject = f"{entity_type.upper()}: {jira_key}"
+        if jira_name:
+            subject = f"{subject} ({jira_name})"
+
+        # Get CF IDs for the mapping fields
+        cf_op_id_field = f"J2O OP {entity_type.title()} ID"
+        cf_op_id = cf_ids.get(cf_op_id_field)
+        cf_entity_type_id = cf_ids.get("J2O Entity Type")
+
+        script = (
+            "begin\n"
+            f"  project = Project.find({project_id})\n"
+            f"  wp_type = Type.find({type_id})\n"
+            f"  subject = '{escape_ruby_single_quoted(subject)}'\n"
+            "  status = Status.default || Status.first\n"
+            "  priority = IssuePriority.default || IssuePriority.first\n"
+            "  # Find existing or create new\n"
+            f"  wp = project.work_packages.where(type_id: {type_id}).find_by(subject: subject)\n"
+            "  created = false\n"
+            "  if wp.nil?\n"
+            "    wp = WorkPackage.new(\n"
+            "      project: project,\n"
+            "      type: wp_type,\n"
+            "      subject: subject,\n"
+            "      status: status,\n"
+            "      priority: priority,\n"
+            "      author: User.admin.first || User.first\n"
+            "    )\n"
+            "    created = true\n"
+            "  end\n"
+            "  # Set custom field values\n"
+            "  cf_values = {}\n"
+            f"  cf_values[{cf_op_id}] = {op_entity_id} if {cf_op_id}\n"
+            if cf_op_id
+            else f"  cf_values[{cf_entity_type_id}] = '{entity_type}' if {cf_entity_type_id}\n"
+            if cf_entity_type_id
+            else ""
+            "  wp.custom_field_values = cf_values if cf_values.any?\n"
+            "  wp.save!\n"
+            "  { success: true, id: wp.id, subject: wp.subject, created: created }\n"
+            "rescue => e\n"
+            "  { success: false, error: e.message, backtrace: e.backtrace.first(3) }\n"
+            "end\n"
+        )
+
+        try:
+            result = self._client.execute_json_query(script)
+            if isinstance(result, dict):
+                if result.get("success"):
+                    action = "Created" if result.get("created") else "Updated"
+                    self._logger.debug(
+                        "%s provenance WP for %s '%s' → OP ID %d",
+                        action,
+                        entity_type,
+                        jira_key,
+                        op_entity_id,
+                    )
+                return result
+            return {"success": False, "error": f"Unexpected result: {result}"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    def restore_entity_mappings(self, entity_type: str) -> dict[str, dict[str, Any]]:
+        """Restore Jira→OP mappings by querying provenance work packages.
+
+        Args:
+            entity_type: One of the configured ``ENTITY_TYPES``.
+
+        Returns:
+            Dict mapping Jira key → mapping data. Empty dict if the J2O
+            Migration project doesn't exist or no provenance data is found.
+
+        """
+        if entity_type not in self.ENTITY_TYPES:
+            msg = f"Invalid entity type: {entity_type}. Must be one of {self.ENTITY_TYPES}"
+            raise ValueError(msg)
+
+        # Get the project (may not exist if never recorded).
+        try:
+            project_result = self._client.get_project_by_identifier(self.PROJECT_IDENTIFIER)
+            if not project_result or not project_result.get("id"):
+                self._logger.info("J2O Migration project not found - no provenance data available")
+                return {}
+            project_id = int(project_result["id"])
+        except Exception:
+            self._logger.debug("J2O Migration project not found")
+            return {}
+
+        type_name = f"J2O {entity_type.title()} Mapping"
+        cf_op_id_field = f"J2O OP {entity_type.title()} ID"
+
+        script = (
+            "begin\n"
+            f"  project = Project.find({project_id})\n"
+            f"  wp_type = Type.find_by(name: '{type_name}')\n"
+            "  return [].to_json unless wp_type\n"
+            f"  cf_op_id = CustomField.find_by(name: '{cf_op_id_field}', type: 'WorkPackageCustomField')\n"
+            "  cf_entity_type = CustomField.find_by(name: 'J2O Entity Type', type: 'WorkPackageCustomField')\n"
+            "  # Also get J2O Origin fields for full provenance\n"
+            "  cf_origin_key = CustomField.find_by(name: 'J2O Origin Key', type: 'WorkPackageCustomField')\n"
+            "  cf_origin_id = CustomField.find_by(name: 'J2O Origin ID', type: 'WorkPackageCustomField')\n"
+            "  cf_origin_system = CustomField.find_by(name: 'J2O Origin System', type: 'WorkPackageCustomField')\n"
+            f"  wps = project.work_packages.where(type_id: wp_type.id)\n"
+            "  wps.map do |wp|\n"
+            "    {\n"
+            "      id: wp.id,\n"
+            "      subject: wp.subject,\n"
+            "      op_entity_id: (cf_op_id ? wp.custom_value_for(cf_op_id)&.value&.to_i : nil),\n"
+            "      entity_type: (cf_entity_type ? wp.custom_value_for(cf_entity_type)&.value : nil),\n"
+            "      j2o_origin_key: (cf_origin_key ? wp.custom_value_for(cf_origin_key)&.value : nil),\n"
+            "      j2o_origin_id: (cf_origin_id ? wp.custom_value_for(cf_origin_id)&.value : nil),\n"
+            "      j2o_origin_system: (cf_origin_system ? wp.custom_value_for(cf_origin_system)&.value : nil)\n"
+            "    }\n"
+            "  end\n"
+            "rescue => e\n"
+            "  { error: e.message }\n"
+            "end\n"
+        )
+
+        try:
+            result = self._client.execute_json_query(script)
+            if isinstance(result, dict) and result.get("error"):
+                self._logger.warning("Error restoring %s mappings: %s", entity_type, result["error"])
+                return {}
+
+            if not isinstance(result, list):
+                return {}
+
+            # Build mapping from subject parsing and CF values
+            mappings: dict[str, dict[str, Any]] = {}
+            for wp in result:
+                # Parse subject to extract Jira key: "TYPE: jira-key (name)" or "TYPE: jira-key"
+                subject = wp.get("subject", "")
+                prefix = f"{entity_type.upper()}: "
+                if subject.startswith(prefix):
+                    rest = subject[len(prefix) :]
+                    # Handle "(name)" suffix
+                    if " (" in rest and rest.endswith(")"):
+                        jira_key = rest.split(" (")[0]
+                        jira_name = rest.split(" (")[1].rstrip(")")
+                    else:
+                        jira_key = rest
+                        jira_name = None
+
+                    mappings[jira_key] = {
+                        "jira_key": jira_key,
+                        "jira_name": jira_name,
+                        "openproject_id": wp.get("op_entity_id"),
+                        "matched_by": "j2o_provenance",
+                        "j2o_origin_key": wp.get("j2o_origin_key"),
+                        "j2o_origin_id": wp.get("j2o_origin_id"),
+                        "j2o_origin_system": wp.get("j2o_origin_system"),
+                        "restored_from_op": True,
+                        "provenance_wp_id": wp.get("id"),
+                    }
+
+            self._logger.info("Restored %d %s mappings from provenance", len(mappings), entity_type)
+            return mappings
+
+        except Exception as e:
+            self._logger.warning("Failed to restore %s mappings from provenance: %s", entity_type, e)
+            return {}
+
+    def bulk_record_entities(
+        self,
+        entity_type: str,
+        mappings: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Bulk record provenance for multiple entities in one Rails call.
+
+        Args:
+            entity_type: One of the configured ``ENTITY_TYPES``.
+            mappings: Each dict needs ``jira_key`` and ``op_entity_id`` (or
+                ``openproject_id``); ``jira_name`` is optional.
+
+        Returns:
+            Dict with ``success`` count, ``failed`` count, and ``errors`` (max 10).
+
+        """
+        # Lazy import avoids the openproject_client ↔ this-module import cycle.
+        from src.clients.openproject_client import escape_ruby_single_quoted
+
+        if entity_type not in self.ENTITY_TYPES:
+            msg = f"Invalid entity type: {entity_type}. Must be one of {self.ENTITY_TYPES}"
+            raise ValueError(msg)
+
+        if not mappings:
+            return {"success": 0, "failed": 0, "errors": []}
+
+        # Ensure infrastructure exists (once for all)
+        project_id = self.ensure_migration_project()
+        type_ids = self.ensure_provenance_types(project_id)
+        cf_ids = self.ensure_provenance_custom_fields()
+
+        type_id = type_ids.get(entity_type)
+        if not type_id:
+            return {"success": 0, "failed": len(mappings), "errors": [f"No type ID for {entity_type}"]}
+
+        cf_op_id_field = f"J2O OP {entity_type.title()} ID"
+        cf_op_id = cf_ids.get(cf_op_id_field)
+        cf_entity_type_id = cf_ids.get("J2O Entity Type")
+
+        # Build Ruby array of mappings
+        ruby_mappings = []
+        for m in mappings:
+            jira_key = m.get("jira_key", "")
+            jira_name = m.get("jira_name", "")
+            op_entity_id = m.get("op_entity_id") or m.get("openproject_id")
+            if jira_key and op_entity_id:
+                subject = f"{entity_type.upper()}: {jira_key}"
+                if jira_name:
+                    subject = f"{subject} ({jira_name})"
+                ruby_mappings.append(
+                    f"  {{ subject: '{escape_ruby_single_quoted(subject)}', op_entity_id: {op_entity_id} }}",
+                )
+
+        if not ruby_mappings:
+            return {"success": 0, "failed": 0, "errors": []}
+
+        script = (
+            "begin\n"
+            f"  project = Project.find({project_id})\n"
+            f"  wp_type = Type.find({type_id})\n"
+            "  status = Status.default || Status.first\n"
+            "  priority = IssuePriority.default || IssuePriority.first\n"
+            "  author = User.admin.first || User.first\n"
+            f"  cf_op_id = {cf_op_id or 'nil'}\n"
+            f"  cf_entity_type_id = {cf_entity_type_id or 'nil'}\n"
+            "  mappings = [\n" + ",\n".join(ruby_mappings) + "\n  ]\n"
+            "  success = 0\n"
+            "  failed = 0\n"
+            "  errors = []\n"
+            "  mappings.each do |m|\n"
+            "    begin\n"
+            "      wp = project.work_packages.where(type_id: wp_type.id).find_by(subject: m[:subject])\n"
+            "      if wp.nil?\n"
+            "        wp = WorkPackage.new(\n"
+            "          project: project,\n"
+            "          type: wp_type,\n"
+            "          subject: m[:subject],\n"
+            "          status: status,\n"
+            "          priority: priority,\n"
+            "          author: author\n"
+            "        )\n"
+            "      end\n"
+            "      cf_values = {}\n"
+            "      cf_values[cf_op_id] = m[:op_entity_id] if cf_op_id\n"
+            f"      cf_values[cf_entity_type_id] = '{entity_type}' if cf_entity_type_id\n"
+            "      wp.custom_field_values = cf_values if cf_values.any?\n"
+            "      wp.save!\n"
+            "      success += 1\n"
+            "    rescue => e\n"
+            "      failed += 1\n"
+            '      errors << "#{m[:subject]}: #{e.message}"\n'
+            "    end\n"
+            "  end\n"
+            "  { success: success, failed: failed, errors: errors.first(10) }\n"
+            "rescue => e\n"
+            "  { success: 0, failed: mappings.size, errors: [e.message] }\n"
+            "end\n"
+        )
+
+        try:
+            result = self._client.execute_json_query(script)
+            if isinstance(result, dict):
+                return result
+            return {"success": 0, "failed": len(mappings), "errors": [f"Unexpected result: {result}"]}
+        except Exception as e:
+            return {"success": 0, "failed": len(mappings), "errors": [str(e)]}


### PR DESCRIPTION
## Summary

- Continues Phase 2 god-class split: the J2O Migration Provenance subsystem (Jira→OP entity mappings stored as work packages in a dedicated project) moves into its own focused service.
- \`openproject_client.py\`: **6,906 → 6,534 LOC** (-372, -5.4%).
- New \`openproject_provenance_service.py\`: 465 LOC.
- Cumulative across Phase 2a+2b+2c: openproject_client.py **7,342 → 6,534** (-808, -11%).
- No behaviour change.

## Changes

### Methods moved

All keep their public names on \`OpenProjectClient\` (delegators); the implementation lives on the service:

| OpenProjectClient (delegator)              | Service method                  |
| ------------------------------------------ | ------------------------------- |
| \`ensure_j2o_migration_project\`           | \`ensure_migration_project\`    |
| \`ensure_j2o_provenance_types\`            | \`ensure_provenance_types\`     |
| \`ensure_j2o_provenance_custom_fields\`    | \`ensure_provenance_custom_fields\` |
| \`record_entity_provenance\`               | \`record_entity\`               |
| \`restore_entity_mappings_from_provenance\`| \`restore_entity_mappings\`     |
| \`bulk_record_entity_provenance\`          | \`bulk_record_entities\`        |

### Class constants moved (with the data)

| OpenProjectClient                       | Service                |
| --------------------------------------- | ---------------------- |
| \`J2O_MIGRATION_PROJECT_IDENTIFIER\`    | \`PROJECT_IDENTIFIER\` |
| \`J2O_MIGRATION_PROJECT_NAME\`          | \`PROJECT_NAME\`       |
| \`J2O_PROVENANCE_ENTITY_TYPES\`         | \`ENTITY_TYPES\`       |

A grep confirmed these constants weren't referenced from outside \`openproject_client.py\`, so they could move cleanly.

### Lazy infrastructure cache moves with the methods

The previously-instance \`_j2o_provenance_cache\` (project_id + type_ids + cf_ids, populated lazily on first \`record_entity_provenance\` call) lives on the service now as \`self._cache\`. The check changes from \`hasattr()\` to \`self._cache is None\` for clarity; semantics identical.

### Cross-service composition

\`ensure_provenance_custom_fields\` now calls \`self._client.custom_fields.ensure_custom_field\` directly instead of going through the \`OpenProjectClient.ensure_custom_field\` delegator. One less hop, and a clearer illustration of how the services compose. (The custom_fields service landed in #109 / #110.)

### Lazy import for the cycle

\`escape_ruby_single_quoted\` is imported lazily inside \`record_entity\` and \`bulk_record_entities\` to avoid the \`openproject_client ↔ openproject_provenance_service\` import cycle at module load time. Same pattern as \`OpenProjectCustomFieldService\`.

## Type of Change

- [x] Refactoring (no functional changes)

## Testing

- [x] Unit tests pass — \`pytest tests/unit/\` → **937 passed**
- [x] Mypy — \`mypy src/\` → clean on 99 source files
- [x] Ruff — \`ruff check .\` and \`ruff format --check .\` clean

## Process note

Following up on the Phase 2a/2b feedback ([PR #111](https://github.com/netresearch/jira-to-openproject/pull/111) bundled all the unresolved review comments) — going forward I'm waiting for the Copilot review pass to land on each PR before merging, so any new feedback gets addressed in-PR rather than as a follow-up.

## Related

Phase 2c of [ADR-002 target architecture](docs/adr/ADR-002-target-architecture.md). Subsequent PRs continue the openproject_client.py split:

- **Phase 2d**: \`OpenProjectRailsRunner\` (script execution + console output parsing — the largest remaining chunk at ~1,500 LOC).
- **Phase 2e**: \`OpenProjectFileTransfer\` (SSH + Docker file ops).
- **Phase 2f-h**: User / Project / WorkPackage services.
- **Phase 2i**: same treatment for \`jira_client.py\` (2,852 LOC).