### PR TITLE
Architecture phase 2d: extract OpenProjectFileTransferService

### DIFF
--- a/src/clients/openproject_client.py
+++ b/src/clients/openproject_client.py
@@ -14,7 +14,6 @@ from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
 from src import config
 from src.clients.docker_client import DockerClient
@@ -321,10 +320,12 @@ class OpenProjectClient:
         # functional seams). Backward-compat: same-named methods on
         # OpenProjectClient delegate to the corresponding service.
         from src.clients.openproject_custom_field_service import OpenProjectCustomFieldService
+        from src.clients.openproject_file_transfer_service import OpenProjectFileTransferService
         from src.clients.openproject_provenance_service import OpenProjectProvenanceService
 
         self.custom_fields = OpenProjectCustomFieldService(self)
         self.provenance = OpenProjectProvenanceService(self)
+        self.file_transfer = OpenProjectFileTransferService(self)
 
         logger.success(
             "OpenProjectClient initialized for host %s, container %s",
@@ -413,145 +414,30 @@ class OpenProjectClient:
     def _generate_unique_temp_filename(self, base_name: str) -> str:
         """Generate a temporary filename; stable for tests, unique in prod.
 
-        In normal runs we include timestamp/pid/random for uniqueness.
-        Under unit tests (detected via PYTEST_CURRENT_TEST), we return
-        deterministic '/tmp/{base_name}.json' to match test expectations.
+        Thin delegator over ``self.file_transfer.generate_unique_temp_filename``.
         """
-        if os.getenv("PYTEST_CURRENT_TEST"):
-            return f"/tmp/{base_name}.json"
-        timestamp = int(time.time())
-        pid = os.getpid()
-        random_suffix = secrets.token_hex(3)
-        return f"/tmp/{base_name}_{timestamp}_{pid}_{random_suffix}.json"
+        return self.file_transfer.generate_unique_temp_filename(base_name)
 
     def _create_script_file(self, script_content: str) -> Path:
         """Create a temporary file with the script content.
 
-        Args:
-            script_content: Content to write to the file
-
-        Returns:
-            Path to the created file
-
-        Raises:
-            OSError: If unable to create or write to the script file
-
+        Thin delegator over ``self.file_transfer.create_script_file``.
         """
-        file_path = None
-        try:
-            # Create a temporary directory if needed
-            temp_dir = Path(self.file_manager.data_dir) / "temp_scripts"
-            temp_dir.mkdir(parents=True, exist_ok=True)
-
-            # Generate a unique filename
-            filename = f"openproject_script_{os.urandom(4).hex()}.rb"
-            file_path = temp_dir / filename
-
-            # Write the content directly instead of using tempfile module
-            with file_path.open("w", encoding="utf-8") as f:
-                f.write(script_content)
-
-            # Log the absolute path for easier debugging
-            logger.debug("Created temporary script file: %s", file_path.as_posix())
-        except OSError:
-            error_msg = f"Failed to create script file: {file_path}"
-            logger.exception(error_msg)
-            raise OSError(error_msg) from None
-        except Exception:
-            error_msg = f"Failed to create script file: {file_path}"
-            logger.exception(error_msg)
-            raise OSError(error_msg) from None
-        else:
-            return file_path
+        return self.file_transfer.create_script_file(script_content)
 
     def _transfer_rails_script(self, local_path: Path | str) -> Path:
         """Transfer a script to the Rails environment.
 
-        Args:
-            local_path: Path to the script file (Path object or string)
-
-        Returns:
-            Path to the script in the container
-
-        Raises:
-            FileTransferError: If transfer fails
-
+        Thin delegator over ``self.file_transfer.transfer_rails_script``.
         """
-        try:
-            # Convert string to Path if needed
-            if isinstance(local_path, str):
-                local_path = Path(local_path)
-
-            # Get the absolute path for better error messages
-            abs_path = local_path.absolute()
-            logger.debug("Transferring script from: %s", abs_path)
-
-            # Use just the base filename for the container path
-            container_path = Path("/tmp") / local_path.name
-
-            self.docker_client.transfer_file_to_container(abs_path, container_path)
-
-            logger.debug(
-                "Successfully transferred file to container at %s",
-                container_path,
-            )
-
-        except Exception as e:
-            # Verify the local file exists and is readable only after failure
-            if isinstance(local_path, Path):
-                if not local_path.is_file():
-                    msg = f"Local file does not exist: {local_path}"
-                    raise FileTransferError(msg) from e
-
-                if not os.access(local_path, os.R_OK):
-                    msg = f"Local file is not readable: {local_path}"
-                    raise FileTransferError(msg) from e
-
-            msg = "Failed to transfer script."
-            raise FileTransferError(msg) from e
-
-        return container_path
+        return self.file_transfer.transfer_rails_script(local_path)
 
     def _cleanup_script_files(self, files_or_local: Any, remote_path: Path | None = None) -> None:
         """Clean up temporary files after execution.
 
-        Two supported modes (for backward compatibility and tests):
-        - files_or_local is a list of filenames (str/Path): iterate and issue remote cleanup via SSH, suppressing errors
-        - files_or_local is a Path and remote_path is a Path: remove local and remote paths
+        Thin delegator over ``self.file_transfer.cleanup_script_files``.
         """
-        # Mode 1: list of remote filenames
-        if isinstance(files_or_local, (list, tuple)):
-            for name in files_or_local:
-                try:
-                    remote_file = name if isinstance(name, str) else getattr(name, "name", str(name))
-                    cmd = f"docker exec {shlex.quote(self.container_name)} rm -f {shlex.quote(f'/tmp/{Path(remote_file).name}')}"
-                    self.ssh_client.execute_command(cmd)
-                except Exception as e:
-                    logger.warning("Cleanup failed for %s: %s", name, e)
-            return
-
-        # Mode 2: explicit local/remote Path cleanup
-        local_path = files_or_local
-        # Clean up local file
-        try:
-            if isinstance(local_path, Path) and local_path.exists():
-                local_path.unlink()
-                logger.debug("Cleaned up local script file: %s", local_path)
-        except Exception as e:
-            logger.warning("Non-critical error cleaning up local file: %s", e)
-
-        # Clean up remote file
-        try:
-            if isinstance(remote_path, Path):
-                command = [
-                    "rm",
-                    "-f",
-                    quote(remote_path.as_posix()),
-                ]
-                self.ssh_client.execute_command(" ".join(command))
-                logger.debug("Cleaned up remote script file: %s", remote_path)
-        except Exception as e:
-            logger.warning("Non-critical error cleaning up remote file: %s", e)
+        self.file_transfer.cleanup_script_files(files_or_local, remote_path)
 
     def execute(self, script_content: str) -> dict[str, Any]:
         """Execute a Ruby script directly.
@@ -906,20 +792,9 @@ class OpenProjectClient:
     ) -> None:
         """Transfer a file from local to the OpenProject container.
 
-        Args:
-            local_path: Path to local file
-            container_path: Destination path in container
-
-        Raises:
-            FileTransferError: If the transfer fails for any reason
-
+        Thin delegator over ``self.file_transfer.transfer_file_to_container``.
         """
-        try:
-            self.docker_client.transfer_file_to_container(local_path, container_path)
-        except Exception as e:
-            error_msg = "Failed to transfer file to container."
-            logger.exception(error_msg)
-            raise FileTransferError(error_msg) from e
+        self.file_transfer.transfer_file_to_container(local_path, container_path)
 
     def is_connected(self) -> bool:
         """Test if connected to OpenProject.
@@ -3829,27 +3704,9 @@ J2O_DATA
     ) -> Path:
         """Copy a file from the container to the local system.
 
-        Args:
-            container_path: Path to the file in the container
-            local_path: Path where the file should be saved locally
-
-        Returns:
-            Path to the local file
-
-        Raises:
-            FileTransferError: If transfer fails
-            FileNotFoundError: If container file doesn't exist
-
+        Thin delegator over ``self.file_transfer.transfer_file_from_container``.
         """
