### PR TITLE
refactor(phase-3a): introduce Pydantic v2 domain models + branded IDs

### DIFF
--- a/src/domain/__init__.py
+++ b/src/domain/__init__.py
@@ -1,0 +1,37 @@
+"""Domain layer for j2o (ADR-002 phase 3a).
+
+This package will host the framework-agnostic core of the migration tool —
+branded identifier types today; richer value objects and domain services in
+subsequent phases. Adoption is intentionally gradual: nothing here changes
+runtime behaviour until call sites are updated.
+"""
+
+from __future__ import annotations
+
+from src.domain.ids import (
+    JiraAccountId,
+    JiraIssueKey,
+    JiraProjectKey,
+    JiraUserKey,
+    OpCustomFieldId,
+    OpPriorityId,
+    OpProjectId,
+    OpStatusId,
+    OpTypeId,
+    OpUserId,
+    OpWorkPackageId,
+)
+
+__all__ = [
+    "JiraAccountId",
+    "JiraIssueKey",
+    "JiraProjectKey",
+    "JiraUserKey",
+    "OpCustomFieldId",
+    "OpPriorityId",
+    "OpProjectId",
+    "OpStatusId",
+    "OpTypeId",
+    "OpUserId",
+    "OpWorkPackageId",
+]

--- a/src/domain/ids.py
+++ b/src/domain/ids.py
@@ -1,0 +1,86 @@
+"""Branded identifier types for the j2o domain layer.
+
+Phase 3a of ADR-002 introduces a thin nominal type layer over the primitive
+``str`` and ``int`` ids that flow between the Jira and OpenProject sides of
+the migration. The goal is *zero runtime cost* combined with *type-checker
+enforcement* — mypy will refuse to assign an ``OpProjectId`` where an
+``OpUserId`` is expected, even though both are ``int`` at runtime.
+
+All branded ids in this module are declared with :func:`typing.NewType`,
+which gives us:
+
+* No runtime overhead — ``OpUserId(42)`` is literally ``42`` after the
+  call returns; the wrapper exists only for the type checker.
+* Distinct types — mypy treats ``OpUserId`` and ``OpProjectId`` as
+  different types even though they share the same underlying ``int``.
+* Implicit upcast — a ``NewType`` value is still accepted everywhere
+  the base type is accepted, so existing call sites that take ``int``
+  continue to work without any changes.
+
+Adoption is intentionally gradual: phase 3a only *introduces* these
+aliases. Subsequent phases (3-gamma and beyond) will tighten signatures
+one module at a time so reviewers can land each change in isolation.
+"""
+
+from __future__ import annotations
+
+from typing import NewType
+
+# ── Jira identifiers ─────────────────────────────────────────────────────
+# Jira identifiers are strings. ``JiraIssueKey`` is the human-readable
+# ``ABC-123`` form; ``JiraProjectKey`` is the project slug (``ABC``);
+# ``JiraUserKey`` is the legacy username/key field; ``JiraAccountId`` is
+# the cloud-only opaque GDPR-compatible id.
+
+JiraIssueKey = NewType("JiraIssueKey", str)
+"""Human-readable issue key, e.g. ``"ABC-123"``."""
+
+JiraProjectKey = NewType("JiraProjectKey", str)
+"""Project key (the prefix in an issue key), e.g. ``"ABC"``."""
+
+JiraUserKey = NewType("JiraUserKey", str)
+"""Server/Data-Center user ``key`` field (legacy username-based)."""
+
+JiraAccountId = NewType("JiraAccountId", str)
+"""Cloud ``accountId`` — opaque, GDPR-stable user identifier."""
+
+
+# ── OpenProject identifiers ──────────────────────────────────────────────
+# OpenProject ids are integers. We brand the most common ones so that the
+# Jira→OP mapping layer cannot silently swap them at the call site.
+
+OpUserId = NewType("OpUserId", int)
+"""OpenProject ``users.id`` primary key."""
+
+OpProjectId = NewType("OpProjectId", int)
+"""OpenProject ``projects.id`` primary key."""
+
+OpWorkPackageId = NewType("OpWorkPackageId", int)
+"""OpenProject ``work_packages.id`` primary key."""
+
+OpCustomFieldId = NewType("OpCustomFieldId", int)
+"""OpenProject ``custom_fields.id`` primary key."""
+
+OpStatusId = NewType("OpStatusId", int)
+"""OpenProject ``statuses.id`` primary key (work-package status)."""
+
+OpPriorityId = NewType("OpPriorityId", int)
+"""OpenProject ``enumerations.id`` primary key for priorities."""
+
+OpTypeId = NewType("OpTypeId", int)
+"""OpenProject ``types.id`` primary key (work-package type)."""
+
+
+__all__ = [
+    "JiraAccountId",
+    "JiraIssueKey",
+    "JiraProjectKey",
+    "JiraUserKey",
+    "OpCustomFieldId",
+    "OpPriorityId",
+    "OpProjectId",
+    "OpStatusId",
+    "OpTypeId",
+    "OpUserId",
+    "OpWorkPackageId",
+]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,7 +1,47 @@
 """Models package for data structures used in the application."""
 
 from src.models.component_results import ComponentResult
+from src.models.jira import (
+    JiraAttachment,
+    JiraComment,
+    JiraComponentRef,
+    JiraIssue,
+    JiraIssueFields,
+    JiraIssueTypeRef,
+    JiraPriorityRef,
+    JiraProject,
+    JiraProjectCategoryRef,
+    JiraStatusRef,
+    JiraUser,
+    JiraVersionRef,
+)
 from src.models.migration_error import MigrationError
 from src.models.migration_results import MigrationResult
+from src.models.openproject import (
+    OpCustomField,
+    OpProject,
+    OpUser,
+    OpWorkPackage,
+)
 
-__all__ = ["ComponentResult", "MigrationError", "MigrationResult"]
+__all__ = [
+    "ComponentResult",
+    "JiraAttachment",
+    "JiraComment",
+    "JiraComponentRef",
+    "JiraIssue",
+    "JiraIssueFields",
+    "JiraIssueTypeRef",
+    "JiraPriorityRef",
+    "JiraProject",
+    "JiraProjectCategoryRef",
+    "JiraStatusRef",
+    "JiraUser",
+    "JiraVersionRef",
+    "MigrationError",
+    "MigrationResult",
+    "OpCustomField",
+    "OpProject",
+    "OpUser",
+    "OpWorkPackage",
+]

--- a/src/models/jira/__init__.py
+++ b/src/models/jira/__init__.py
@@ -1,0 +1,32 @@
+"""Jira-side Pydantic models (ADR-002 phase 3a)."""
+
+from __future__ import annotations
+
+from src.models.jira.issue import (
+    JiraAttachment,
+    JiraComment,
+    JiraComponentRef,
+    JiraIssue,
+    JiraIssueFields,
+    JiraIssueTypeRef,
+    JiraPriorityRef,
+    JiraStatusRef,
+    JiraVersionRef,
+)
+from src.models.jira.project import JiraProject, JiraProjectCategoryRef
+from src.models.jira.user import JiraUser
+
+__all__ = [
+    "JiraAttachment",
+    "JiraComment",
+    "JiraComponentRef",
+    "JiraIssue",
+    "JiraIssueFields",
+    "JiraIssueTypeRef",
+    "JiraPriorityRef",
+    "JiraProject",
+    "JiraProjectCategoryRef",
+    "JiraStatusRef",
+    "JiraUser",
+    "JiraVersionRef",
+]

