### PR TITLE
refactor(phase-2v): extract OpenProjectAdminCleanupService

### DIFF
--- a/src/clients/openproject_admin_cleanup_service.py
+++ b/src/clients/openproject_admin_cleanup_service.py
@@ -1,0 +1,127 @@
+"""Admin cleanup helpers for the OpenProject Rails console.
+
+Phase 2v of ADR-002 collects the destructive admin operations onto a
+focused service so they're easy to find and audit. The service owns:
+
+* ``delete_all_projects`` — ``Project.delete_all`` (no validation,
+  no callbacks).
+* ``delete_non_default_issue_types`` — destroys every ``Type`` with
+  ``is_default: false`` AND ``is_standard: false`` (callbacks fire).
+* ``delete_non_default_issue_statuses`` — destroys every ``Status``
+  with ``is_default: false`` (callbacks fire).
+
+Note on authorisation
+---------------------
+The Rails-console execution path runs whatever the console session is
+allowed to run; there is no server-side admin guard inside these
+helpers. The methods exist for migration teardown and CI fixture
+reset, NOT for runtime use against a live install. Wrap them in your
+own authorisation check (or just don't call them) if you have any
+concerns about misuse.
+
+Note on return values
+---------------------
+The pre-extraction implementation routed through
+``self.execute_query`` whose result is the raw console output as a
+*string* — so the previous ``isinstance(count, int)`` guard always
+saw ``False`` and the methods silently reported 0 even when
+``Project.delete_all`` etc. succeeded. Same bug Gemini caught for
+``delete_all_work_packages`` during Phase 2n review. Fixed at the
+move by routing through ``execute_json_query`` so the integer comes
+back as an actual ``int``.
+
+``OpenProjectClient`` exposes the service via ``self.admin_cleanup``
+and keeps thin delegators for the same method names so existing call
+sites work unchanged. ``delete_all_custom_fields`` stays on the
+client as a delegator into ``OpenProjectCustomFieldService`` (where
+it was extracted in Phase 2a/2b) — no further move needed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.clients.exceptions import QueryExecutionError
+
+if TYPE_CHECKING:
+    from src.clients.openproject_client import OpenProjectClient
+
+
+class OpenProjectAdminCleanupService:
+    """Destructive admin / cleanup helpers for ``OpenProjectClient``."""
+
+    def __init__(self, client: OpenProjectClient) -> None:
+        self._client = client
+        self._logger = client.logger
+
+    def delete_all_projects(self) -> int:
+        """Delete all projects in bulk.
+
+        Returns:
+            Number of deleted projects
+
+        Raises:
+            QueryExecutionError: If bulk deletion fails
+
+        """
+        try:
+            # ``execute_json_query`` parses the integer; the previous
+            # ``execute_query`` returned the raw console string and
+            # the ``isinstance(count, int)`` guard always saw
+            # ``False``, masking successful runs as "0 deleted".
+            count = self._client.execute_json_query("Project.delete_all")
+            return count if isinstance(count, int) else 0
+        except Exception as e:
+            msg = "Failed to delete all projects."
+            raise QueryExecutionError(msg) from e
+
+    def delete_non_default_issue_types(self) -> int:
+        """Delete non-default issue types (work package types).
+
+        Returns:
+            Number of deleted types
+
+        Raises:
+            QueryExecutionError: If deletion fails
+
+        """
+        script = """
+        non_default_types = Type.where(is_default: false, is_standard: false)
+        count = non_default_types.count
+        non_default_types.destroy_all
+        count
+        """
+
+        try:
+            # See ``delete_all_projects`` — switch from
+            # ``execute_query`` to ``execute_json_query`` so the count
+            # comes back as a real int rather than a console string.
+            count = self._client.execute_json_query(script)
+            return count if isinstance(count, int) else 0
+        except Exception as e:
+            msg = "Failed to delete non-default issue types."
+            raise QueryExecutionError(msg) from e
+
+    def delete_non_default_issue_statuses(self) -> int:
+        """Delete non-default issue statuses.
+
+        Returns:
+            Number of deleted statuses
+
+        Raises:
+            QueryExecutionError: If deletion fails
+
+        """
+        script = """
+        non_default_statuses = Status.where(is_default: false)
+        count = non_default_statuses.count
+        non_default_statuses.destroy_all
+        count
+        """
+
+        try:
+            count = self._client.execute_json_query(script)
+            return count if isinstance(count, int) else 0
+        except Exception as e:
+            msg = "Failed to delete non-default issue statuses."
+            raise QueryExecutionError(msg) from e

--- a/src/clients/openproject_admin_cleanup_service.py
+++ b/src/clients/openproject_admin_cleanup_service.py
@@ -25,10 +25,12 @@ The pre-extraction implementation routed through
 ``self.execute_query`` whose result is the raw console output as a
 *string* — so the previous ``isinstance(count, int)`` guard always
 saw ``False`` and the methods silently reported 0 even when
-``Project.delete_all`` etc. succeeded. Same bug Gemini caught for
-``delete_all_work_packages`` during Phase 2n review. Fixed at the
-move by routing through ``execute_json_query`` so the integer comes
-back as an actual ``int``.
+``Project.delete_all`` etc. succeeded. Same shape as the
+``delete_all_work_packages`` bug fixed during Phase 2n review.
+Fixed at the move by routing through ``execute_json_query`` so the
+integer comes back as an actual ``int``. When the response somehow
+isn't an integer the method warns via ``self._logger`` and returns
+0 — still honest, but flags the anomaly for log scraping.
 
 ``OpenProjectClient`` exposes the service via ``self.admin_cleanup``
 and keeps thin delegators for the same method names so existing call
@@ -70,7 +72,13 @@ class OpenProjectAdminCleanupService:
             # the ``isinstance(count, int)`` guard always saw
             # ``False``, masking successful runs as "0 deleted".
             count = self._client.execute_json_query("Project.delete_all")
-            return count if isinstance(count, int) else 0
+            if isinstance(count, int):
+                return count
+            self._logger.warning(
+                "Project.delete_all returned non-int %s; reporting 0 deleted",
+                type(count).__name__,
+            )
+            return 0
         except Exception as e:
             msg = "Failed to delete all projects."
             raise QueryExecutionError(msg) from e
@@ -97,7 +105,13 @@ class OpenProjectAdminCleanupService:
             # ``execute_query`` to ``execute_json_query`` so the count
             # comes back as a real int rather than a console string.
             count = self._client.execute_json_query(script)
-            return count if isinstance(count, int) else 0
+            if isinstance(count, int):
+                return count
+            self._logger.warning(
+                "delete_non_default_issue_types returned non-int %s; reporting 0 deleted",
+                type(count).__name__,
+            )
+            return 0
         except Exception as e:
             msg = "Failed to delete non-default issue types."
             raise QueryExecutionError(msg) from e
@@ -121,7 +135,13 @@ class OpenProjectAdminCleanupService:
 
         try:
             count = self._client.execute_json_query(script)
-            return count if isinstance(count, int) else 0
+            if isinstance(count, int):
+                return count
+            self._logger.warning(
+                "delete_non_default_issue_statuses returned non-int %s; reporting 0 deleted",
+                type(count).__name__,
+            )
+            return 0
         except Exception as e:
             msg = "Failed to delete non-default issue statuses."
             raise QueryExecutionError(msg) from e

--- a/src/clients/openproject_client.py
+++ b/src/clients/openproject_client.py
@@ -311,6 +311,7 @@ class OpenProjectClient:
         # Composed services (Phase 2 of ADR-002 — splitting the god-class along
         # functional seams). Backward-compat: same-named methods on
         # OpenProjectClient delegate to the corresponding service.
+        from src.clients.openproject_admin_cleanup_service import OpenProjectAdminCleanupService
         from src.clients.openproject_associations_service import OpenProjectAssociationsService
         from src.clients.openproject_custom_field_service import OpenProjectCustomFieldService
         from src.clients.openproject_file_transfer_service import OpenProjectFileTransferService
@@ -346,6 +347,7 @@ class OpenProjectClient:
         self.wp_content = OpenProjectWorkPackageContentService(self)
         self.project_attributes = OpenProjectProjectAttributeService(self)
         self.project_setup = OpenProjectProjectSetupService(self)
+        self.admin_cleanup = OpenProjectAdminCleanupService(self)
 
         logger.success(
             "OpenProjectClient initialized for host %s, container %s",
@@ -1868,19 +1870,9 @@ JSON_DATA
     def delete_all_projects(self) -> int:
         """Delete all projects in bulk.
 