-        try:
-            return self.docker_client.copy_file_from_container(
-                container_path,
-                local_path,
-            )
-
-        except Exception as e:
-            msg = "Error transferring file from container."
-            raise FileTransferError(msg) from e
+        return self.file_transfer.transfer_file_from_container(container_path, local_path)
 
     def get_users(self) -> list[dict[str, Any]]:
         """Get all users from OpenProject.

--- a/src/clients/openproject_file_transfer_service.py
+++ b/src/clients/openproject_file_transfer_service.py
@@ -1,0 +1,232 @@
+"""File transfer + temp script lifecycle for the OpenProject container.
+
+Phase 2d of ADR-002: continues the god-class split. The Rails-script
+infrastructure plus the bare file-transfer plumbing — all the methods
+that move files between Python, the OpenProject server, and the
+container — moves into a focused service.
+
+Methods cover three responsibilities:
+
+* **Local script preparation**: create temp directories, generate unique
+  filenames, write Ruby scripts to disk.
+* **Container transfer**: ship files into and out of the container via
+  the underlying ``DockerClient``.
+* **Cleanup**: best-effort removal of local + remote temp files after
+  use, with two API shapes for backward compatibility.
+
+The Rails-execution methods (``execute``, ``execute_query``,
+``execute_json_query``, ``execute_script_with_data``,
+``execute_large_query_to_json_file``, ``_parse_rails_output``, etc.) stay
+on ``OpenProjectClient`` for now and call back through delegators — they
+are conceptually the "runner" rather than the "transport" and will move
+into ``OpenProjectRailsRunnerService`` in a follow-up phase.
+
+``OpenProjectClient`` exposes the service via ``self.file_transfer`` and
+keeps thin delegators for the same method names so existing call sites
+(internal client methods, the other services, migrations) work
+unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import shlex
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
+
+if TYPE_CHECKING:
+    from src.clients.openproject_client import OpenProjectClient
+
+
+class OpenProjectFileTransferService:
+    """Local-temp-file + container-file-transfer + cleanup helpers."""
+
+    def __init__(self, client: OpenProjectClient) -> None:
+        self._client = client
+        self._logger = client.logger
+
+    # ── local temp file management ────────────────────────────────────────
+
+    def generate_unique_temp_filename(self, base_name: str) -> str:
+        """Generate a temporary filename; stable for tests, unique in prod.
+
+        In normal runs we include timestamp/pid/random for uniqueness.
+        Under unit tests (detected via PYTEST_CURRENT_TEST), we return
+        deterministic ``/tmp/{base_name}.json`` to match test expectations.
+        """
+        if os.getenv("PYTEST_CURRENT_TEST"):
+            return f"/tmp/{base_name}.json"
+        timestamp = int(time.time())
+        pid = os.getpid()
+        random_suffix = secrets.token_hex(3)
+        return f"/tmp/{base_name}_{timestamp}_{pid}_{random_suffix}.json"
+
+    def create_script_file(self, script_content: str) -> Path:
+        """Create a temporary file with the given Ruby script content.
+
+        Args:
+            script_content: Content to write to the file
+
+        Returns:
+            Path to the created file
+
+        Raises:
+            OSError: If unable to create or write to the script file
+
+        """
+        file_path: Path | None = None
+        try:
+            temp_dir = Path(self._client.file_manager.data_dir) / "temp_scripts"
+            temp_dir.mkdir(parents=True, exist_ok=True)
+
+            filename = f"openproject_script_{os.urandom(4).hex()}.rb"
+            file_path = temp_dir / filename
+
+            with file_path.open("w", encoding="utf-8") as f:
+                f.write(script_content)
+
+            self._logger.debug("Created temporary script file: %s", file_path.as_posix())
+        except OSError:
+            error_msg = f"Failed to create script file: {file_path}"
+            self._logger.exception(error_msg)
+            raise OSError(error_msg) from None
+        except Exception:
+            error_msg = f"Failed to create script file: {file_path}"
+            self._logger.exception(error_msg)
+            raise OSError(error_msg) from None
+        else:
+            return file_path
+
+    # ── container transfer ────────────────────────────────────────────────
+
+    def transfer_rails_script(self, local_path: Path | str) -> Path:
+        """Transfer a Ruby script from a local path into the container under /tmp.
+
+        Returns the resulting container path.
+
+        Raises:
+            FileTransferError: If transfer fails (lazy-imported from openproject_client).
+
+        """
+        # Lazy import avoids the openproject_client ↔ this-module cycle.
+        from src.clients.openproject_client import FileTransferError
+
+        try:
+            if isinstance(local_path, str):
+                local_path = Path(local_path)
+
+            abs_path = local_path.absolute()
+            self._logger.debug("Transferring script from: %s", abs_path)
+
+            container_path = Path("/tmp") / local_path.name
+
+            self._client.docker_client.transfer_file_to_container(abs_path, container_path)
+
+            self._logger.debug(
+                "Successfully transferred file to container at %s",
+                container_path,
+            )
+
+        except Exception as e:
+            # Verify the local file exists and is readable only after failure
+            if isinstance(local_path, Path):
+                if not local_path.is_file():
+                    msg = f"Local file does not exist: {local_path}"
+                    raise FileTransferError(msg) from e
+
+                if not os.access(local_path, os.R_OK):
+                    msg = f"Local file is not readable: {local_path}"
+                    raise FileTransferError(msg) from e
+
+            msg = "Failed to transfer script."
+            raise FileTransferError(msg) from e
+
+        return container_path
+
+    def transfer_file_to_container(self, local_path: Path, container_path: Path) -> None:
+        """Transfer an arbitrary file from local to the OpenProject container.
+
+        Raises:
+            FileTransferError: If the transfer fails for any reason.
+
+        """
+        from src.clients.openproject_client import FileTransferError
+
+        try:
+            self._client.docker_client.transfer_file_to_container(local_path, container_path)
+        except Exception as e:
+            error_msg = "Failed to transfer file to container."
+            self._logger.exception(error_msg)
+            raise FileTransferError(error_msg) from e
+
+    def transfer_file_from_container(self, container_path: Path, local_path: Path) -> Path:
+        """Copy a file from the container to the local system.
+
+        Raises:
+            FileTransferError: If transfer fails.
+            FileNotFoundError: If the container file doesn't exist.
+
+        """
+        from src.clients.openproject_client import FileTransferError
+
+        try:
+            return self._client.docker_client.copy_file_from_container(
+                container_path,
+                local_path,
+            )
+
+        except Exception as e:
+            msg = "Error transferring file from container."
+            raise FileTransferError(msg) from e
+
+    # ── cleanup ───────────────────────────────────────────────────────────
+
+    def cleanup_script_files(
+        self,
+        files_or_local: Any,
+        remote_path: Path | None = None,
+    ) -> None:
+        """Best-effort cleanup of temp script files (local + remote).
+
+        Two supported call shapes (kept for backward compatibility with
+        existing tests and call sites):
+
+        * ``files_or_local`` is a ``list`` / ``tuple`` of remote filenames —
+          iterate and issue remote ``rm`` via SSH inside the container,
+          suppressing errors.
+        * ``files_or_local`` is a ``Path`` and ``remote_path`` is a ``Path`` —
+          remove the local file then the remote file.
+        """
+        # Mode 1: list of remote filenames
+        if isinstance(files_or_local, (list, tuple)):
+            for name in files_or_local:
+                try:
+                    remote_file = name if isinstance(name, str) else getattr(name, "name", str(name))
+                    cmd = (
+                        f"docker exec {shlex.quote(self._client.container_name)} "
+                        f"rm -f {shlex.quote(f'/tmp/{Path(remote_file).name}')}"
+                    )
+                    self._client.ssh_client.execute_command(cmd)
+                except Exception as e:
+                    self._logger.warning("Cleanup failed for %s: %s", name, e)
+            return
+
+        # Mode 2: explicit local/remote Path cleanup
+        local_path = files_or_local
+        try:
+            if isinstance(local_path, Path) and local_path.exists():
+                local_path.unlink()
+                self._logger.debug("Cleaned up local script file: %s", local_path)
+        except Exception as e:
+            self._logger.warning("Non-critical error cleaning up local file: %s", e)
+
+        try:
+            if isinstance(remote_path, Path):
+                command = ["rm", "-f", quote(remote_path.as_posix())]
+                self._client.ssh_client.execute_command(" ".join(command))
+                self._logger.debug("Cleaned up remote script file: %s", remote_path)
+        except Exception as e:
+            self._logger.warning("Non-critical error cleaning up remote file: %s", e)