--- a/src/models/jira/issue.py
+++ b/src/models/jira/issue.py
@@ -1,0 +1,277 @@
+"""Pydantic v2 models for Jira issue payloads.
+
+The migration code consumes Jira issues from two boundaries:
+
+* The Jira REST/SDK pipeline — :class:`jira.Issue` instances with nested
+  ``fields`` exposing ``status``, ``priority``, ``issuetype`` etc.
+* The cached JSON dict shape produced by
+  :mod:`src.clients.jira_issue_service` (``get_issue_details`` and the
+  batch fetchers).
+
+We model the structural minimum the migration actually relies on. Nested
+references (status, priority, issue type, components, fix versions,
+comments, attachments) get their own small Pydantic models rather than
+being inlined as ``dict[str, Any]`` — this keeps the boundary checked
+without exploding into a full Jira schema.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.domain.ids import JiraIssueKey
+from src.models.jira.user import JiraUser
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Coerce a value to ``str`` while preserving ``None``."""
+    return None if value is None else str(value)
+
+
+class JiraStatusRef(BaseModel):
+    """Reference to a Jira status (``id`` + ``name``)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    id: str | None = None
+    name: str | None = None
+
+
+class JiraPriorityRef(BaseModel):
+    """Reference to a Jira priority (``id`` + ``name``)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    id: str | None = None
+    name: str | None = None
+
+
+class JiraIssueTypeRef(BaseModel):
+    """Reference to a Jira issue type (``id`` + ``name``)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    id: str | None = None
+    name: str | None = None
+
+
+class JiraVersionRef(BaseModel):
+    """Reference to a Jira version (``fixVersions`` entries)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    id: str | None = None
+    name: str | None = None
+
+
+class JiraComponentRef(BaseModel):
+    """Reference to a Jira component."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    id: str | None = None
+    name: str | None = None
+
+
+class JiraComment(BaseModel):
+    """A Jira issue comment."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    id: str | None = None
+    body: str | None = None
+    author: str | None = None
+    """Author display name (the cache flattens the SDK's nested author)."""
+    created: str | None = None
+
+
+class JiraAttachment(BaseModel):
+    """A Jira issue attachment reference."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    id: str | None = None
+    filename: str | None = None
+    size: int | None = None
+    content: str | None = None
+    """Download URL — the SDK calls this attribute ``url``."""
+
+
+class JiraIssueFields(BaseModel):
+    """Inner ``fields`` block of a Jira issue."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    summary: str | None = None
+    description: str | None = None
+
+    status: JiraStatusRef | None = None
+    priority: JiraPriorityRef | None = None
+    issue_type: JiraIssueTypeRef | None = Field(default=None, alias="issuetype")
+
+    assignee: JiraUser | None = None
+    reporter: JiraUser | None = None
+
+    created: str | None = None
+    updated: str | None = None
+
+    labels: list[str] = Field(default_factory=list)
+    fix_versions: list[JiraVersionRef] = Field(default_factory=list, alias="fixVersions")
+    components: list[JiraComponentRef] = Field(default_factory=list)
+
+    comments: list[JiraComment] = Field(default_factory=list)
+    attachments: list[JiraAttachment] = Field(default_factory=list)
+
+
+class JiraIssue(BaseModel):
+    """Canonical representation of a Jira issue."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    key: JiraIssueKey
+    id: str
+    fields: JiraIssueFields = Field(default_factory=JiraIssueFields)
+
+    # ── classmethod constructors ─────────────────────────────────────────
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> JiraIssue:
+        """Build a :class:`JiraIssue` from a cache/REST dict shape.
+
+        Two dict layouts are supported:
+
+        * The "REST-shaped" dict, where nested fields live under
+          ``raw["fields"]`` (this matches ``issue.raw``).
+        * The "flattened" dict produced by ``get_issue_details``, which
+          hoists ``summary``, ``description``, ``status``, ``issue_type``
+          (note: snake_case alias for ``issuetype``), ``created``,
+          ``updated``, ``assignee``, ``reporter``, ``comments`` and
+          ``attachments`` to the top level.
+
+        We detect the flattened shape by the absence of a ``fields``
+        member and assemble a synthetic ``fields`` block from the
+        top-level keys.
+        """
+        if "fields" in raw and isinstance(raw["fields"], dict):
+            return cls.model_validate(raw)
+
+        # Flattened shape — re-pack into a nested ``fields`` block.
+        fields_payload: dict[str, Any] = {}
+        for key in (
+            "summary",
+            "description",
+            "status",
+            "priority",
+            "created",
+            "updated",
+            "assignee",
+            "reporter",
+            "labels",
+            "fixVersions",
+            "fix_versions",
+            "components",
+            "comments",
+            "attachments",
+        ):
+            if key in raw:
+                fields_payload[key] = raw[key]
+        # ``issue_type`` (snake) and ``issuetype`` (camel) are both seen.
+        if "issuetype" in raw:
+            fields_payload["issuetype"] = raw["issuetype"]
+        elif "issue_type" in raw:
+            fields_payload["issuetype"] = raw["issue_type"]
+
+        return cls.model_validate(
+            {
+                "key": raw.get("key"),
+                "id": raw.get("id"),
+                "fields": fields_payload,
+            },
+        )
+
+    @classmethod
+    def from_jira_obj(cls, obj: Any) -> JiraIssue:
+        """Build a :class:`JiraIssue` from a ``jira.Issue`` SDK instance."""
+        sdk_fields = getattr(obj, "fields", None)
+
+        def _ref(value: Any) -> dict[str, Any] | None:
+            if value is None:
+                return None
+            return {
+                "id": _str_or_none(getattr(value, "id", None)),
+                "name": _str_or_none(getattr(value, "name", None)),
+            }
+
+        assignee_obj = getattr(sdk_fields, "assignee", None) if sdk_fields else None
+        reporter_obj = getattr(sdk_fields, "reporter", None) if sdk_fields else None
+
+        comment_block = getattr(sdk_fields, "comment", None) if sdk_fields else None
+        comments_iter = getattr(comment_block, "comments", None) if comment_block else None
+        comments_payload: list[dict[str, Any]] = []
+        if comments_iter:
+            for c in comments_iter:
+                author_obj = getattr(c, "author", None)
+                comments_payload.append(
+                    {
+                        "id": _str_or_none(getattr(c, "id", None)),
+                        "body": getattr(c, "body", None),
+                        "author": getattr(author_obj, "displayName", None) if author_obj else None,
+                        "created": getattr(c, "created", None),
+                    },
+                )
+
+        attachments_iter = getattr(sdk_fields, "attachment", None) if sdk_fields else None
+        attachments_payload: list[dict[str, Any]] = []
+        if attachments_iter:
+            for att in attachments_iter:
+                attachments_payload.append(
+                    {
+                        "id": _str_or_none(getattr(att, "id", None)),
+                        "filename": getattr(att, "filename", None),
+                        "size": getattr(att, "size", None),
+                        "content": getattr(att, "url", None),
+                    },
+                )
+
+        labels = list(getattr(sdk_fields, "labels", []) or []) if sdk_fields else []
+
+        fix_versions_iter = getattr(sdk_fields, "fixVersions", None) if sdk_fields else None
+        fix_versions_payload = [_ref(v) for v in (fix_versions_iter or []) if v is not None]
+
+        components_iter = getattr(sdk_fields, "components", None) if sdk_fields else None
+        components_payload = [_ref(c) for c in (components_iter or []) if c is not None]
+
+        fields_payload: dict[str, Any] = {
+            "summary": getattr(sdk_fields, "summary", None) if sdk_fields else None,
+            "description": getattr(sdk_fields, "description", None) if sdk_fields else None,
+            "status": _ref(getattr(sdk_fields, "status", None)) if sdk_fields else None,
+            "priority": _ref(getattr(sdk_fields, "priority", None)) if sdk_fields else None,
+            "issuetype": _ref(getattr(sdk_fields, "issuetype", None)) if sdk_fields else None,
+            "assignee": (JiraUser.from_jira_obj(assignee_obj) if assignee_obj else None),
+            "reporter": (JiraUser.from_jira_obj(reporter_obj) if reporter_obj else None),
+            "created": getattr(sdk_fields, "created", None) if sdk_fields else None,
+            "updated": getattr(sdk_fields, "updated", None) if sdk_fields else None,
+            "labels": [str(label) for label in labels],
+            "fixVersions": fix_versions_payload,
+            "components": components_payload,
+            "comments": comments_payload,
+            "attachments": attachments_payload,
+        }
+
+        return cls.model_validate(
+            {
+                "key": getattr(obj, "key", None),
+                "id": _str_or_none(getattr(obj, "id", None)),
+                "fields": fields_payload,
+            },
+        )
+
+
+__all__ = [
+    "JiraAttachment",
+    "JiraComment",
+    "JiraComponentRef",
+    "JiraIssue",
+    "JiraIssueFields",
+    "JiraIssueTypeRef",
+    "JiraPriorityRef",
+    "JiraStatusRef",
+    "JiraVersionRef",
+]

--- a/src/models/jira/project.py
+++ b/src/models/jira/project.py
@@ -1,0 +1,141 @@
+"""Pydantic v2 model for Jira project payloads.
+
+The shape modelled here matches the dict produced by
+``JiraProjectService.get_projects`` (see :mod:`src.clients.jira_project_service`).
+That dict is the one persisted to the JSON cache *and* the one consumed by
+the migration layer, so it is the right boundary for our Pydantic model.
+
+For SDK ingestion (a ``jira.Project`` instance) the relevant attributes
+mirror the dict keys, with the addition that ``project.raw`` exposes the
+underlying REST payload from which we can read ``projectCategory``,
+``lead`` and ``avatarUrls`` directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from src.domain.ids import JiraProjectKey
+
+
+class JiraProjectCategoryRef(BaseModel):
+    """Lightweight reference for a project category (id + name)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    id: str | None = None
+    name: str | None = None
+
+
+class JiraProject(BaseModel):
+    """Canonical representation of a Jira project."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    key: JiraProjectKey
+    """Project key (the prefix in an issue key)."""
+
+    name: str
+    """Display name of the project."""
+
+    id: str
+    """Numeric project id (returned by Jira as a string)."""
+
+    description: str = ""
+    """Project description. Empty string when absent (matches the cache shape)."""
+
+    lead: str | None = None
+    """Lead user *login* (Server/DC ``name``/``key``). ``None`` if not set."""
+
+    lead_display: str | None = None
+    """Lead user display name. ``None`` if not set."""
+
+    browse_url: str | None = None
+    """``{base_url}/browse/{key}`` URL — convenient for issue links."""
+
+    archived: bool = False
+    """``True`` if the project has been archived in Jira."""
+
+    project_type_key: str | None = None
+    """Jira project type, e.g. ``"software"``, ``"business"``."""
+
+    project_category: JiraProjectCategoryRef | None = None
+    """Project category reference, if the project belongs to one."""
+
+    avatar_url: str | None = None
+    """Preferred avatar URL (largest available size)."""
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> JiraProject:
+        """Build a :class:`JiraProject` from the cached JSON dict shape."""
+        # The cache stores ``project_category`` as either a dict ``{"id":..,
+        # "name":..}`` or an empty mapping. Normalise to ``None`` when empty
+        # so consumers don't have to test both ``is None`` and ``== {}``.
+        normalised = dict(raw)
+        category = normalised.get("project_category")
+        if isinstance(category, dict) and not category.get("id") and not category.get("name"):
+            normalised["project_category"] = None
+        return cls.model_validate(normalised)
+
+    @classmethod
+    def from_jira_obj(cls, obj: Any, *, browse_url: str | None = None) -> JiraProject:
+        """Build a :class:`JiraProject` from a ``jira.Project`` SDK instance.
+
+        ``browse_url`` is supplied by the caller because the SDK does not
+        carry the base URL on the project object — that lives on the
+        client. Pass ``None`` when the URL is not needed.
+        """
+        raw_detail: dict[str, Any] = getattr(obj, "raw", {}) or {}
+
+        category_raw = raw_detail.get("projectCategory") or {}
+        if not isinstance(category_raw, dict):
+            category_raw = {}
+        category: JiraProjectCategoryRef | None
+        if category_raw.get("id") or category_raw.get("name"):
+            category = JiraProjectCategoryRef.model_validate(
+                {
+                    "id": str(category_raw.get("id")) if category_raw.get("id") else None,
+                    "name": str(category_raw.get("name")) if category_raw.get("name") else None,
+                },
+            )
+        else:
+            category = None
+
+        lead_info = raw_detail.get("lead") or {}
+        if not isinstance(lead_info, dict):
+            lead_info = {}
+        lead_login = lead_info.get("name") or lead_info.get("key")
+        lead_display = lead_info.get("displayName")
+
+        avatar_urls = raw_detail.get("avatarUrls") or {}
+        if not isinstance(avatar_urls, dict):
+            avatar_urls = {}
+        preferred_avatar_url: str | None = None
+        for size_key in ("128x128", "64x64", "48x48", "32x32", "24x24", "16x16"):
+            candidate = avatar_urls.get(size_key)
+            if candidate:
+                preferred_avatar_url = str(candidate)
+                break
+
+        description = raw_detail.get("description") or ""
+
+        return cls.model_validate(
+            {
+                "key": getattr(obj, "key", None),
+                "name": getattr(obj, "name", None),
+                "id": getattr(obj, "id", None),
+                "description": description,
+                "lead": lead_login,
+                "lead_display": lead_display,
+                "browse_url": browse_url,
+                "archived": bool(raw_detail.get("archived", False)),
+                "project_type_key": (raw_detail.get("projectTypeKey") or getattr(obj, "projectTypeKey", None)),
+                "project_category": category,
+                "avatar_url": preferred_avatar_url,
+            },
+        )
+
+
+__all__ = ["JiraProject", "JiraProjectCategoryRef"]

