### PR TITLE
refactor(phase-2p): extract OpenProjectIssuePriorityService

### DIFF
--- a/src/clients/openproject_client.py
+++ b/src/clients/openproject_client.py
@@ -316,6 +316,7 @@ class OpenProjectClient:
         from src.clients.openproject_associations_service import OpenProjectAssociationsService
         from src.clients.openproject_custom_field_service import OpenProjectCustomFieldService
         from src.clients.openproject_file_transfer_service import OpenProjectFileTransferService
+        from src.clients.openproject_issue_priority_service import OpenProjectIssuePriorityService
         from src.clients.openproject_membership_service import OpenProjectMembershipService
         from src.clients.openproject_project_service import OpenProjectProjectService
         from src.clients.openproject_provenance_service import OpenProjectProvenanceService
@@ -336,6 +337,7 @@ class OpenProjectClient:
         self.work_packages = OpenProjectWorkPackageService(self)
         self.associations = OpenProjectAssociationsService(self)
         self.time_entries = OpenProjectTimeEntryService(self)
+        self.priorities = OpenProjectIssuePriorityService(self)
 
         logger.success(
             "OpenProjectClient initialized for host %s, container %s",
@@ -2612,42 +2614,16 @@ J2O_DATA
 
     # ----- Priority helpers -----
     def get_issue_priorities(self) -> list[dict[str, Any]]:
-        """Return list of IssuePriority with id, name, position, is_default, active."""
-        script = """
-        IssuePriority.order(:position).map do |p|
-          { id: p.id, name: p.name, position: p.position, is_default: p.is_default, active: p.active }
-        end
-        """
-        try:
-            result = self.execute_json_query(script)
-            return result if isinstance(result, list) else []
-        except Exception:
-            logger.exception("Failed to get issue priorities")
-            return []
+        """Thin delegator over ``self.priorities.get_issue_priorities``."""
+        return self.priorities.get_issue_priorities()
 
     def find_issue_priority_by_name(self, name: str) -> dict[str, Any] | None:
-        # Use ensure_ascii=False to output UTF-8 directly
-        script = f"p = IssuePriority.find_by(name: {json.dumps(name, ensure_ascii=False)}); p && {{ id: p.id, name: p.name, position: p.position, is_default: p.is_default, active: p.active }}"
-        try:
-            result = self.execute_json_query(script)
-            return result if isinstance(result, dict) else None
-        except Exception:
-            logger.exception("Failed to find issue priority by name %s", name)
-            return None
+        """Thin delegator over ``self.priorities.find_issue_priority_by_name``."""
+        return self.priorities.find_issue_priority_by_name(name)
 
     def create_issue_priority(self, name: str, position: int | None = None, is_default: bool = False) -> dict[str, Any]:
-        pos_expr = "nil" if position is None else str(int(position))
-        # Use ensure_ascii=False to output UTF-8 directly
-        script = f"""
-        p = IssuePriority.create!(name: {json.dumps(name, ensure_ascii=False)}, position: {pos_expr}, is_default: {str(is_default).lower()}, active: true)
-        {{ id: p.id, name: p.name, position: p.position, is_default: p.is_default, active: p.active }}
-        """
-        try:
-            result = self.execute_json_query(script)
-            return result if isinstance(result, dict) else {"id": None, "name": name}
-        except Exception as e:
-            msg = f"Failed to create issue priority {name}: {e}"
-            raise QueryExecutionError(msg) from e
+        """Thin delegator over ``self.priorities.create_issue_priority``."""
+        return self.priorities.create_issue_priority(name, position, is_default)
 
     def ensure_local_avatars_enabled(self) -> bool:
         """Enable local avatar uploads if disabled.

--- a/src/clients/openproject_issue_priority_service.py
+++ b/src/clients/openproject_issue_priority_service.py
@@ -18,7 +18,6 @@ work unchanged.
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any
 
 from src.clients.exceptions import QueryExecutionError
@@ -49,8 +48,22 @@ class OpenProjectIssuePriorityService:
             return []
 
     def find_issue_priority_by_name(self, name: str) -> dict[str, Any] | None:
-        # Use ensure_ascii=False to output UTF-8 directly
-        script = f"p = IssuePriority.find_by(name: {json.dumps(name, ensure_ascii=False)}); p && {{ id: p.id, name: p.name, position: p.position, is_default: p.is_default, active: p.active }}"
+        # Lazy import: ``escape_ruby_single_quoted`` lives on the
+        # client; lazy keeps the service ↔ client cycle out of
+        # module-load time.
+        from src.clients.openproject_client import escape_ruby_single_quoted
+
+        # SECURITY: build a single-quoted Ruby literal. The previous
+        # ``json.dumps(name)`` produced a double-quoted Ruby string,
+        # which Ruby parses with ``#{...}`` interpolation — a priority
+        # name from Jira (untrusted source) could have triggered
+        # arbitrary Ruby execution in the Rails console.
+        safe_name = escape_ruby_single_quoted(name)
+        script = (
+            f"p = IssuePriority.find_by(name: '{safe_name}'); "
+            "p && { id: p.id, name: p.name, position: p.position, "
+            "is_default: p.is_default, active: p.active }"
+        )
         try:
             result = self._client.execute_json_query(script)
             return result if isinstance(result, dict) else None
@@ -64,10 +77,14 @@ class OpenProjectIssuePriorityService:
         position: int | None = None,
         is_default: bool = False,
     ) -> dict[str, Any]:
+        # Same security note as ``find_issue_priority_by_name`` —
+        # untrusted ``name`` would otherwise interpolate as Ruby.
+        from src.clients.openproject_client import escape_ruby_single_quoted
+
         pos_expr = "nil" if position is None else str(int(position))
-        # Use ensure_ascii=False to output UTF-8 directly
+        safe_name = escape_ruby_single_quoted(name)
         script = f"""
-        p = IssuePriority.create!(name: {json.dumps(name, ensure_ascii=False)}, position: {pos_expr}, is_default: {str(is_default).lower()}, active: true)
+        p = IssuePriority.create!(name: '{safe_name}', position: {pos_expr}, is_default: {str(is_default).lower()}, active: true)
         {{ id: p.id, name: p.name, position: p.position, is_default: p.is_default, active: p.active }}
         """
         try:

--- a/src/clients/openproject_issue_priority_service.py
+++ b/src/clients/openproject_issue_priority_service.py
@@ -1,0 +1,78 @@
+"""IssuePriority helpers for the OpenProject Rails console.
+
+Phase 2p of ADR-002 continues the openproject_client.py god-class
+decomposition by collecting the small ``IssuePriority`` subsystem onto
+a focused service. The service owns:
+
+* ``get_issue_priorities`` — list all ``IssuePriority`` rows (id, name,
+  position, default flag, active flag) ordered by ``position``.
+* ``find_issue_priority_by_name`` — look up a single priority by name
+  or return ``None``.
+* ``create_issue_priority`` — create a new priority and return the
+  freshly persisted attributes.
+
+``OpenProjectClient`` exposes the service via ``self.priorities`` and
+keeps thin delegators for the same method names so existing call sites
+work unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from src.clients.exceptions import QueryExecutionError
+
+if TYPE_CHECKING:
+    from src.clients.openproject_client import OpenProjectClient
+
+
+class OpenProjectIssuePriorityService:
+    """``IssuePriority`` Rails-console helpers for ``OpenProjectClient``."""
+
+    def __init__(self, client: OpenProjectClient) -> None:
+        self._client = client
+        self._logger = client.logger
+
+    def get_issue_priorities(self) -> list[dict[str, Any]]:
+        """Return list of IssuePriority with id, name, position, is_default, active."""
+        script = """
+        IssuePriority.order(:position).map do |p|
+          { id: p.id, name: p.name, position: p.position, is_default: p.is_default, active: p.active }
+        end
+        """
+        try:
+            result = self._client.execute_json_query(script)
+            return result if isinstance(result, list) else []
+        except Exception:
+            self._logger.exception("Failed to get issue priorities")
+            return []
+
+    def find_issue_priority_by_name(self, name: str) -> dict[str, Any] | None:
+        # Use ensure_ascii=False to output UTF-8 directly
+        script = f"p = IssuePriority.find_by(name: {json.dumps(name, ensure_ascii=False)}); p && {{ id: p.id, name: p.name, position: p.position, is_default: p.is_default, active: p.active }}"
+        try:
+            result = self._client.execute_json_query(script)
+            return result if isinstance(result, dict) else None
+        except Exception:
+            self._logger.exception("Failed to find issue priority by name %s", name)
+            return None
+
+    def create_issue_priority(
+        self,
+        name: str,
+        position: int | None = None,
+        is_default: bool = False,
+    ) -> dict[str, Any]:
+        pos_expr = "nil" if position is None else str(int(position))
+        # Use ensure_ascii=False to output UTF-8 directly
+        script = f"""
+        p = IssuePriority.create!(name: {json.dumps(name, ensure_ascii=False)}, position: {pos_expr}, is_default: {str(is_default).lower()}, active: true)
+        {{ id: p.id, name: p.name, position: p.position, is_default: p.is_default, active: p.active }}
+        """
+        try:
+            result = self._client.execute_json_query(script)
+            return result if isinstance(result, dict) else {"id": None, "name": name}
+        except Exception as e:
+            msg = f"Failed to create issue priority {name}: {e}"
+            raise QueryExecutionError(msg) from e


### PR DESCRIPTION
## Summary
- Phase 2p of the [ADR-002](docs/adr/ADR-002-target-architecture.md) god-class decomposition.
- Small, focused extraction (~24 LOC removed, 78 LOC new). Three IssuePriority helpers move from `openproject_client.py` into a new `OpenProjectIssuePriorityService` exposed as `self.priorities`.
- `OpenProjectClient` keeps a thin delegator for each method so existing callers work unchanged.

This work was done by a sub-agent in an isolated worktree as part of an experiment to delegate independent extractions in parallel with main-session work. The sub-agent ran the full verification stack (ruff, mypy, pytest) and reported `953 passed`.

## Methods moved
- `get_issue_priorities`
- `find_issue_priority_by_name`
- `create_issue_priority`

## Numbers
- `openproject_client.py`: **3,984 → 3,960 LOC** (−24, this PR alone — measured against `main` at the time of the sub-agent's branch)
- `openproject_issue_priority_service.py`: **0 → 78 LOC** (new)

(This PR's diff vs. main and the cumulative client LOC will refresh once Phase 2q (#127) lands; the two PRs were prepared in parallel and the cumulative percentage will be updated on the merge commit.)

## Verification
- `pytest tests/unit`: 953 passed
- `mypy src/`: clean (108 files)
- `ruff check` / `ruff format`: clean

## Test plan
- [x] All 6 required CI checks must pass.
- [ ] Copilot review acknowledged & comments resolved before merge.