### PR TITLE
chore(harness): modernise pre-commit hooks + tighten branch protection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,66 @@
+# Pre-commit hooks for fast local feedback before push.
+#
+# Mirrors the *required* CI checks on this repo (Lint (ruff), Type check (mypy),
+# Tests (pytest)) so local commits/pushes catch the same issues CI does — the
+# previous setup was running legacy tools (black, isort, flake8) that the
+# project no longer enforces, and CI checks could fail despite green pre-commit.
+#
+# Hook stages
+# -----------
+# - ``pre-commit`` (default): fast checks that run on every commit
+#   (ruff lint+format, file-shape checks, JSON validation).
+# - ``pre-push``: heavier checks that run before push but not every commit
+#   (mypy, unit tests with coverage gate). These mirror CI's required checks.
+#
+# Run all on demand:
+#     pre-commit run --all-files
+#     pre-commit run --hook-stage pre-push --all-files
+#
+# Install:
+#     pre-commit install              # commit-stage hooks
+#     pre-commit install --hook-type pre-push   # pre-push hooks
+
 repos:
-  - repo: https://github.com/psf/black
-    rev: 25.12.0
+  # Ruff replaces black + isort + flake8 + pyupgrade. Keep the version pin in
+  # sync with pyproject.toml's [project.optional-dependencies] dev pin.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
     hooks:
-      - id: black
+      - id: ruff
+        name: ruff lint
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+        name: ruff format
 
-  - repo: https://github.com/pycqa/isort
-    rev: 7.0.0
+  # Mypy as a pre-push gate. Slower than ruff so we don't run it on every
+  # commit. ``files: ^src/`` matches the [tool.mypy] scope in pyproject.toml.
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.20.2
     hooks:
-      - id: isort
+      - id: mypy
+        name: mypy (src/)
+        args: [--config-file=pyproject.toml]
+        files: ^src/
+        stages: [pre-push]
+        # Mypy needs the project deps to resolve types; let pre-commit set
+        # up its own venv with the type stubs declared in pyproject.toml.
+        additional_dependencies:
+          - types-PyYAML
+          - types-aiofiles
+          - types-requests
+          - pydantic
+          - jira
+          - sqlalchemy
+          - tenacity
+          - pybreaker
+          - structlog
+          - psutil
+          - jsonschema
+          - fastapi
+          - rich
+          - redis
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.3.0
-    hooks:
-      - id: flake8
-
-  # Temporarily disabled mypy due to large number of type annotation issues
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.16.1
-  #   hooks:
-  #     - id: mypy
-
+  # Pre-commit's own house-keeping hooks.
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -27,37 +68,33 @@ repos:
       - id: trailing-whitespace
       - id: check-added-large-files
       - id: check-yaml
+        # The .pre-commit-config.yaml uses block-scalar literals that some
+        # variants of check-yaml stumble on; the default config is fine.
+      - id: check-toml
+      - id: check-merge-conflict
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-      - id: pyupgrade
-        args: [--py313-plus]
-
-  # Test-related hooks for improved developer experience
+  # Project-local hooks for tests + JSON sanity.
   - repo: local
     hooks:
-      - id: quick-tests
-        name: Quick Unit Tests
-        entry: python scripts/test_helper.py quick
-        language: system
-        stages: [pre-push]
-        pass_filenames: false
-
+      # Fast smoke-test on commit when test files change. Cheap enough not to
+      # gate everyone's flow but catches obvious "I broke a test fixture" cases.
       - id: smoke-tests-on-commit
-        name: Smoke Tests (if tests changed)
+        name: Smoke tests (when tests/ changed)
         entry: python scripts/test_helper.py smoke
         language: system
         files: ^tests/.*\.py$
         pass_filenames: false
 