--- a/src/models/jira/user.py
+++ b/src/models/jira/user.py
@@ -1,0 +1,103 @@
+"""Pydantic v2 model for Jira user payloads.
+
+The migration receives Jira users in two shapes:
+
+1. As a plain ``dict`` loaded from a cached JSON file or a REST response —
+   the canonical Jira REST shape with camelCase keys (``accountId``,
+   ``displayName``, ``timeZone``, …).
+2. As a ``jira.User`` SDK object exposed via attribute access. The SDK is
+   inconsistent about a few fields (notably ``timeZone`` vs ``timezone``,
+   and ``avatarUrls`` may be a custom dict-like object).
+
+:meth:`JiraUser.from_dict` and :meth:`JiraUser.from_jira_obj` normalise
+both inputs into the same Pydantic instance. Field aliases let callers
+construct instances using either snake_case (``account_id=…``) or the
+original Jira camelCase (``accountId=…``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.domain.ids import JiraAccountId, JiraUserKey
+
+
+class JiraUser(BaseModel):
+    """Canonical representation of a Jira user account."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    key: JiraUserKey | None = None
+    """Server/DC ``key`` field (legacy username-based identifier)."""
+
+    account_id: JiraAccountId | None = Field(default=None, alias="accountId")
+    """Cloud ``accountId`` — opaque, GDPR-stable user identifier."""
+
+    name: str | None = None
+    """Login/username (Server/DC). May be absent on Cloud instances."""
+
+    display_name: str | None = Field(default=None, alias="displayName")
+    """Human-readable display name."""
+
+    email_address: str | None = Field(default=None, alias="emailAddress")
+    """Primary email address. May be redacted on Cloud."""
+
+    active: bool = True
+    """``True`` for active accounts, ``False`` for deactivated ones."""
+
+    time_zone: str | None = Field(default=None, alias="timeZone")
+    """IANA timezone, e.g. ``"Europe/Berlin"``."""
+
+    locale: str | None = None
+    """Locale tag, e.g. ``"en_US"``."""
+
+    self_url: str | None = Field(default=None, alias="self")
+    """Canonical REST URL for this user (``/rest/api/2/user?...``)."""
+
+    avatar_urls: dict[str, str] | None = Field(default=None, alias="avatarUrls")
+    """Avatar URLs keyed by size, e.g. ``"48x48"``. ``None`` if unavailable."""
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> JiraUser:
+        """Build a :class:`JiraUser` from a Jira REST/JSON dict shape."""
+        return cls.model_validate(raw)
+
+    @classmethod
+    def from_jira_obj(cls, obj: Any) -> JiraUser:
+        """Build a :class:`JiraUser` from a ``jira.User`` SDK instance.
+
+        The SDK exposes its fields via attribute access. We normalise the
+        ``timeZone``/``timezone`` discrepancy here, and tolerate a missing
+        ``active`` flag (defaulting to ``True`` to match the SDK behaviour
+        we observed in :mod:`src.clients.jira_user_service`).
+        """
+        avatar_urls_attr = getattr(obj, "avatarUrls", None)
+        avatar_urls: dict[str, str] | None
+        if avatar_urls_attr is None:
+            avatar_urls = None
+        else:
+            try:
+                avatar_urls = {str(k): str(v) for k, v in dict(avatar_urls_attr).items() if v} or None
+            except TypeError, ValueError:
+                avatar_urls = None
+
+        return cls.model_validate(
+            {
+                "key": getattr(obj, "key", None),
+                "accountId": getattr(obj, "accountId", None),
+                "name": getattr(obj, "name", None),
+                "displayName": getattr(obj, "displayName", None),
+                "emailAddress": getattr(obj, "emailAddress", None),
+                "active": getattr(obj, "active", True),
+                # SDK quirk: some versions expose ``timezone`` lowercase.
+                "timeZone": getattr(obj, "timeZone", None) or getattr(obj, "timezone", None),
+                "locale": getattr(obj, "locale", None),
+                "self": getattr(obj, "self", None),
+                "avatarUrls": avatar_urls,
+            },
+        )
+
+
+__all__ = ["JiraUser"]