--- a/tests/integration/test_openproject_client.py
+++ b/tests/integration/test_openproject_client.py
@@ -165,8 +165,12 @@ class TestOpenProjectClient(unittest.TestCase):
         """Test script file creation."""
         test_script = "puts 'Hello, World!'"
 
-        # Mock the data_dir path and os.urandom for the random filename
-        with patch("src.clients.openproject_client.os.urandom", return_value=b"abcd"):
+        # Mock the data_dir path and os.urandom for the random filename.
+        # ``_create_script_file`` is a delegator on OpenProjectClient over
+        # ``OpenProjectFileTransferService.create_script_file`` (Phase 2d of
+        # ADR-002 moved the implementation there), so the os.urandom call now
+        # resolves through the service module's ``os`` import.
+        with patch("src.clients.openproject_file_transfer_service.os.urandom", return_value=b"abcd"):
             # Mock Path.open to return a mock file
             mock_file = MagicMock()
             mock_file.__enter__.return_value = mock_file


### PR DESCRIPTION
## Summary

- Continues Phase 2 god-class split: the file-transfer + temp-script lifecycle methods move into a focused service.
- \`openproject_client.py\`: **6,534 → 6,392 LOC** (-142, -2.2%).
- New \`openproject_file_transfer_service.py\`: 232 LOC.
- Cumulative across Phase 2a+2b+2c+2d: openproject_client.py **7,342 → 6,392** (-950, -12.9%).
- No behaviour change.

## Changes

### Methods moved

All keep their public names on \`OpenProjectClient\` (delegators); ~15 internal call sites continue to work unchanged.

| OpenProjectClient (delegator)        | Service method                  |
| ------------------------------------ | ------------------------------- |
| \`_generate_unique_temp_filename\`   | \`generate_unique_temp_filename\` |
| \`_create_script_file\`              | \`create_script_file\`          |
| \`_transfer_rails_script\`           | \`transfer_rails_script\`       |
| \`_cleanup_script_files\`            | \`cleanup_script_files\`        |
| \`transfer_file_to_container\`       | \`transfer_file_to_container\`  |
| \`transfer_file_from_container\`     | \`transfer_file_from_container\`|

### Cycle handling

\`FileTransferError\` is lazy-imported inside each service method that needs it (same pattern as the CF and Provenance services use for \`escape_ruby_single_quoted\`). This avoids the \`openproject_client ↔ openproject_file_transfer_service\` import cycle at module load time.

### What stays

The Rails *execution* methods (\`execute\`, \`execute_query\`, \`execute_json_query\`, \`execute_script_with_data\`, \`execute_large_query_to_json_file\`, \`_parse_rails_output\`, \`_check_console_output_for_errors\`, etc.) stay on \`OpenProjectClient\` — they're the "runner", and will move into \`OpenProjectRailsRunnerService\` in **Phase 2e**. This PR just extracts the file-transport layer they depend on.

## Type of Change

- [x] Refactoring (no functional changes)

## Testing

- [x] Unit tests pass — \`pytest tests/unit/\` → **937 passed**
- [x] Mypy — \`mypy src/\` → clean on 100 source files
- [x] Ruff — \`ruff check .\` and \`ruff format --check .\` clean

## Related

Phase 2d of [ADR-002 target architecture](docs/adr/ADR-002-target-architecture.md). Subsequent PRs:

- **Phase 2e**: \`OpenProjectRailsRunnerService\` (the largest remaining chunk — \`execute*\` family + console output parsing, ~1,200 LOC).
- **Phase 2f-h**: User / Project / WorkPackage services.
- **Phase 2i**: same treatment for \`jira_client.py\` (2,852 LOC).