-        Returns:
-            Number of deleted projects
-
-        Raises:
-            QueryExecutionError: If bulk deletion fails
-
+        Thin delegator over ``self.admin_cleanup.delete_all_projects``.
         """
-        try:
-            count = self.execute_query("Project.delete_all")
-            return count if isinstance(count, int) else 0
-        except Exception as e:
-            msg = "Failed to delete all projects."
-            raise QueryExecutionError(msg) from e
+        return self.admin_cleanup.delete_all_projects()
 
     def delete_all_custom_fields(self) -> int:
         """Delete all custom fields in bulk.
@@ -1892,50 +1884,16 @@ JSON_DATA
     def delete_non_default_issue_types(self) -> int:
         """Delete non-default issue types (work package types).
 
-        Returns:
-            Number of deleted types
-
-        Raises:
-            QueryExecutionError: If deletion fails
-
+        Thin delegator over ``self.admin_cleanup.delete_non_default_issue_types``.
         """
-        script = """
-        non_default_types = Type.where(is_default: false, is_standard: false)
-        count = non_default_types.count
-        non_default_types.destroy_all
-        count
-        """
-
-        try:
-            count = self.execute_query(script)
-            return count if isinstance(count, int) else 0
-        except Exception as e:
-            msg = "Failed to delete non-default issue types."
-            raise QueryExecutionError(msg) from e
+        return self.admin_cleanup.delete_non_default_issue_types()
 
     def delete_non_default_issue_statuses(self) -> int:
         """Delete non-default issue statuses.
 
-        Returns:
-            Number of deleted statuses
-
-        Raises:
-            QueryExecutionError: If deletion fails
-
+        Thin delegator over ``self.admin_cleanup.delete_non_default_issue_statuses``.
         """
