### PR TITLE
fix(review): address Copilot comments on #119 (Phase 2i)

### DIFF
--- a/src/clients/openproject_rails_runner_service.py
+++ b/src/clients/openproject_rails_runner_service.py
@@ -891,7 +891,11 @@ class OpenProjectRailsRunnerService:
         Args:
             query: Rails query to execute; will be coerced to JSON in Ruby
             container_file: Absolute path inside the container to write JSON content
-            timeout: Ruby execution timeout (defaults to client.command_timeout)
+            timeout: Optional Ruby execution timeout. When ``None`` the per-path
+                defaults are used: 90s for the persistent tmux console
+                ``execute()`` call (matches ``RailsConsoleClient`` defaults) and
+                300s for ``bundle exec rails runner`` subprocesses, since the
+                runner has higher cold-start cost on large projects.
 
         Returns:
             Parsed JSON data
@@ -1017,9 +1021,15 @@ class OpenProjectRailsRunnerService:
                         context="execute_large_query_to_json_file(load)",
                     )
                 except Exception as e:
-                    # Fallback to rails runner on console instability
+                    # Fallback to rails runner on console instability. Use the
+                    # same runner timeout as the explicit-runner path so this
+                    # branch doesn't silently inherit the DockerClient default
+                    # (which would either time out short or hang long).
                     runner_cmd = f"(cd /app || cd /opt/openproject) && bundle exec rails runner {runner_script_path}"
-                    stdout, stderr, rc = client.docker_client.execute_command(runner_cmd)
+                    stdout, stderr, rc = client.docker_client.execute_command(
+                        runner_cmd,
+                        timeout=timeout or 300,
+                    )
                     if rc != 0:
                         q_msg = f"rails runner failed (rc={rc}): {stderr[:500]}"
                         raise QueryExecutionError(q_msg) from e
@@ -1059,7 +1069,14 @@ class OpenProjectRailsRunnerService:
                         f.write(ruby_script)
                     client.docker_client.transfer_file_to_container(local_tmp, Path(runner_script_path))
                     runner_cmd = f"(cd /app || cd /opt/openproject) && bundle exec rails runner {runner_script_path}"
-                    stdout, stderr, rc = client.docker_client.execute_command(runner_cmd)
+                    # Same explicit timeout as the other runner paths. This
+                    # fallback fires when the persistent tmux console crashed
+                    # mid-query, so a fresh ``bundle exec rails runner`` boots
+                    # cold — 300s matches the explicit-runner branch.
+                    stdout, stderr, rc = client.docker_client.execute_command(
+                        runner_cmd,
+                        timeout=timeout or 300,
+                    )
                     if rc != 0:
                         q_msg = f"rails runner failed (rc={rc}): {stderr[:500]}"
                         raise QueryExecutionError(q_msg) from e
@@ -1074,7 +1091,11 @@ class OpenProjectRailsRunnerService:
         try:
             max_wait_seconds = int(wait_env) if wait_env else 600
         except Exception:
-            max_wait_seconds = 60
+            # Invalid env value: fall back to the same 600s default as the
+            # no-env branch instead of an unrelated 60s short window. The
+            # original 60s here was a copy-paste from another caller and
+            # made invalid env values silently shrink the wait by 10×.
+            max_wait_seconds = 600
         poll_interval = 0.5
         attempts = max(1, int(max_wait_seconds / poll_interval))
 

--- a/src/clients/openproject_rails_runner_service.py
+++ b/src/clients/openproject_rails_runner_service.py
@@ -893,9 +893,12 @@ class OpenProjectRailsRunnerService:
             container_file: Absolute path inside the container to write JSON content
             timeout: Optional Ruby execution timeout. When ``None`` the per-path
                 defaults are used: 90s for the persistent tmux console