-      - id: test-coverage-check
-        name: Test Coverage Check
-        entry: bash -c 'python -m pytest --cov=src --cov-fail-under=80 tests/unit/'
+      # Pre-push: run the same unit suite CI runs, with an 80% coverage gate.
+      # Mirrors the "Tests (pytest)" required check in CI.
+      - id: unit-tests
+        name: Unit tests (with coverage gate)
+        entry: bash -c '.venv/bin/pytest --cov=src --cov-fail-under=80 tests/unit/'
         language: system
         stages: [pre-push]
         pass_filenames: false
 
+      # JSON sanity check for the taskmaster file (kept from previous config).
       - id: check-tasks-json
         name: Check tasks.json for valid JSON
         entry: python -c "import json; f=open('.taskmaster/tasks/tasks.json'); json.load(f)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,17 +87,21 @@ repos:
 
       # Pre-push: run the same unit suite CI runs, with an 80% coverage gate.
       # Mirrors the "Tests (pytest)" required check in CI.
+      # Uses ``python -m pytest`` so the hook works regardless of the user's
+      # virtual-env directory name (.venv, venv, env, system pip install, ...).
       - id: unit-tests
         name: Unit tests (with coverage gate)
-        entry: bash -c '.venv/bin/pytest --cov=src --cov-fail-under=80 tests/unit/'
+        entry: python -m pytest --cov=src --cov-fail-under=80 tests/unit/
         language: system
         stages: [pre-push]
         pass_filenames: false
 
       # JSON sanity check for the taskmaster file (kept from previous config).
+      # Open with encoding="utf-8" so the check is deterministic across
+      # platforms (Windows defaults to cp1252) and survives non-ASCII data.
       - id: check-tasks-json
         name: Check tasks.json for valid JSON
-        entry: python -c "import json; f=open('.taskmaster/tasks/tasks.json'); json.load(f)"
+        entry: python -c "import json; json.load(open('.taskmaster/tasks/tasks.json', encoding='utf-8'))"
         language: python
         files: ^\.taskmaster/tasks/tasks\.json$
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,32 +33,29 @@ repos:
         name: ruff format
 
   # Mypy as a pre-push gate. Slower than ruff so we don't run it on every
-  # commit. ``files: ^src/`` matches the [tool.mypy] scope in pyproject.toml.
+  # commit. Configured to run over the *entire* ``[tool.mypy] files = ["src"]``
+  # scope from pyproject.toml every time — not just the touched files —
+  # because cross-module type errors only surface that way (and pre-commit's
+  # default file-by-file invocation can silently skip pushes that don't
+  # change ``src/``). This mirrors how CI invokes ``mypy src/``.
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.20.2
     hooks:
       - id: mypy
         name: mypy (src/)
         args: [--config-file=pyproject.toml]
-        files: ^src/
+        pass_filenames: false
+        always_run: true
         stages: [pre-push]
-        # Mypy needs the project deps to resolve types; let pre-commit set
-        # up its own venv with the type stubs declared in pyproject.toml.
+        # Keep the pre-commit mypy env reproducible by installing only
+        # explicit type stubs here. Runtime deps are handled by mypy's
+        # ``ignore_missing_imports = true`` in pyproject.toml — adding them
+        # as unpinned ``additional_dependencies`` would drift away from
+        # ``uv.lock`` and break unpredictably on upstream releases.
         additional_dependencies:
           - types-PyYAML
           - types-aiofiles
           - types-requests
-          - pydantic
-          - jira
-          - sqlalchemy
-          - tenacity
-          - pybreaker
-          - structlog
-          - psutil
-          - jsonschema
-          - fastapi
-          - rich
-          - redis
 
   # Pre-commit's own house-keeping hooks.
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -85,10 +82,15 @@ repos:
         files: ^tests/.*\.py$
         pass_filenames: false
 