-        script = """
-        non_default_statuses = Status.where(is_default: false)
-        count = non_default_statuses.count
-        non_default_statuses.destroy_all
-        count
-        """
-
-        try:
-            count = self.execute_query(script)
-            return count if isinstance(count, int) else 0
-        except Exception as e:
-            msg = "Failed to delete non-default issue statuses."
-            raise QueryExecutionError(msg) from e
+        return self.admin_cleanup.delete_non_default_issue_statuses()
 
     def get_time_entry_activities(self) -> list[dict[str, Any]]:
         """Get all available time entry activities from OpenProject.


### PR DESCRIPTION
## Summary
- Phase 2v of the [ADR-002](docs/adr/ADR-002-target-architecture.md) god-class decomposition.
- Three destructive admin / cleanup helpers move from `openproject_client.py` into a new `OpenProjectAdminCleanupService` exposed as `self.admin_cleanup`.
- `OpenProjectClient` keeps a thin delegator for each method so existing callers work unchanged.

## Methods moved
- `delete_all_projects` — `Project.delete_all` (no validation, no callbacks).
- `delete_non_default_issue_types` — destroys every `Type` with `is_default: false` AND `is_standard: false` (callbacks fire).
- `delete_non_default_issue_statuses` — destroys every `Status` with `is_default: false` (callbacks fire).

(`delete_all_custom_fields` is already a delegator into `OpenProjectCustomFieldService` from Phase 2a/2b — left unchanged.)

## Bug fix during the move
The pre-extraction implementation routed all three methods through `self.execute_query`, which returns the raw console output as a *string*. The downstream `isinstance(count, int)` guard always saw `False` and the methods silently reported 0 even when `Project.delete_all` etc. succeeded — same shape as the `delete_all_work_packages` bug Gemini caught during Phase 2n review (#125). Switched all three to `execute_json_query` so the integer comes back as an actual `int`.

## Note on authorisation
The Rails-console execution path runs whatever the console session is allowed to run; there is no server-side admin guard inside these helpers. Module docstring documents that the methods are for migration teardown / CI fixture reset, NOT runtime use against a live install.

## Numbers
- `openproject_client.py`: **2,562 → 2,520 LOC** (−42)
- `openproject_admin_cleanup_service.py`: **0 → 127 LOC** (new)
- Cumulative across phases 2a–2v: `openproject_client.py` **7,342 → 2,520 LOC** (−4,822, **−65.7%**)

## Verification
- `pytest tests/unit`: 953 passed
- `mypy src/`: clean (114 files)
- `ruff check` / `ruff format`: clean

## Test plan
- [x] All 6 required CI checks must pass.
- [ ] Copilot review acknowledged & comments resolved before merge.