-                ``execute()`` call (matches ``RailsConsoleClient`` defaults) and
-                300s for ``bundle exec rails runner`` subprocesses, since the
-                runner has higher cold-start cost on large projects.
+                ``execute()`` call and 300s for ``bundle exec rails runner``
+                subprocesses (the runner has higher cold-start cost on large
+                projects). These values are deliberately tighter than the
+                ``RailsConsoleClient.command_timeout`` default (180s) — large
+                JSON queries should fail fast when the console is unstable so
+                the rails-runner fallback can take over.
 
         Returns:
             Parsed JSON data
@@ -1024,11 +1027,13 @@ class OpenProjectRailsRunnerService:
                     # Fallback to rails runner on console instability. Use the
                     # same runner timeout as the explicit-runner path so this
                     # branch doesn't silently inherit the DockerClient default
-                    # (which would either time out short or hang long).
+                    # (which would either time out short or hang long). Use
+                    # ``is not None`` so a caller-supplied ``timeout=0`` is
+                    # respected literally rather than treated as "default".
                     runner_cmd = f"(cd /app || cd /opt/openproject) && bundle exec rails runner {runner_script_path}"
                     stdout, stderr, rc = client.docker_client.execute_command(
                         runner_cmd,
-                        timeout=timeout or 300,
+                        timeout=timeout if timeout is not None else 300,
                     )
                     if rc != 0:
                         q_msg = f"rails runner failed (rc={rc}): {stderr[:500]}"
@@ -1072,10 +1077,12 @@ class OpenProjectRailsRunnerService:
                     # Same explicit timeout as the other runner paths. This
                     # fallback fires when the persistent tmux console crashed
                     # mid-query, so a fresh ``bundle exec rails runner`` boots
-                    # cold — 300s matches the explicit-runner branch.
+                    # cold — 300s matches the explicit-runner branch. Use
+                    # ``is not None`` so a caller-supplied ``timeout=0`` is
+                    # respected literally rather than treated as "default".
                     stdout, stderr, rc = client.docker_client.execute_command(
                         runner_cmd,
-                        timeout=timeout or 300,
+                        timeout=timeout if timeout is not None else 300,
                     )
                     if rc != 0:
                         q_msg = f"rails runner failed (rc={rc}): {stderr[:500]}"


### PR DESCRIPTION
## Summary
Four Copilot review comments on the Phase 2i extraction (#119) landed after auto-merge had already fired (Copilot reviews are non-blocking by GitHub design and can't be made a required check). All four are real correctness / clarity bugs on the rails-runner fallback paths.

## Fixes

### 1. Docstring lied about \`timeout\` (line 894)
The docstring said \`timeout\` defaults to \`client.command_timeout\`. The implementation actually uses **90s for the tmux console path** and **300s for ``bundle exec rails runner`` cold subprocesses**. Updated the docstring to describe the real per-path defaults — keeping the two values intentionally split since the runner has higher cold-start cost.

### 2. Console-load fallback dropped its timeout (line 1022)
In the \`mode == 'console'\` branch, the rails-runner fallback (when console \`load\` raises) called \`execute_command(runner_cmd)\` with no \`timeout\` — silently inheriting whatever DockerClient default was in play. Pass \`timeout=timeout or 300\` to mirror the explicit-runner branch.

### 3. Direct-tmux fallback dropped its timeout (line 1062)
Same omission in the \`else\` branch (direct tmux \`execute\` → runner fallback). Passes \`timeout=timeout or 300\`.

### 4. Invalid \`J2O_QUERY_RESULT_WAIT_SECONDS\` shrunk wait 10× (line 1077)
When the env var was unset the loop waited **600s**; when the env var was *invalid* it only waited **60s** — a silent 10× cliff that would surface as random "file not found" failures. Use 600s in both fallbacks; added a comment so it doesn't regress.

## Verification
- \`pytest tests/unit\`: 953 passed
- \`mypy src/\`: clean
- \`ruff check\` / \`ruff format\`: clean

## Test plan
- [x] All 6 required CI checks must pass.
- [ ] All 4 Copilot comment threads resolved with replies pointing at this PR.