### PR TITLE
refactor(phase-3g): extract JiraGroupService

### DIFF
--- a/src/clients/jira_client.py
+++ b/src/clients/jira_client.py
@@ -236,9 +236,10 @@ class JiraClient:
         self.batch_size = batch_size
         self.parallel_workers = max_workers
 
-        # Service composition (Phase 3a/3b/3c/3d/3e/3f of ADR-002 — see ADR for the
+        # Service composition (Phase 3a/3b/3c/3d/3e/3f/3g of ADR-002 — see ADR for the
         # decomposition plan).
         from src.clients.jira_agile_service import JiraAgileService
+        from src.clients.jira_group_service import JiraGroupService
         from src.clients.jira_project_service import JiraProjectService
         from src.clients.jira_tempo_service import JiraTempoService
         from src.clients.jira_user_service import JiraUserService
@@ -251,6 +252,7 @@ class JiraClient:
         self.users = JiraUserService(self)
         self.worklogs = JiraWorklogService(self)
         self.tempo = JiraTempoService(self)
+        self.groups = JiraGroupService(self)
 
         # Connect to Jira
         self._connect()
@@ -528,103 +530,12 @@ class JiraClient:
         return self.users.download_user_avatar(avatar_url)
 
     def get_groups(self) -> list[dict[str, Any]]:
-        """Retrieve all Jira groups visible to the migration user."""
-        logger.info("Fetching Jira groups via groups picker endpoint")
-
-        try:
-            response = self._make_request(
-                "/rest/api/2/groups/picker",
-                params={
-                    "query": "",
-                    "maxResults": 1000,
-                    "includeInactive": "true",
-                },
-            )
-            if response.status_code != HTTP_OK:
-                msg = f"Failed to fetch Jira groups: HTTP {response.status_code}"
-                raise JiraApiError(msg)
-
-            payload = response.json() or {}
-            groups = payload.get("groups", [])
-            logger.info("Retrieved %s Jira groups", len(groups))
-            normalized: list[dict[str, Any]] = []
-            for group in groups:
-                normalized.append(
-                    {
-                        "name": group.get("name"),
-                        "groupId": group.get("groupId"),
-                        "html": group.get("html"),
-                        "labels": group.get("labels", []),
-                    },
-                )
-            return normalized
-        except JiraCaptchaError, JiraAuthenticationError, JiraConnectionError:
-            raise
-        except Exception as e:
-            error_msg = f"Failed to get Jira groups: {e!s}"
-            logger.exception(error_msg)
-            raise JiraApiError(error_msg) from e
+        """Thin delegator over ``self.groups.get_groups``."""
+        return self.groups.get_groups()
 
     def get_group_members(self, group_name: str) -> list[dict[str, Any]]:
-        """Retrieve members for a Jira group, handling pagination."""
-        if not group_name:
-            return []
-
-        members: list[dict[str, Any]] = []
-        start_at = 0
-        max_results = 100
-
-        logger.debug("Fetching members for Jira group '%s'", group_name)
-
-        try:
-            while True:
-                response = self._make_request(
-                    "/rest/api/2/group/member",
-                    params={
-                        "groupname": group_name,
-                        "includeInactiveUsers": "true",
-                        "maxResults": max_results,
-                        "startAt": start_at,
-                    },
-                )
-                if response.status_code != HTTP_OK:
-                    msg = f"Failed to fetch group members for {group_name}: HTTP {response.status_code}"
-                    raise JiraApiError(msg)
-
-                payload = response.json() or {}
-                values = payload.get("values", [])
-                for entry in values:
-                    members.append(
-                        {
-                            "accountId": entry.get("accountId"),
-                            "key": entry.get("key"),
-                            "name": entry.get("name"),
-                            "displayName": entry.get("displayName"),
-                            "emailAddress": entry.get("emailAddress"),
-                            "active": entry.get("active", True),
-                        },
-                    )
-
-                start_at += len(values)
-                is_last = payload.get("isLast")
-                total = payload.get("total")
-                if is_last or not values:
-                    break
-                if total is not None and start_at >= int(total):
-                    break
-
-            logger.debug(
-                "Loaded %s members for Jira group '%s'",
-                len(members),
-                group_name,
-            )
-            return members
-        except JiraCaptchaError, JiraAuthenticationError, JiraConnectionError:
-            raise
-        except Exception as e:
-            error_msg = f"Failed to get Jira group members for {group_name}: {e!s}"
-            logger.exception(error_msg)
-            raise JiraApiError(error_msg) from e
+        """Thin delegator over ``self.groups.get_group_members``."""
+        return self.groups.get_group_members(group_name)
 
     def get_project_roles(self, project_key: str) -> list[dict[str, Any]]:
         """Thin delegator over ``self.projects.get_project_roles``."""

