### PR TITLE
refactor(phase-3c): extract JiraAgileService

### DIFF
--- a/src/clients/jira_agile_service.py
+++ b/src/clients/jira_agile_service.py
@@ -1,0 +1,168 @@
+"""Jira Software (Agile) board and sprint queries.
+
+Phase 3c of ADR-002 continues the jira_client.py decomposition. The
+agile-related methods (board listing, board configuration, board
+sprints) move into a focused service.
+
+The service is exposed on ``JiraClient`` as ``self.agile`` and the
+client keeps thin delegators so existing call sites continue to work
+unchanged. Like ``JiraProjectService`` and ``JiraWorkflowService`` this
+is HTTP-only — calls go through the ``jira`` SDK session — so there is
+no Ruby-script escaping to worry about.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from requests import exceptions
+
+from src.clients.jira_client import (
+    HTTP_BAD_REQUEST_MIN,
+    JiraApiError,
+    JiraConnectionError,
+)
+
+if TYPE_CHECKING:
+    from src.clients.jira_client import JiraClient
+
+
+class JiraAgileService:
+    """Jira Software (Agile) queries for ``JiraClient``."""
+
+    def __init__(self, client: JiraClient) -> None:
+        self._client = client
+        # ``JiraClient`` uses the module-level ``logger`` from
+        # ``src.clients.jira_client`` — pick that up so the service can
+        # log through ``self._logger`` like the OpenProject services do.
+        from src.clients.jira_client import logger
+
+        self._logger = logger
+
+    # ── reads ────────────────────────────────────────────────────────────
+
+    def get_boards(self) -> list[dict[str, Any]]:
+        """Return Jira Software boards (Scrum/Kanban)."""
+        client = self._client
+        if not client.jira:
+            msg = "Jira client is not initialized"
+            raise JiraConnectionError(msg)
+
+        url = f"{client.base_url}/rest/agile/1.0/board"
+        self._logger.info("Fetching Jira boards")
+
+        try:
+            start_at = 0
+            max_results = 50
+            boards: list[dict[str, Any]] = []
+
+            while True:
+                params = {"startAt": start_at, "maxResults": max_results}
+                response = client.jira._session.get(
+                    url,
+                    params=params,
+                )
+                response.raise_for_status()
+                payload = response.json()
+                values = payload.get("values") if isinstance(payload, dict) else None
+                batch = values if isinstance(values, list) else []
+                boards.extend(batch)
+
+                is_last = payload.get("isLast", False) if isinstance(payload, dict) else True
+                if is_last or not batch:
+                    break
+                start_at += max_results
+
+            self._logger.info("Retrieved %s Jira boards", len(boards))
+            return boards
+        except Exception as exc:
+            error_msg = f"Failed to fetch Jira boards: {exc!s}"
+            self._logger.exception(error_msg)
+            raise JiraApiError(error_msg) from exc
+
+    def get_board_configuration(self, board_id: int) -> dict[str, Any]:
+        """Return configuration details for a Jira Software board."""
+        client = self._client
+        if not client.jira:
+            msg = "Jira client is not initialized"
+            raise JiraConnectionError(msg)
+
+        url = f"{client.base_url}/rest/agile/1.0/board/{board_id}/configuration"
+        self._logger.debug("Fetching board configuration for %s", board_id)
+
+        try:
+            response = client.jira._session.get(url)
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict):
+                msg = "Unexpected board configuration payload"
+                raise ValueError(msg)
+            return payload
+        except Exception as exc:
+            error_msg = f"Failed to fetch Jira board configuration ({board_id}): {exc!s}"
+            self._logger.exception(error_msg)
+            raise JiraApiError(error_msg) from exc
+
+    def get_board_sprints(self, board_id: int) -> list[dict[str, Any]]:
+        """Return sprints associated with a Jira Software board."""
+        client = self._client
+        if not client.jira:
+            msg = "Jira client is not initialized"
+            raise JiraConnectionError(msg)
+
+        url = f"{client.base_url}/rest/agile/1.0/board/{board_id}/sprint"
+        self._logger.debug("Fetching sprints for board %s", board_id)
+
+        try:
+            start_at = 0
+            max_results = 50
+            sprints: list[dict[str, Any]] = []
+
+            while True:
+                params = {
+                    "startAt": start_at,
+                    "maxResults": max_results,
+                    "state": "future,active,closed",
+                }
+                try:
+                    response = client.jira._session.get(
+                        url,
+                        params=params,
+                    )
+                    response.raise_for_status()
+                except JiraApiError as exc:
+                    message = str(exc)
+                    if "doesn't support sprints" in message:
+                        self._logger.debug(
+                            "Board %s does not support sprints; skipping sprint extraction",
+                            board_id,
+                        )
+                        return []
+                    raise
+                except exceptions.HTTPError as exc:
+                    status = getattr(exc.response, "status_code", None)
+                    if status == HTTP_BAD_REQUEST_MIN and exc.response is not None:
+                        text = exc.response.text or ""
+                        if "doesn't support sprints" in text:
+                            self._logger.debug(
+                                "Board %s does not support sprints; skipping sprint extraction",
+                                board_id,
+                            )
+                            return []
+                    raise
+                payload = response.json()
+                values = payload.get("values") if isinstance(payload, dict) else None
+                batch = values if isinstance(values, list) else []
+                sprints.extend(batch)
+
+                is_last = payload.get("isLast", False) if isinstance(payload, dict) else True
+                if is_last or not batch:
+                    break
+                start_at += max_results
+
+            self._logger.debug("Board %s has %s sprints", board_id, len(sprints))
+            return sprints
+        except Exception as exc:
+            error_msg = f"Failed to fetch sprints for board {board_id}: {exc!s}"
+            self._logger.exception(error_msg)
+            raise JiraApiError(error_msg) from exc

--- a/src/clients/jira_client.py
+++ b/src/clients/jira_client.py
@@ -238,13 +238,15 @@ class JiraClient:
         self.batch_size = batch_size
         self.parallel_workers = max_workers
 
-        # Service composition (Phase 3a/3b of ADR-002 — see ADR for the
+        # Service composition (Phase 3a/3b/3c of ADR-002 — see ADR for the
         # decomposition plan).
+        from src.clients.jira_agile_service import JiraAgileService
         from src.clients.jira_project_service import JiraProjectService
         from src.clients.jira_workflow_service import JiraWorkflowService
 
         self.projects = JiraProjectService(self)
         self.workflows = JiraWorkflowService(self)
+        self.agile = JiraAgileService(self)
 
         # Connect to Jira
         self._connect()
@@ -1822,127 +1824,16 @@ class JiraClient:
     # ---------------------------------------------------------------------- #
 
     def get_boards(self) -> list[dict[str, Any]]:
-        """Return Jira Software boards (Scrum/Kanban)."""
-        if not self.jira:
-            msg = "Jira client is not initialized"
-            raise JiraConnectionError(msg)
-
-        url = f"{self.base_url}/rest/agile/1.0/board"
-        logger.info("Fetching Jira boards")
-
-        try:
-            start_at = 0
-            max_results = 50
-            boards: list[dict[str, Any]] = []
-
-            while True:
-                params = {"startAt": start_at, "maxResults": max_results}
-                response = self.jira._session.get(
-                    url,
-                    params=params,
-                )
-                response.raise_for_status()
-                payload = response.json()
-                values = payload.get("values") if isinstance(payload, dict) else None
-                batch = values if isinstance(values, list) else []
-                boards.extend(batch)
-
-                is_last = payload.get("isLast", False) if isinstance(payload, dict) else True
-                if is_last or not batch:
-                    break
-                start_at += max_results
-
-            logger.info("Retrieved %s Jira boards", len(boards))
-            return boards
-        except Exception as exc:
-            error_msg = f"Failed to fetch Jira boards: {exc!s}"
-            logger.exception(error_msg)
-            raise JiraApiError(error_msg) from exc
+        """Thin delegator over ``self.agile.get_boards``."""
+        return self.agile.get_boards()
 
     def get_board_configuration(self, board_id: int) -> dict[str, Any]:
-        """Return configuration details for a Jira Software board."""
-        if not self.jira:
-            msg = "Jira client is not initialized"
-            raise JiraConnectionError(msg)
-
-        url = f"{self.base_url}/rest/agile/1.0/board/{board_id}/configuration"
-        logger.debug("Fetching board configuration for %s", board_id)
-
-        try:
-            response = self.jira._session.get(url)
-            response.raise_for_status()
-            payload = response.json()
-            if not isinstance(payload, dict):
-                msg = "Unexpected board configuration payload"
-                raise ValueError(msg)
-            return payload
-        except Exception as exc:
-            error_msg = f"Failed to fetch Jira board configuration ({board_id}): {exc!s}"
-            logger.exception(error_msg)
-            raise JiraApiError(error_msg) from exc
+        """Thin delegator over ``self.agile.get_board_configuration``."""
+        return self.agile.get_board_configuration(board_id)
 
     def get_board_sprints(self, board_id: int) -> list[dict[str, Any]]:
-        """Return sprints associated with a Jira Software board."""
-        if not self.jira:
-            msg = "Jira client is not initialized"
-            raise JiraConnectionError(msg)
-
-        url = f"{self.base_url}/rest/agile/1.0/board/{board_id}/sprint"
-        logger.debug("Fetching sprints for board %s", board_id)
-
-        try:
-            start_at = 0
-            max_results = 50
-            sprints: list[dict[str, Any]] = []
-
-            while True:
-                params = {
-                    "startAt": start_at,
-                    "maxResults": max_results,
-                    "state": "future,active,closed",
-                }
-                try:
-                    response = self.jira._session.get(
-                        url,
-                        params=params,
-                    )
-                    response.raise_for_status()
-                except JiraApiError as exc:
-                    message = str(exc)
-                    if "doesn't support sprints" in message:
-                        logger.debug(
-                            "Board %s does not support sprints; skipping sprint extraction",
-                            board_id,
-                        )
-                        return []
-                    raise
-                except exceptions.HTTPError as exc:
-                    status = getattr(exc.response, "status_code", None)
-                    if status == HTTP_BAD_REQUEST_MIN and exc.response is not None:
-                        text = exc.response.text or ""
-                        if "doesn't support sprints" in text:
-                            logger.debug(
-                                "Board %s does not support sprints; skipping sprint extraction",
-                                board_id,
-                            )
-                            return []
-                    raise
-                payload = response.json()
-                values = payload.get("values") if isinstance(payload, dict) else None
-                batch = values if isinstance(values, list) else []
-                sprints.extend(batch)
-
-                is_last = payload.get("isLast", False) if isinstance(payload, dict) else True
-                if is_last or not batch:
-                    break
-                start_at += max_results
-
-            logger.debug("Board %s has %s sprints", board_id, len(sprints))
-            return sprints
-        except Exception as exc:
-            error_msg = f"Failed to fetch sprints for board {board_id}: {exc!s}"
-            logger.exception(error_msg)
-            raise JiraApiError(error_msg) from exc
+        """Thin delegator over ``self.agile.get_board_sprints``."""
+        return self.agile.get_board_sprints(board_id)
 
     # ---------------------------------------------------------------------- #
     # Reporting helpers (filters & dashboards)                               #


### PR DESCRIPTION
## Summary
- Phase 3c of the [ADR-002](docs/adr/ADR-002-target-architecture.md) god-class decomposition. Third slice of the `jira_client.py` decomposition.
- Three Jira Agile (boards + sprints) methods move from `jira_client.py` into a new `JiraAgileService` exposed as `self.agile`.
- Done by a sub-agent in worktree isolation (with verification completed in the main session — see commit message).

## Methods moved
- `get_boards` — paginated GET via `client.jira._session`.
- `get_board_configuration`
- `get_board_sprints` — paginated GET.

## Numbers
- `jira_client.py`: **2,467 → 2,358 LOC** (−109)
- `jira_agile_service.py`: **0 → 168 LOC** (new)
- Cumulative across phases 3a–3c: `jira_client.py` **2,852 → 2,358 LOC** (−494, −17.3%)

## Verification
- `pytest tests/unit`: 953 passed
- `mypy src/`: clean (120 files)
- `ruff check` / `ruff format`: clean

## Test plan
- [x] All 6 required CI checks must pass.
- [ ] Copilot review acknowledged & comments resolved before merge.