-      # Pre-push: run the same unit suite CI runs, with an 80% coverage gate.
-      # Mirrors the "Tests (pytest)" required check in CI.
-      # Uses ``python -m pytest`` so the hook works regardless of the user's
-      # virtual-env directory name (.venv, venv, env, system pip install, ...).
+      # Pre-push: unit tests with an 80% coverage gate. Faster than CI's
+      # full pytest run (which collects all of tests/ and lets conftest
+      # skip integration/functional/e2e by default) but covers the same
+      # fast-failure surface — anything that breaks the unit suite would
+      # also break the CI "Tests (pytest)" check. Running ``tests/unit/``
+      # explicitly keeps this hook predictable and quick (~5 min) so
+      # contributors actually run it before push.
+      # Uses ``python -m pytest`` so the hook works regardless of the
+      # virtual-env directory name (.venv, venv, env, system, ...).
       - id: unit-tests
         name: Unit tests (with coverage gate)
         entry: python -m pytest --cov=src --cov-fail-under=80 tests/unit/


### PR DESCRIPTION
## Why

Two recent PRs (#115 → #116) landed with broken pytest because **only \`container-tests\` was a required CI check** on this repo, so auto-merge fired even when \`Tests (pytest)\` failed. Pre-commit also ran legacy tools (\`black\`, \`isort\`, \`flake8\`) that pyproject doesn't enforce, plus disabled mypy entirely — so a green \`pre-commit run\` didn't mean CI would pass.

This PR addresses both layers.

## Pre-commit changes (.pre-commit-config.yaml)

| Removed | Reason |
| ------- | ------ |
| \`psf/black\` | Replaced by \`ruff format\` (project uses ruff) |
| \`pycqa/isort\` | Replaced by ruff (handles import sorting) |
| \`pycqa/flake8\` | Replaced by ruff (handles lint) |
| \`asottile/pyupgrade --py313-plus\` | Replaced by ruff; project targets py3.14, not 3.13 |
| \`quick-tests\` local hook | Subsumed by \`unit-tests\` below |

| Added | Stage | Mirrors CI check |
| ----- | ----- | ---------------- |
| \`ruff\` (lint, \`--fix --exit-non-zero-on-fix\`) | pre-commit | Lint (ruff) |
| \`ruff-format\` | pre-commit | Lint (ruff) |
| \`mypy\` v1.20.2 (scoped to \`^src/\`) | pre-push | Type check (mypy) |
| \`unit-tests\` (\`pytest --cov=src --cov-fail-under=80 tests/unit/\`) | pre-push | Tests (pytest) |
| \`check-toml\`, \`check-merge-conflict\` | pre-commit | (sanity) |

The mypy hook ships with the type-stub deps from pyproject.toml's \`[project.optional-dependencies] dev\` listed under \`additional_dependencies\` so pre-commit can resolve types in its own venv.

## Branch protection changes (already applied via gh api)

Required status checks on \`main\` went from **1 → 6**:

Was:
- \`container-tests\`

Now:
- \`container-tests\`
- \`Tests (pytest)\`
- \`Lint (ruff)\`
- \`Type check (mypy)\`
- \`Python Dependency Audit\`
- \`gitleaks / Secret Scanning\`

Auto-merge now requires every one of these to pass before firing — the failure mode that let #115 merge with a broken pytest can't recur.

## Usage

\`\`\`bash
pre-commit install                          # commit-stage hooks
pre-commit install --hook-type pre-push     # pre-push hooks (mypy + pytest)
pre-commit run --all-files                  # ad-hoc run all
pre-commit run --hook-stage pre-push --all-files   # heavy hooks too
\`\`\`

## Type of Change

- [x] CI/CD or infrastructure changes
- [x] Bug fix (process: prevents broken-CI auto-merge)

## Testing

- YAML validated (\`python -c "import yaml; yaml.safe_load(open('.pre-commit-config.yaml'))"\`)
- Pre-commit hook IDs and stages match pre-commit-hooks v6.0.0 / ruff-pre-commit v0.15.12 / mirrors-mypy v1.20.2 schemas
- Branch protection check verified via \`gh api repos/.../branches/main/protection/required_status_checks\`

## Process note

Going forward, with required checks tightened, even \`gh pr merge --auto\` will only fire when the **whole** check matrix is green and Copilot's review threads are resolved. Combined with pre-commit catching the same issues locally before push, both layers protect main.