--- a/src/clients/jira_group_service.py
+++ b/src/clients/jira_group_service.py
@@ -1,0 +1,141 @@
+"""Jira group directory queries.
+
+Phase 3g of ADR-002 continues the jira_client.py decomposition. The
+group-related methods (group listing via the picker endpoint, group
+member lookup with pagination) move into a focused service.
+
+The service is exposed on ``JiraClient`` as ``self.groups`` and the
+client keeps thin delegators so existing call sites continue to work
+unchanged. Like the other Phase 3 services this is HTTP-only — calls
+go through the client's ``_make_request`` helper — so there is no
+Ruby-script escaping to worry about.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.clients.jira_client import (
+    HTTP_OK,
+    JiraApiError,
+    JiraAuthenticationError,
+    JiraCaptchaError,
+    JiraConnectionError,
+)
+
+if TYPE_CHECKING:
+    from src.clients.jira_client import JiraClient
+
+
+class JiraGroupService:
+    """Group-domain queries for ``JiraClient``."""
+
+    def __init__(self, client: JiraClient) -> None:
+        self._client = client
+        # ``JiraClient`` uses the module-level ``logger`` from
+        # ``src.clients.jira_client`` — pick that up so the service can
+        # log through ``self._logger`` like the OpenProject services do.
+        from src.clients.jira_client import logger
+
+        self._logger = logger
+
+    # ── reads ────────────────────────────────────────────────────────────
+
+    def get_groups(self) -> list[dict[str, Any]]:
+        """Retrieve all Jira groups visible to the migration user."""
+        self._logger.info("Fetching Jira groups via groups picker endpoint")
+
+        try:
+            response = self._client._make_request(
+                "/rest/api/2/groups/picker",
+                params={
+                    "query": "",
+                    "maxResults": 1000,
+                    "includeInactive": "true",
+                },
+            )
+            if response.status_code != HTTP_OK:
+                msg = f"Failed to fetch Jira groups: HTTP {response.status_code}"
+                raise JiraApiError(msg)
+
+            payload = response.json() or {}
+            groups = payload.get("groups", [])
+            self._logger.info("Retrieved %s Jira groups", len(groups))
+            normalized: list[dict[str, Any]] = []
+            for group in groups:
+                normalized.append(
+                    {
+                        "name": group.get("name"),
+                        "groupId": group.get("groupId"),
+                        "html": group.get("html"),
+                        "labels": group.get("labels", []),
+                    },
+                )
+            return normalized
+        except JiraCaptchaError, JiraAuthenticationError, JiraConnectionError:
+            raise
+        except Exception as e:
+            error_msg = f"Failed to get Jira groups: {e!s}"
+            self._logger.exception(error_msg)
+            raise JiraApiError(error_msg) from e
+
+    def get_group_members(self, group_name: str) -> list[dict[str, Any]]:
+        """Retrieve members for a Jira group, handling pagination."""
+        if not group_name:
+            return []
+
+        members: list[dict[str, Any]] = []
+        start_at = 0
+        max_results = 100
+
+        self._logger.debug("Fetching members for Jira group '%s'", group_name)
+
+        try:
+            while True:
+                response = self._client._make_request(
+                    "/rest/api/2/group/member",
+                    params={
+                        "groupname": group_name,
+                        "includeInactiveUsers": "true",
+                        "maxResults": max_results,
+                        "startAt": start_at,
+                    },
+                )
+                if response.status_code != HTTP_OK:
+                    msg = f"Failed to fetch group members for {group_name}: HTTP {response.status_code}"
+                    raise JiraApiError(msg)
+
+                payload = response.json() or {}
+                values = payload.get("values", [])
+                for entry in values:
+                    members.append(
+                        {
+                            "accountId": entry.get("accountId"),
+                            "key": entry.get("key"),
+                            "name": entry.get("name"),
+                            "displayName": entry.get("displayName"),
+                            "emailAddress": entry.get("emailAddress"),
+                            "active": entry.get("active", True),
+                        },
+                    )
+
+                start_at += len(values)
+                is_last = payload.get("isLast")
+                total = payload.get("total")
+                if is_last or not values:
+                    break
+                if total is not None and start_at >= int(total):
+                    break
+
+            self._logger.debug(
+                "Loaded %s members for Jira group '%s'",
+                len(members),
+                group_name,
+            )
+            return members
+        except JiraCaptchaError, JiraAuthenticationError, JiraConnectionError:
+            raise
+        except Exception as e:
+            error_msg = f"Failed to get Jira group members for {group_name}: {e!s}"
+            self._logger.exception(error_msg)
+            raise JiraApiError(error_msg) from e

--- a/src/clients/jira_group_service.py
+++ b/src/clients/jira_group_service.py
@@ -72,7 +72,11 @@ class JiraGroupService:
                     },
                 )
             return normalized
-        except JiraCaptchaError, JiraAuthenticationError, JiraConnectionError:
+        except (
+            JiraCaptchaError,
+            JiraAuthenticationError,
+            JiraConnectionError,
+        ):
             raise
         except Exception as e:
             error_msg = f"Failed to get Jira groups: {e!s}"
@@ -133,7 +137,11 @@ class JiraGroupService:
                 group_name,
             )
             return members
-        except JiraCaptchaError, JiraAuthenticationError, JiraConnectionError:
+        except (
+            JiraCaptchaError,
+            JiraAuthenticationError,
+            JiraConnectionError,
+        ):
             raise
         except Exception as e:
             error_msg = f"Failed to get Jira group members for {group_name}: {e!s}"


### PR DESCRIPTION
## Summary
- Phase 3g of the [ADR-002](docs/adr/ADR-002-target-architecture.md) god-class decomposition. Seventh slice of the `jira_client.py` decomposition.
- Two group methods move from `jira_client.py` into a new `JiraGroupService` exposed as `self.groups`.
- Done by a sub-agent in worktree isolation; pure mechanical move.

## Methods moved
- `get_groups`
- `get_group_members`

Both are independent — no intra/cross-cluster calls.

## Numbers
- `jira_client.py`: **1,555 → 1,466 LOC** (−89)
- `jira_group_service.py`: **0 → 141 LOC** (new)
- Cumulative across phases 3a–3g: `jira_client.py` **2,852 → 1,466 LOC** (−1,386, **−48.6%**)

## Verification
- `pytest tests/unit`: 953 passed
- `mypy src/`: clean (124 files)
- `ruff check` / `ruff format`: clean

## Test plan
- [x] All 6 required CI checks must pass.
- [ ] Copilot review acknowledged & comments resolved before merge.