--- a/src/models/jira/user.py
+++ b/src/models/jira/user.py
@@ -80,7 +80,10 @@ class JiraUser(BaseModel):
         else:
             try:
                 avatar_urls = {str(k): str(v) for k, v in dict(avatar_urls_attr).items() if v} or None
-            except TypeError, ValueError:
+            except (
+                TypeError,
+                ValueError,
+            ):
                 avatar_urls = None
 
         return cls.model_validate(

--- a/src/models/openproject/__init__.py
+++ b/src/models/openproject/__init__.py
@@ -1,0 +1,15 @@
+"""OpenProject-side Pydantic models (ADR-002 phase 3a)."""
+
+from __future__ import annotations
+
+from src.models.openproject.custom_field import OpCustomField
+from src.models.openproject.project import OpProject
+from src.models.openproject.user import OpUser
+from src.models.openproject.work_package import OpWorkPackage
+
+__all__ = [
+    "OpCustomField",
+    "OpProject",
+    "OpUser",
+    "OpWorkPackage",
+]

--- a/src/models/openproject/custom_field.py
+++ b/src/models/openproject/custom_field.py
@@ -1,0 +1,55 @@
+"""Pydantic v2 model for OpenProject custom field payloads.
+
+The shape modelled here matches the ``CustomField.as_json`` dump produced
+by :mod:`src.clients.openproject_custom_field_service` and the helpers in
+:mod:`src.clients.openproject_work_package_custom_field_service`. Only the
+fields the migration actually relies on are modelled — the Rails
+``CustomField`` record has many more attributes that we don't need to type
+yet.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.domain.ids import OpCustomFieldId
+
+
+class OpCustomField(BaseModel):
+    """Canonical representation of an OpenProject custom field."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    id: OpCustomFieldId | None = None
+    name: str
+    field_format: str
+    """Rails field format token: ``"string"``, ``"text"``, ``"int"``, ``"float"``,
+    ``"list"``, ``"user"``, ``"version"``, ``"date"``, ``"bool"``, etc."""
+
+    is_required: bool = False
+    is_filter: bool = False
+    is_for_all: bool = False
+    """``True`` activates the CF for every project automatically."""
+
+    searchable: bool = False
+    editable: bool = True
+    visible: bool = True
+    multi_value: bool = False
+
+    default_value: str | None = None
+    min_length: int | None = None
+    max_length: int | None = None
+    regexp: str | None = None
+
+    possible_values: list[str] = Field(default_factory=list)
+    """Enumerated values for ``list``-format CFs. Empty for other formats."""
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> OpCustomField:
+        """Build an :class:`OpCustomField` from a Rails/REST dict shape."""
+        return cls.model_validate(raw)
+
+
+__all__ = ["OpCustomField"]

--- a/src/models/openproject/project.py
+++ b/src/models/openproject/project.py
@@ -1,0 +1,57 @@
+"""Pydantic v2 model for OpenProject project payloads.
+
+The shape modelled here matches the dict produced by
+:mod:`src.clients.openproject_project_service` (``get_projects`` and the
+single-project lookups) and the create/update payload consumed by
+``ProjectMigration``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.domain.ids import OpProjectId
+
+
+class OpProject(BaseModel):
+    """Canonical representation of an OpenProject project."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    id: OpProjectId | None = None
+    """OpenProject ``projects.id`` primary key (``None`` for create payloads)."""
+
+    name: str
+    """Display name of the project."""
+
+    identifier: str
+    """URL-safe project identifier (slug)."""
+
+    description: str = ""
+    """Project description. Empty string when absent — matches the Rails dump."""
+
+    parent_id: OpProjectId | None = None
+    """Parent project id for hierarchical projects."""
+
+    public: bool = False
+    """``True`` if the project is publicly visible."""
+
+    status: str | None = None
+    """Status name (``"on_track"``, ``"at_risk"``, …) — mirrors ``status&.name``."""
+
+    enabled_module_names: list[str] = Field(default_factory=list, alias="enabled_modules")
+    """Enabled OpenProject module identifiers (``"work_package_tracking"`` …).
+
+    Accepts both ``enabled_module_names`` (the canonical OP API name) and
+    ``enabled_modules`` (the alias used by the Rails JSON dump) on input.
+    """
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> OpProject:
+        """Build an :class:`OpProject` from a Rails/REST dict shape."""
+        return cls.model_validate(raw)
+
+
+__all__ = ["OpProject"]

--- a/src/models/openproject/user.py
+++ b/src/models/openproject/user.py
@@ -1,0 +1,50 @@
+"""Pydantic v2 model for OpenProject user payloads.
+
+The shape modelled here matches what
+:mod:`src.clients.openproject_user_service` returns and what
+:mod:`src.utils.enhanced_user_association_migrator` consumes — a flat dict
+with ``login``, ``mail``, ``firstname``/``lastname`` and friends. The
+``email`` alias accommodates the small number of code paths that still
+use the older REST key.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.domain.ids import OpUserId
+
+
+class OpUser(BaseModel):
+    """Canonical representation of an OpenProject user."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    id: OpUserId | None = None
+    """OpenProject ``users.id`` primary key."""
+
+    login: str | None = None
+    """OpenProject login (the OP equivalent of a Jira ``name``)."""
+
+    firstname: str | None = None
+    lastname: str | None = None
+
+    mail: str | None = Field(default=None, alias="email")
+    """Email address. Accepts both ``mail`` (canonical Rails attribute) and
+    ``email`` (older REST shape) on input via Pydantic alias."""
+
+    admin: bool = False
+    """``True`` if this account has the global admin role."""
+
+    language: str | None = None
+    """User language preference, e.g. ``"en"``."""
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> OpUser:
+        """Build an :class:`OpUser` from a Rails/REST dict shape."""
+        return cls.model_validate(raw)
+
+
+__all__ = ["OpUser"]

--- a/src/models/openproject/work_package.py
+++ b/src/models/openproject/work_package.py
@@ -1,0 +1,64 @@
+"""Pydantic v2 model for OpenProject work-package payloads.
+
+The shape modelled here matches the dict consumed by
+``WorkPackageMigration`` create/update calls and produced by the Rails
+``WorkPackage`` enumeration in
+:mod:`src.clients.openproject_work_package_service`. We model the
+attribute-style payload (``project_id``, ``type_id`` …) rather than the
+``_links``-shaped HAL form; the service layer translates between the two.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from src.domain.ids import (
+    OpPriorityId,
+    OpProjectId,
+    OpStatusId,
+    OpTypeId,
+    OpUserId,
+    OpWorkPackageId,
+)
+
+
+class OpWorkPackage(BaseModel):
+    """Canonical representation of an OpenProject work package."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    id: OpWorkPackageId | None = None
+    """``work_packages.id`` primary key (``None`` for create payloads)."""
+
+    subject: str | None = None
+    description: str | None = None
+
+    type_id: OpTypeId | None = None
+    status_id: OpStatusId | None = None
+    priority_id: OpPriorityId | None = None
+    project_id: OpProjectId | None = None
+
+    assigned_to_id: OpUserId | None = None
+    responsible_id: OpUserId | None = None
+
+    start_date: str | None = None
+    """ISO-formatted date string. Kept as ``str`` to match the Rails dump."""
+
+    due_date: str | None = None
+    """ISO-formatted date string."""
+
+    parent_id: OpWorkPackageId | None = None
+    done_ratio: int | None = None
+
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> OpWorkPackage:
+        """Build an :class:`OpWorkPackage` from a Rails/REST dict shape."""
+        return cls.model_validate(raw)
+
+
+__all__ = ["OpWorkPackage"]

--- a/tests/unit/test_models_domain_ids.py
+++ b/tests/unit/test_models_domain_ids.py
@@ -1,0 +1,66 @@
+"""Tests for branded identifier types in :mod:`src.domain.ids`.
+
+``NewType`` is a no-op at runtime — these tests pin that contract so a
+future refactor that swaps ``NewType`` for ``Annotated`` (or vice versa)
+trips the suite if the substitution would change runtime semantics.
+"""
+
+from __future__ import annotations
+
+from src.domain.ids import (
+    JiraAccountId,
+    JiraIssueKey,
+    JiraProjectKey,
+    JiraUserKey,
+    OpCustomFieldId,
+    OpPriorityId,
+    OpProjectId,
+    OpStatusId,
+    OpTypeId,
+    OpUserId,
+    OpWorkPackageId,
+)
+
+
+def test_jira_str_brands_are_zero_cost() -> None:
+    issue = JiraIssueKey("ABC-123")
+    project = JiraProjectKey("ABC")
+    user_key = JiraUserKey("jdoe")
+    account = JiraAccountId("557058:abc")
+
+    # NewType wrappers are runtime-equal to their underlying values.
+    assert issue == "ABC-123"
+    assert project == "ABC"
+    assert user_key == "jdoe"
+    assert account == "557058:abc"
+    # All four are concretely ``str`` at runtime.
+    assert isinstance(issue, str)
+    assert isinstance(account, str)
+
+
+def test_op_int_brands_are_zero_cost() -> None:
+    user = OpUserId(1)
+    project = OpProjectId(2)
+    wp = OpWorkPackageId(3)
+    cf = OpCustomFieldId(4)
+    status = OpStatusId(5)
+    priority = OpPriorityId(6)
+    op_type = OpTypeId(7)
+
+    assert user == 1
+    assert project == 2
+    assert wp == 3
+    assert cf == 4
+    assert status == 5
+    assert priority == 6
+    assert op_type == 7
+    # Concretely ``int`` at runtime.
+    assert isinstance(user, int)
+    assert isinstance(op_type, int)
+
+
+def test_branded_ids_compose_with_unbranded_arithmetic() -> None:
+    """At runtime, branded ints behave exactly like ints."""
+    wp = OpWorkPackageId(40)
+    assert wp + 2 == 42
+    assert sorted([OpUserId(3), OpUserId(1), OpUserId(2)]) == [1, 2, 3]

--- a/tests/unit/test_models_jira_issue.py
+++ b/tests/unit/test_models_jira_issue.py
@@ -1,0 +1,228 @@
+"""Tests for :class:`src.models.jira.JiraIssue` and friends."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.models.jira import JiraIssue, JiraIssueFields
+
+
+def _nested_dict_shape() -> dict[str, object]:
+    return {
+        "key": "ABC-123",
+        "id": "10001",
+        "fields": {
+            "summary": "Hello",
+            "description": "World",
+            "status": {"id": "1", "name": "Open"},
+            "priority": {"id": "3", "name": "Medium"},
+            "issuetype": {"id": "10", "name": "Bug"},
+            "assignee": {
+                "accountId": "557058:abc",
+                "displayName": "Jane",
+                "emailAddress": "jane@example.com",
+            },
+            "reporter": {
+                "accountId": "557058:def",
+                "displayName": "John",
+            },
+            "created": "2026-01-01T12:00:00.000+0000",
+            "updated": "2026-01-02T12:00:00.000+0000",
+            "labels": ["bug", "urgent"],
+            "fixVersions": [{"id": "1", "name": "v1.0"}],
+            "components": [{"id": "5", "name": "Backend"}],
+        },
+    }
+
+
+def test_from_dict_nested_shape() -> None:
+    issue = JiraIssue.from_dict(_nested_dict_shape())
+
+    assert issue.key == "ABC-123"
+    assert issue.id == "10001"
+    assert isinstance(issue.fields, JiraIssueFields)
+    assert issue.fields.summary == "Hello"
+    assert issue.fields.description == "World"
+    assert issue.fields.status is not None
+    assert issue.fields.status.name == "Open"
+    assert issue.fields.priority is not None
+    assert issue.fields.priority.name == "Medium"
+    assert issue.fields.issue_type is not None
+    assert issue.fields.issue_type.name == "Bug"
+    assert issue.fields.assignee is not None
+    assert issue.fields.assignee.display_name == "Jane"
+    assert issue.fields.assignee.email_address == "jane@example.com"
+    assert issue.fields.reporter is not None
+    assert issue.fields.reporter.display_name == "John"
+    assert issue.fields.labels == ["bug", "urgent"]
+    assert len(issue.fields.fix_versions) == 1
+    assert issue.fields.fix_versions[0].name == "v1.0"
+    assert len(issue.fields.components) == 1
+    assert issue.fields.components[0].name == "Backend"
+
+
+def test_from_dict_flattened_shape_assembles_fields_block() -> None:
+    flattened: dict[str, object] = {
+        "id": "10001",
+        "key": "ABC-123",
+        "summary": "Hello",
+        "description": "World",
+        # Flattened shape uses snake_case for issue_type.
+        "issue_type": {"id": "10", "name": "Bug"},
+        "status": {"id": "1", "name": "Open"},
+        "created": "2026-01-01T12:00:00.000+0000",
+        "updated": "2026-01-02T12:00:00.000+0000",
+        "assignee": {"name": "jdoe", "display_name": "Jane"},
+        "reporter": {"name": "jrep", "display_name": "John"},
+        "comments": [
+            {"id": "100", "body": "first", "author": "Jane", "created": "2026-01-01T12:00"},
+        ],
+        "attachments": [
+            {"id": "200", "filename": "f.txt", "size": 12, "content": "https://x"},
+        ],
+    }
+    issue = JiraIssue.from_dict(flattened)
+
+    assert issue.key == "ABC-123"
+    assert issue.id == "10001"
+    assert issue.fields.summary == "Hello"
+    assert issue.fields.issue_type is not None
+    assert issue.fields.issue_type.name == "Bug"
+    assert issue.fields.status is not None
+    assert issue.fields.status.name == "Open"
+    assert len(issue.fields.comments) == 1
+    assert issue.fields.comments[0].body == "first"
+    assert issue.fields.comments[0].author == "Jane"
+    assert len(issue.fields.attachments) == 1
+    assert issue.fields.attachments[0].filename == "f.txt"
+    assert issue.fields.attachments[0].size == 12
+
+
+def test_from_dict_minimal_shape_defaults_empty_fields() -> None:
+    issue = JiraIssue.from_dict({"key": "ABC-1", "id": "1"})
+    assert issue.fields.summary is None
+    assert issue.fields.labels == []
+    assert issue.fields.fix_versions == []
+    assert issue.fields.components == []
+    assert issue.fields.comments == []
+    assert issue.fields.attachments == []
+
+
+def test_from_dict_extra_fields_are_ignored() -> None:
+    issue = JiraIssue.from_dict(
+        {
+            "key": "ABC-1",
+            "id": "1",
+            "fields": {"summary": "x", "votes": {"votes": 2}},
+            "expand": "names,renderedFields",
+        },
+    )
+    assert issue.key == "ABC-1"
+    assert issue.fields.summary == "x"
+    assert "expand" not in issue.model_dump()
+
+
+def test_from_jira_obj_happy_path() -> None:
+    assignee = SimpleNamespace(
+        accountId="557058:abc",
+        displayName="Jane",
+        emailAddress="jane@example.com",
+    )
+    reporter = SimpleNamespace(accountId="557058:def", displayName="John")
+    status = SimpleNamespace(id="1", name="Open")
+    priority = SimpleNamespace(id="3", name="Medium")
+    issuetype = SimpleNamespace(id="10", name="Bug")
+    fix_version = SimpleNamespace(id="1", name="v1.0")
+    component = SimpleNamespace(id="5", name="Backend")
+
+    comment_obj = SimpleNamespace(
+        id="100",
+        body="first",
+        author=SimpleNamespace(displayName="Jane"),
+        created="2026-01-01T12:00",
+    )
+    comment_block = SimpleNamespace(comments=[comment_obj])
+
+    attachment_obj = SimpleNamespace(
+        id="200",
+        filename="f.txt",
+        size=12,
+        url="https://x.example.com/f.txt",
+    )
+
+    fields = SimpleNamespace(
+        summary="Hello",
+        description="World",
+        status=status,
+        priority=priority,
+        issuetype=issuetype,
+        assignee=assignee,
+        reporter=reporter,
+        created="2026-01-01T12:00:00.000+0000",
+        updated="2026-01-02T12:00:00.000+0000",
+        labels=["bug"],
+        fixVersions=[fix_version],
+        components=[component],
+        comment=comment_block,
+        attachment=[attachment_obj],
+    )
+    obj = SimpleNamespace(id="10001", key="ABC-123", fields=fields)
+
+    issue = JiraIssue.from_jira_obj(obj)
+
+    assert issue.key == "ABC-123"
+    assert issue.id == "10001"
+    assert issue.fields.summary == "Hello"
+    assert issue.fields.status is not None
+    assert issue.fields.status.name == "Open"
+    assert issue.fields.priority is not None
+    assert issue.fields.priority.name == "Medium"
+    assert issue.fields.issue_type is not None
+    assert issue.fields.issue_type.name == "Bug"
+    assert issue.fields.assignee is not None
+    assert issue.fields.assignee.display_name == "Jane"
+    assert issue.fields.reporter is not None
+    assert issue.fields.reporter.display_name == "John"
+    assert issue.fields.labels == ["bug"]
+    assert len(issue.fields.fix_versions) == 1
+    assert issue.fields.fix_versions[0].name == "v1.0"
+    assert len(issue.fields.components) == 1
+    assert issue.fields.components[0].name == "Backend"
+    assert len(issue.fields.comments) == 1
+    assert issue.fields.comments[0].author == "Jane"
+    assert issue.fields.comments[0].body == "first"
+    assert len(issue.fields.attachments) == 1
+    assert issue.fields.attachments[0].content == "https://x.example.com/f.txt"
+
+
+def test_from_jira_obj_missing_assignee_and_reporter_default_to_none() -> None:
+    fields = SimpleNamespace(
+        summary="Hello",
+        description=None,
+        status=None,
+        priority=None,
+        issuetype=None,
+        assignee=None,
+        reporter=None,
+        created=None,
+        updated=None,
+        labels=None,
+        fixVersions=None,
+        components=None,
+        comment=None,
+        attachment=None,
+    )
+    obj = SimpleNamespace(id="10001", key="ABC-123", fields=fields)
+
+    issue = JiraIssue.from_jira_obj(obj)
+
+    assert issue.fields.assignee is None
+    assert issue.fields.reporter is None
+    assert issue.fields.status is None
+    assert issue.fields.priority is None
+    assert issue.fields.issue_type is None
+    assert issue.fields.labels == []
+    assert issue.fields.fix_versions == []
+    assert issue.fields.components == []
+    assert issue.fields.comments == []
+    assert issue.fields.attachments == []

--- a/tests/unit/test_models_jira_project.py
+++ b/tests/unit/test_models_jira_project.py
@@ -1,0 +1,139 @@
+"""Tests for :class:`src.models.jira.JiraProject`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.models.jira import JiraProject, JiraProjectCategoryRef
+
+
+def test_from_dict_happy_path() -> None:
+    raw = {
+        "key": "ABC",
+        "name": "Alpha Beta Charlie",
+        "id": "10000",
+        "description": "Demo project",
+        "lead": "jdoe",
+        "lead_display": "Jane Doe",
+        "browse_url": "https://jira.example.com/browse/ABC",
+        "archived": False,
+        "project_type_key": "software",
+        "project_category": {"id": "1", "name": "Internal"},
+        "avatar_url": "https://avatars.example.com/abc-128.png",
+    }
+    project = JiraProject.from_dict(raw)
+
+    assert project.key == "ABC"
+    assert project.name == "Alpha Beta Charlie"
+    assert project.id == "10000"
+    assert project.description == "Demo project"
+    assert project.lead == "jdoe"
+    assert project.lead_display == "Jane Doe"
+    assert project.browse_url == "https://jira.example.com/browse/ABC"
+    assert project.archived is False
+    assert project.project_type_key == "software"
+    assert isinstance(project.project_category, JiraProjectCategoryRef)
+    assert project.project_category.id == "1"
+    assert project.project_category.name == "Internal"
+    assert project.avatar_url == "https://avatars.example.com/abc-128.png"
+
+
+def test_from_dict_empty_category_normalised_to_none() -> None:
+    project = JiraProject.from_dict(
+        {
+            "key": "ABC",
+            "name": "A",
+            "id": "1",
+            "project_category": {},
+        },
+    )
+    assert project.project_category is None
+
+
+def test_from_dict_missing_optional_fields_use_defaults() -> None:
+    project = JiraProject.from_dict({"key": "ABC", "name": "A", "id": "1"})
+
+    assert project.description == ""
+    assert project.lead is None
+    assert project.lead_display is None
+    assert project.browse_url is None
+    assert project.archived is False
+    assert project.project_type_key is None
+    assert project.project_category is None
+    assert project.avatar_url is None
+
+
+def test_from_dict_extra_fields_are_ignored() -> None:
+    project = JiraProject.from_dict(
+        {
+            "key": "ABC",
+            "name": "A",
+            "id": "1",
+            "url": "ignored",
+            "avatar_urls": {"48x48": "ignored"},
+            "project_category_name": "ignored",
+            "project_category_id": "ignored",
+        },
+    )
+    assert project.key == "ABC"
+    assert "url" not in project.model_dump()
+    assert "avatar_urls" not in project.model_dump()
+
+
+def test_from_jira_obj_happy_path() -> None:
+    obj = SimpleNamespace(
+        id="10000",
+        key="ABC",
+        name="Alpha",
+        projectTypeKey="software",
+        raw={
+            "description": "Demo project",
+            "lead": {"name": "jdoe", "displayName": "Jane Doe"},
+            "projectCategory": {"id": 1, "name": "Internal"},
+            "avatarUrls": {
+                "16x16": "https://avatars.example.com/abc-16.png",
+                "48x48": "https://avatars.example.com/abc-48.png",
+                "128x128": "https://avatars.example.com/abc-128.png",
+            },
+            "projectTypeKey": "software",
+            "archived": False,
+        },
+    )
+    project = JiraProject.from_jira_obj(obj, browse_url="https://jira.example.com/browse/ABC")
+
+    assert project.key == "ABC"
+    assert project.id == "10000"
+    assert project.description == "Demo project"
+    assert project.lead == "jdoe"
+    assert project.lead_display == "Jane Doe"
+    assert project.browse_url == "https://jira.example.com/browse/ABC"
+    assert project.project_type_key == "software"
+    assert project.project_category is not None
+    assert project.project_category.id == "1"
+    assert project.project_category.name == "Internal"
+    # Largest available avatar URL is preferred.
+    assert project.avatar_url == "https://avatars.example.com/abc-128.png"
+
+
+def test_from_jira_obj_missing_raw_falls_back_to_empty_metadata() -> None:
+    obj = SimpleNamespace(id="1", key="ABC", name="A")
+    project = JiraProject.from_jira_obj(obj)
+
+    assert project.key == "ABC"
+    assert project.description == ""
+    assert project.lead is None
+    assert project.lead_display is None
+    assert project.project_category is None
+    assert project.avatar_url is None
+    assert project.archived is False
+
+
+def test_from_jira_obj_lead_falls_back_to_key_when_name_missing() -> None:
+    obj = SimpleNamespace(
+        id="1",
+        key="ABC",
+        name="A",
+        raw={"lead": {"key": "fallback-key"}},
+    )
+    project = JiraProject.from_jira_obj(obj)
+    assert project.lead == "fallback-key"

--- a/tests/unit/test_models_jira_user.py
+++ b/tests/unit/test_models_jira_user.py
@@ -1,0 +1,135 @@
+"""Tests for :class:`src.models.jira.JiraUser`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.models.jira import JiraUser
+
+
+def test_from_dict_happy_path() -> None:
+    raw = {
+        "key": "jdoe",
+        "accountId": "557058:abc",
+        "name": "jdoe",
+        "displayName": "Jane Doe",
+        "emailAddress": "jane@example.com",
+        "active": True,
+        "timeZone": "Europe/Berlin",
+        "locale": "en_US",
+        "self": "https://jira.example.com/rest/api/2/user?username=jdoe",
+        "avatarUrls": {"48x48": "https://avatars.example.com/jdoe-48.png"},
+    }
+    user = JiraUser.from_dict(raw)
+
+    assert user.key == "jdoe"
+    assert user.account_id == "557058:abc"
+    assert user.name == "jdoe"
+    assert user.display_name == "Jane Doe"
+    assert user.email_address == "jane@example.com"
+    assert user.active is True
+    assert user.time_zone == "Europe/Berlin"
+    assert user.locale == "en_US"
+    assert user.self_url == "https://jira.example.com/rest/api/2/user?username=jdoe"
+    assert user.avatar_urls == {"48x48": "https://avatars.example.com/jdoe-48.png"}
+
+
+def test_from_dict_missing_optional_fields_default_to_none() -> None:
+    user = JiraUser.from_dict({"accountId": "557058:abc"})
+
+    assert user.account_id == "557058:abc"
+    assert user.key is None
+    assert user.display_name is None
+    assert user.email_address is None
+    assert user.time_zone is None
+    assert user.locale is None
+    assert user.self_url is None
+    assert user.avatar_urls is None
+    # Default for missing ``active`` is True.
+    assert user.active is True
+
+
+def test_from_dict_extra_fields_are_ignored() -> None:
+    user = JiraUser.from_dict(
+        {
+            "accountId": "557058:abc",
+            "displayName": "Jane",
+            "applicationRoles": {"size": 1, "items": []},
+            "groups": {"size": 0, "items": []},
+        },
+    )
+    assert user.account_id == "557058:abc"
+    assert user.display_name == "Jane"
+    # Extras silently dropped.
+    assert "application_roles" not in user.model_dump()
+    assert "applicationRoles" not in user.model_dump()
+
+
+def test_alias_accepts_both_camel_and_snake() -> None:
+    via_alias = JiraUser(accountId="X", displayName="Y")  # type: ignore[call-arg]
+    via_field = JiraUser(account_id="X", display_name="Y")
+
+    assert via_alias.account_id == via_field.account_id == "X"
+    assert via_alias.display_name == via_field.display_name == "Y"
+
+
+def test_from_jira_obj_happy_path() -> None:
+    obj = SimpleNamespace(
+        key="jdoe",
+        accountId="557058:abc",
+        name="jdoe",
+        displayName="Jane Doe",
+        emailAddress="jane@example.com",
+        active=True,
+        timeZone="Europe/Berlin",
+        locale="en_US",
+        self="https://jira.example.com/rest/api/2/user?username=jdoe",
+        avatarUrls={"48x48": "https://avatars.example.com/jdoe-48.png"},
+    )
+    user = JiraUser.from_jira_obj(obj)
+
+    assert user.key == "jdoe"
+    assert user.account_id == "557058:abc"
+    assert user.display_name == "Jane Doe"
+    assert user.time_zone == "Europe/Berlin"
+    assert user.avatar_urls == {"48x48": "https://avatars.example.com/jdoe-48.png"}
+
+
+def test_from_jira_obj_falls_back_to_lowercase_timezone() -> None:
+    """Some SDK versions expose ``timezone`` instead of ``timeZone``."""
+    obj = SimpleNamespace(
+        accountId="557058:abc",
+        displayName="Jane",
+        timezone="Europe/Berlin",  # lowercase
+    )
+    user = JiraUser.from_jira_obj(obj)
+    assert user.time_zone == "Europe/Berlin"
+
+
+def test_from_jira_obj_missing_attrs_default_to_none() -> None:
+    obj = SimpleNamespace()
+    user = JiraUser.from_jira_obj(obj)
+
+    assert user.key is None
+    assert user.account_id is None
+    assert user.display_name is None
+    assert user.email_address is None
+    assert user.time_zone is None
+    assert user.avatar_urls is None
+    # ``active`` defaults to True when the attribute is missing.
+    assert user.active is True
+
+
+def test_from_jira_obj_avatar_urls_non_dictlike_falls_back_to_none() -> None:
+    obj = SimpleNamespace(accountId="X", avatarUrls=12345)
+    user = JiraUser.from_jira_obj(obj)
+    assert user.avatar_urls is None
+
+
+def test_from_jira_obj_avatar_urls_filters_falsy_values() -> None:
+    obj = SimpleNamespace(
+        accountId="X",
+        avatarUrls={"48x48": "url", "24x24": "", "16x16": None},
+    )
+    user = JiraUser.from_jira_obj(obj)
+    assert user.avatar_urls == {"48x48": "url"}

--- a/tests/unit/test_models_op_custom_field.py
+++ b/tests/unit/test_models_op_custom_field.py
@@ -1,0 +1,87 @@
+"""Tests for :class:`src.models.openproject.OpCustomField`."""
+
+from __future__ import annotations
+
+from src.models.openproject import OpCustomField
+
+
+def test_from_dict_happy_path() -> None:
+    raw = {
+        "id": 99,
+        "name": "Origin Key",
+        "field_format": "string",
+        "is_required": False,
+        "is_filter": True,
+        "is_for_all": True,
+        "searchable": True,
+        "editable": True,
+        "visible": True,
+        "multi_value": False,
+        "default_value": None,
+        "min_length": 0,
+        "max_length": 255,
+        "regexp": None,
+        "possible_values": [],
+    }
+    cf = OpCustomField.from_dict(raw)
+    assert cf.id == 99
+    assert cf.name == "Origin Key"
+    assert cf.field_format == "string"
+    assert cf.is_required is False
+    assert cf.is_filter is True
+    assert cf.is_for_all is True
+    assert cf.searchable is True
+    assert cf.editable is True
+    assert cf.visible is True
+    assert cf.multi_value is False
+    assert cf.default_value is None
+    assert cf.min_length == 0
+    assert cf.max_length == 255
+    assert cf.regexp is None
+    assert cf.possible_values == []
+
+
+def test_from_dict_minimal_uses_documented_defaults() -> None:
+    cf = OpCustomField.from_dict({"name": "X", "field_format": "list"})
+    assert cf.id is None
+    assert cf.is_required is False
+    assert cf.is_filter is False
+    assert cf.is_for_all is False
+    assert cf.searchable is False
+    # Editable/visible default to True — these match Rails' factory
+    # defaults for new CFs.
+    assert cf.editable is True
+    assert cf.visible is True
+    assert cf.multi_value is False
+    assert cf.default_value is None
+    assert cf.possible_values == []
+
+
+def test_from_dict_with_enumerated_values() -> None:
+    cf = OpCustomField.from_dict(
+        {
+            "name": "Severity",
+            "field_format": "list",
+            "possible_values": ["Low", "Medium", "High"],
+            "multi_value": False,
+        },
+    )
+    assert cf.field_format == "list"
+    assert cf.possible_values == ["Low", "Medium", "High"]
+
+
+def test_from_dict_extra_fields_are_ignored() -> None:
+    cf = OpCustomField.from_dict(
+        {
+            "name": "X",
+            "field_format": "string",
+            "type": "WorkPackageCustomField",
+            "position": 12,
+            "created_at": "2026-01-01",
+        },
+    )
+    assert cf.name == "X"
+    dump = cf.model_dump()
+    assert "type" not in dump
+    assert "position" not in dump
+    assert "created_at" not in dump

--- a/tests/unit/test_models_op_project.py
+++ b/tests/unit/test_models_op_project.py
@@ -1,0 +1,65 @@
+"""Tests for :class:`src.models.openproject.OpProject`."""
+
+from __future__ import annotations
+
+from src.models.openproject import OpProject
+
+
+def test_from_dict_happy_path() -> None:
+    raw = {
+        "id": 7,
+        "name": "Demo",
+        "identifier": "demo",
+        "description": "Demo project",
+        "parent_id": None,
+        "public": False,
+        "status": "on_track",
+        "enabled_module_names": ["work_package_tracking", "wiki"],
+    }
+    project = OpProject.from_dict(raw)
+    assert project.id == 7
+    assert project.name == "Demo"
+    assert project.identifier == "demo"
+    assert project.description == "Demo project"
+    assert project.parent_id is None
+    assert project.public is False
+    assert project.status == "on_track"
+    assert project.enabled_module_names == ["work_package_tracking", "wiki"]
+
+
+def test_from_dict_accepts_enabled_modules_alias() -> None:
+    project = OpProject.from_dict(
+        {
+            "name": "Demo",
+            "identifier": "demo",
+            "enabled_modules": ["work_package_tracking"],
+        },
+    )
+    assert project.enabled_module_names == ["work_package_tracking"]
+
+
+def test_from_dict_missing_optional_fields_use_defaults() -> None:
+    project = OpProject.from_dict({"name": "Demo", "identifier": "demo"})
+    assert project.id is None
+    assert project.description == ""
+    assert project.parent_id is None
+    assert project.public is False
+    assert project.status is None
+    assert project.enabled_module_names == []
+
+
+def test_from_dict_extra_fields_are_ignored() -> None:
+    project = OpProject.from_dict(
+        {
+            "name": "Demo",
+            "identifier": "demo",
+            "active": True,
+            "status_code": 1,
+            "j2o_origin_system": "jira",
+        },
+    )
+    assert project.identifier == "demo"
+    dump = project.model_dump()
+    assert "active" not in dump
+    assert "status_code" not in dump
+    assert "j2o_origin_system" not in dump

--- a/tests/unit/test_models_op_user.py
+++ b/tests/unit/test_models_op_user.py
@@ -1,0 +1,60 @@
+"""Tests for :class:`src.models.openproject.OpUser`."""
+
+from __future__ import annotations
+
+from src.models.openproject import OpUser
+
+
+def test_from_dict_happy_path() -> None:
+    raw = {
+        "id": 42,
+        "login": "jdoe",
+        "firstname": "Jane",
+        "lastname": "Doe",
+        "mail": "jane@example.com",
+        "admin": True,
+        "language": "en",
+    }
+    user = OpUser.from_dict(raw)
+    assert user.id == 42
+    assert user.login == "jdoe"
+    assert user.firstname == "Jane"
+    assert user.lastname == "Doe"
+    assert user.mail == "jane@example.com"
+    assert user.admin is True
+    assert user.language == "en"
+
+
+def test_from_dict_missing_optional_fields_default_to_none() -> None:
+    user = OpUser.from_dict({"login": "jdoe"})
+    assert user.login == "jdoe"
+    assert user.id is None
+    assert user.firstname is None
+    assert user.lastname is None
+    assert user.mail is None
+    assert user.admin is False
+    assert user.language is None
+
+
+def test_from_dict_extra_fields_are_ignored() -> None:
+    user = OpUser.from_dict(
+        {
+            "id": 1,
+            "login": "jdoe",
+            "j2o_origin_system": "jira",
+            "j2o_user_id": "557058:abc",
+            "time_zone": "Europe/Berlin",
+        },
+    )
+    assert user.login == "jdoe"
+    dump = user.model_dump()
+    assert "j2o_origin_system" not in dump
+    assert "time_zone" not in dump
+
+
+def test_email_alias_accepted_as_input() -> None:
+    """Older REST shape uses ``email`` rather than the canonical ``mail``."""
+    via_alias = OpUser.from_dict({"login": "jdoe", "email": "jane@example.com"})
+    via_canonical = OpUser.from_dict({"login": "jdoe", "mail": "jane@example.com"})
+    assert via_alias.mail == "jane@example.com"
+    assert via_canonical.mail == "jane@example.com"

--- a/tests/unit/test_models_op_work_package.py
+++ b/tests/unit/test_models_op_work_package.py
@@ -1,0 +1,81 @@
+"""Tests for :class:`src.models.openproject.OpWorkPackage`."""
+
+from __future__ import annotations
+
+from src.models.openproject import OpWorkPackage
+
+
+def test_from_dict_happy_path() -> None:
+    raw = {
+        "id": 1234,
+        "subject": "Hello",
+        "description": "World",
+        "type_id": 1,
+        "status_id": 2,
+        "priority_id": 3,
+        "project_id": 7,
+        "assigned_to_id": 42,
+        "responsible_id": 43,
+        "start_date": "2026-01-01",
+        "due_date": "2026-01-31",
+        "parent_id": 1233,
+        "done_ratio": 50,
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-02T12:00:00Z",
+    }
+    wp = OpWorkPackage.from_dict(raw)
+
+    assert wp.id == 1234
+    assert wp.subject == "Hello"
+    assert wp.description == "World"
+    assert wp.type_id == 1
+    assert wp.status_id == 2
+    assert wp.priority_id == 3
+    assert wp.project_id == 7
+    assert wp.assigned_to_id == 42
+    assert wp.responsible_id == 43
+    assert wp.start_date == "2026-01-01"
+    assert wp.due_date == "2026-01-31"
+    assert wp.parent_id == 1233
+    assert wp.done_ratio == 50
+    assert wp.created_at == "2026-01-01T12:00:00Z"
+    assert wp.updated_at == "2026-01-02T12:00:00Z"
+
+
+def test_from_dict_missing_optional_fields_default_to_none() -> None:
+    wp = OpWorkPackage.from_dict({})
+    assert wp.id is None
+    assert wp.subject is None
+    assert wp.description is None
+    assert wp.type_id is None
+    assert wp.status_id is None
+    assert wp.priority_id is None
+    assert wp.project_id is None
+    assert wp.assigned_to_id is None
+    assert wp.responsible_id is None
+    assert wp.start_date is None
+    assert wp.due_date is None
+    assert wp.parent_id is None
+    assert wp.done_ratio is None
+    assert wp.created_at is None
+    assert wp.updated_at is None
+
+
+def test_from_dict_extra_fields_are_ignored() -> None:
+    wp = OpWorkPackage.from_dict(
+        {
+            "id": 1,
+            "subject": "Hi",
+            "_links": {"self": {"href": "/api/v3/work_packages/1"}},
+            "lockVersion": 0,
+            "author_id": 5,
+        },
+    )
+    assert wp.id == 1
+    assert wp.subject == "Hi"
+    dump = wp.model_dump()
+    assert "_links" not in dump
+    assert "lockVersion" not in dump
+    # ``author_id`` is intentionally not modelled in 3α — it's used by the
+    # service layer but not by the migration's read/update payloads.
+    assert "author_id" not in dump


### PR DESCRIPTION
## Summary

Phase 3α of [ADR-002](docs/adr/ADR-002-target-architecture.md). Pure-addition PR — no migration or client code modified. Establishes the foundation for the typed pipeline that PRs 3β / 3γ will adopt.

### What's added

**Branded ID types** (`src/domain/ids.py`):
11 `NewType` aliases — 4 Jira string-branded (`JiraIssueKey`, `JiraProjectKey`, `JiraUserKey`, `JiraAccountId`) + 7 OP int-branded (`OpUserId`, `OpProjectId`, `OpWorkPackageId`, `OpCustomFieldId`, `OpStatusId`, `OpPriorityId`, `OpTypeId`). Zero runtime cost, prevent ID mixing at type-check time.

**Pydantic v2 domain models** at module boundaries:
- Jira read shapes: `JiraUser`, `JiraProject` (+ `JiraProjectCategoryRef`), `JiraIssue` (+ `JiraIssueFields`, `JiraStatusRef`, `JiraPriorityRef`, `JiraIssueTypeRef`, `JiraVersionRef`, `JiraComponentRef`, `JiraComment`, `JiraAttachment`)
- OP write shapes: `OpUser`, `OpProject`, `OpWorkPackage`, `OpCustomField`

### Dual-shape pattern

Every model exposes two constructors:
- `from_dict(raw)` — accepts the canonical dict shape (REST response or JSON cache)
- `from_jira_obj(obj)` — accepts the Jira SDK's attribute-based objects, normalizes SDK quirks (e.g. `timeZone` vs `timezone`, `avatarUrls` dict-likes)

`model_config = ConfigDict(populate_by_name=True, extra="ignore")` lets every field accept BOTH the API key (camelCase) and the Python convention (snake_case), so no caller breaks regardless of which shape they hand in.

### Quality gates

- **ruff check + format** — clean on `src/domain`, `src/models`, all new tests
- **mypy** — 0 errors on the 16 new source files
- **pytest** — 40 new unit tests passing; full unit suite 963 passing. The 30 deselected (`tests/unit/test_enhanced_openproject_client.py`) are pre-existing environment-config failures (`Container name is required`) that fail identically on baseline and are unrelated to this PR.

## Test plan
- [x] All quality gates green locally
- [ ] CI green
- [ ] At least one human review pass