### PR TITLE
refactor(phase-3c): unify polymorphic wp_map shape via WorkPackageMappingEntry

### DIFF
--- a/scripts/normalize_wp_mapping.py
+++ b/scripts/normalize_wp_mapping.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Forward-only migration: normalise the persisted ``work_package`` mapping.
+
+ADR-002 phase 3c unifies the polymorphic ``work_package`` mapping shape
+into :class:`~src.models.mapping.WorkPackageMappingEntry`. This script
+rewrites the existing on-disk
+``var/data/work_package_mapping.json`` so every entry conforms to the
+typed dict shape, dropping unrecoverable rows along the way.
+
+The rewrite is *atomic* — we write to a tempfile in the same directory
+and ``os.replace`` it into place. The destination's mode is mirrored
+on the tempfile before the rename so file permissions survive the
+swap.
+
+Usage::
+
+    uv run scripts/normalize_wp_mapping.py [--data-dir <path>] [--dry-run]
+
+Behaviour:
+
+* The script exits ``0`` on success or on benign no-ops (missing or
+  malformed mapping) so it never breaks a user's pipeline.
+* In ``--dry-run`` mode the file on disk is left untouched and a
+  per-key change summary is printed to stdout.
+* Without ``--dry-run`` the file is rewritten and the run is
+  summarised with counts of dict-shaped, int-shaped, and dropped
+  rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Allow ``uv run scripts/...`` and ``python scripts/...`` invocations
+# without requiring the caller to set ``PYTHONPATH``: the project
+# checkout root is the parent of ``scripts/``.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from src.utils.wp_mapping_normalizer import normalize_wp_mapping  # noqa: E402
+
+DEFAULT_DATA_DIR = Path("var/data")
+MAPPING_FILENAME = "work_package_mapping.json"
+
+logger = logging.getLogger("normalize_wp_mapping")
+
+
+def _classify_legacy_shapes(raw: dict[str, object]) -> tuple[int, int]:
+    """Return ``(dict_count, int_count)`` for an already-loaded mapping.
+
+    The classification is best-effort — the actual coercion happens in
+    :func:`normalize_wp_mapping`, which also emits the dropped-count.
+    Booleans are deliberately excluded from ``int_count`` because
+    :meth:`WorkPackageMappingEntry.from_legacy` rejects them.
+    """
+    dict_count = 0
+    int_count = 0
+    for value in raw.values():
+        if isinstance(value, dict):
+            dict_count += 1
+        elif isinstance(value, int) and not isinstance(value, bool):
+            int_count += 1
+    return dict_count, int_count
+
+
+def _atomic_write_json(target: Path, payload: dict[str, dict[str, object]]) -> None:
+    """Write ``payload`` to ``target`` atomically, preserving file mode.
+
+    The tempfile is created in the same directory as ``target`` so the
+    final ``os.replace`` is guaranteed to be atomic on every POSIX
+    filesystem. We capture the source mode (if any) before writing so
+    the rename does not surprise users running with a restrictive umask.
+    """
+    target_dir = target.parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    source_mode: int | None = None
+    try:
+        source_mode = target.stat().st_mode & 0o777
+    except FileNotFoundError:
+        # First-run: no existing file means no mode to preserve.
+        source_mode = None
+
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+        dir=str(target_dir),
+    )
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        if source_mode is not None:
+            os.chmod(tmp_path, source_mode)
+        os.replace(tmp_path, target)
+    except Exception:
+        # Best-effort cleanup of the orphaned tempfile if anything
+        # goes wrong before the atomic rename.
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                logger.warning("Failed to remove tempfile %s", tmp_path)
+        raise
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalise var/data/work_package_mapping.json into the typed "
+            "WorkPackageMappingEntry shape (ADR-002 phase 3c)."
+        ),
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DEFAULT_DATA_DIR,
+        help="Directory holding work_package_mapping.json (default: var/data).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing the file.",
+    )
+    return parser
+
+
+def run(argv: list[str] | None = None) -> int:
+    """Entry point used by :func:`main` and by tests.
+
+    Returns the process exit code. The function never raises on
+    expected failure modes (missing file, malformed JSON, unwritable
+    target) — those map to logged messages and a ``0`` exit so the
+    script is safe to chain in user pipelines.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    data_dir: Path = args.data_dir
+    target = data_dir / MAPPING_FILENAME
+
+    if not target.exists():
+        logger.info("No mapping file at %s; nothing to normalise.", target)
+        return 0
+
+    try:
+        text = target.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Could not read %s: %s", target, exc)
+        return 0
+
+    if not text.strip():
+        logger.info("Mapping file %s is empty; nothing to normalise.", target)
+        return 0
+
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("Mapping file %s is malformed JSON: %s", target, exc)
+        return 0
+
+    if not isinstance(raw, dict):
+        logger.warning(
+            "Mapping file %s has unexpected top-level shape %s; expected dict.",
+            target,
+            type(raw).__name__,
+        )
+        return 0
+
+    dict_count, int_count = _classify_legacy_shapes(raw)
+    normalized, dropped = normalize_wp_mapping(raw)
+
+    if args.dry_run:
+        logger.info(
+            "Dry-run: would normalise %d entries (%d dict, %d int, %d dropped) in %s.",
+            len(normalized),
+            dict_count,
+            int_count,
+            dropped,
+            target,
+        )
+        # Surface a per-key diff for keys whose serialised form would
+        # change. We compare against ``raw`` rather than ``normalized``
+        # to keep the output focused on actual changes.
+        for key, new_value in sorted(normalized.items()):
+            old_value = raw.get(key)
+            if old_value != new_value:
+                print(f"would update {key}: {old_value!r} -> {new_value!r}")
+        return 0
+
+    try:
+        _atomic_write_json(target, normalized)
+    except OSError as exc:
+        logger.warning("Could not write normalised mapping to %s: %s", target, exc)
+        return 0
+
+    logger.info(
+        "Normalized %d entries (%d were already dict-shape, %d were int-shape, %d were dropped)",
+        len(normalized),
+        dict_count,
+        int_count,
+        dropped,
+    )
+    return 0
+
+
+def main() -> None:
+    """Console-script entry point."""
+    sys.exit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/normalize_wp_mapping.py
+++ b/scripts/normalize_wp_mapping.py
@@ -187,7 +187,8 @@ def run(argv: list[str] | None = None) -> int:
 
     if args.dry_run:
         logger.info(
-            "Dry-run: would normalise %d entries (%d dict, %d int, %d dropped) in %s.",
+            "Dry-run: %d input entries → %d normalised (%d dict-shape, %d int-shape, %d dropped) in %s.",
+            len(raw),
             len(normalized),
             dict_count,
             int_count,
@@ -210,7 +211,8 @@ def run(argv: list[str] | None = None) -> int:
         return 0
 
     logger.info(
-        "Normalized %d entries (%d were already dict-shape, %d were int-shape, %d were dropped)",
+        "Normalized %d input entries → %d kept (%d were already dict-shape, %d were int-shape, %d were dropped)",
+        len(raw),
         len(normalized),
         dict_count,
         int_count,

--- a/src/migrations/estimates_migration.py
+++ b/src/migrations/estimates_migration.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from src.config import logger
 from src.migrations.base_migration import BaseMigration, register_entity_types
-from src.models import ComponentResult
+from src.models import ComponentResult, WorkPackageMappingEntry
 
 if TYPE_CHECKING:
     from src.clients.jira_client import JiraClient
@@ -96,11 +96,16 @@ class EstimatesMigration(BaseMigration):  # noqa: D101
         for key, issue in issues.items():
             try:
                 wp_entry = wp_map.get(key)
-                wp_id = None
-                if isinstance(wp_entry, dict):
-                    wp_id = wp_entry.get("openproject_id")
-                elif isinstance(wp_entry, int):
-                    wp_id = wp_entry
+                if wp_entry is None:
+                    continue
+                try:
+                    typed_entry = WorkPackageMappingEntry.from_legacy(key, wp_entry)
+                except ValueError:
+                    # Corrupt or unsupported shape — skip this issue rather
+                    # than abort the run; phase 3c's normalisation script
+                    # will scrub these on the next pass.
+                    continue
+                wp_id = typed_entry.openproject_id
                 if not wp_id:
                     continue
 

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -16,7 +16,7 @@ from src.models.jira import (
     JiraUser,
     JiraVersionRef,
 )
-from src.models.mapping import JiraToOPMapping, WorkPackageMappingEntry
+from src.models.mapping import WorkPackageMappingEntry
 from src.models.migration_error import MigrationError
 from src.models.migration_results import MigrationResult
 from src.models.openproject import (
@@ -39,7 +39,6 @@ __all__ = [
     "JiraProject",
     "JiraProjectCategoryRef",
     "JiraStatusRef",
-    "JiraToOPMapping",
     "JiraUser",
     "JiraVersionRef",
     "MigrationError",

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -16,6 +16,7 @@ from src.models.jira import (
     JiraUser,
     JiraVersionRef,
 )
+from src.models.mapping import JiraToOPMapping, WorkPackageMappingEntry
 from src.models.migration_error import MigrationError
 from src.models.migration_results import MigrationResult
 from src.models.openproject import (
@@ -38,6 +39,7 @@ __all__ = [
     "JiraProject",
     "JiraProjectCategoryRef",
     "JiraStatusRef",
+    "JiraToOPMapping",
     "JiraUser",
     "JiraVersionRef",
     "MigrationError",
@@ -46,4 +48,5 @@ __all__ = [
     "OpProject",
     "OpUser",
     "OpWorkPackage",
+    "WorkPackageMappingEntry",
 ]

--- a/src/models/mapping/__init__.py
+++ b/src/models/mapping/__init__.py
@@ -1,11 +1,17 @@
-"""Mapping-side Pydantic models and legacy mapping helpers (ADR-002 phase 3)."""
+"""Mapping-side Pydantic models and legacy mapping helpers (ADR-002 phase 3).
+
+``JiraToOPMapping`` is intentionally NOT re-exported here. Its module
+(``src.models.mapping.jira_to_op``) calls ``configure_logging(...)`` at
+import time, which uses ``logging.basicConfig(force=True)`` and would
+clobber global logging configuration whenever ``src.models`` is
+imported. Callers who need the legacy class can import it explicitly
+via ``from src.models.mapping.jira_to_op import JiraToOPMapping``.
+"""
 
 from __future__ import annotations
 
-from src.models.mapping.jira_to_op import JiraToOPMapping
 from src.models.mapping.work_package_entry import WorkPackageMappingEntry
 
 __all__ = [
-    "JiraToOPMapping",
     "WorkPackageMappingEntry",
 ]

--- a/src/models/mapping/__init__.py
+++ b/src/models/mapping/__init__.py
@@ -1,0 +1,11 @@
+"""Mapping-side Pydantic models and legacy mapping helpers (ADR-002 phase 3)."""
+
+from __future__ import annotations
+
+from src.models.mapping.jira_to_op import JiraToOPMapping
+from src.models.mapping.work_package_entry import WorkPackageMappingEntry
+
+__all__ = [
+    "JiraToOPMapping",
+    "WorkPackageMappingEntry",
+]

--- a/src/models/mapping/jira_to_op.py
+++ b/src/models/mapping/jira_to_op.py
@@ -3,6 +3,8 @@
 Defines the mapping strategies between Jira and OpenProject data models.
 """
 
+from __future__ import annotations
+
 # Add the logger import
 from src.display import configure_logging
 from src.type_definitions import JiraData, OpenProjectData, StatusMapping, TypeMapping

--- a/src/models/mapping/work_package_entry.py
+++ b/src/models/mapping/work_package_entry.py
@@ -93,9 +93,13 @@ class WorkPackageMappingEntry(BaseModel):
             )
         if isinstance(value, dict):
             # Allow callers to omit ``jira_key`` from the value because it's
-            # already implicit in the surrounding map; injecting it here
-            # keeps the canonical form complete.
-            payload: dict[str, Any] = {"jira_key": key, **value}
+            # already implicit in the surrounding map. The outer mapping key
+            # is the source of truth — if the inner dict has a conflicting
+            # ``jira_key``, the outer wins (silent overwrite would let
+            # data-corrupted upstream entries flow through unflagged, but
+            # raising here would brick a normalisation script users run on
+            # arbitrary historical data; outer-wins fixes the row in place).
+            payload: dict[str, Any] = {**value, "jira_key": key}
             return cls.model_validate(payload)
         msg = f"Unsupported wp_map entry shape for key {key!r}: {type(value).__name__}"
         raise ValueError(msg)

--- a/src/models/mapping/work_package_entry.py
+++ b/src/models/mapping/work_package_entry.py
@@ -1,0 +1,104 @@
+"""Pydantic v2 model for the work-package mapping entry (ADR-002 phase 3c).
+
+Historically the ``work_package`` mapping persisted by
+:mod:`src.migrations.work_package_migration` is a flat ``dict`` whose
+values are *polymorphic*:
+
+* the modern shape is a ``dict`` with at least ``jira_key`` and
+  ``openproject_id``, plus optional ``openproject_project_id``,
+  ``jira_migration_date`` and ``updated_at`` fields; or
+* the legacy shape is a bare ``int`` — the OpenProject work-package id —
+  produced by older migrations that did not yet record metadata.
+
+Phase 3c closes the loop on this polymorphism by introducing a single,
+typed :class:`WorkPackageMappingEntry` and a :meth:`from_legacy`
+constructor that coerces both shapes into the canonical typed form.
+Consumers can opt into the typed flow one site at a time; broader
+adoption (and the matching :class:`MappingRepository` work) is staged
+for phase 4 and phase 7 respectively.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from src.domain.ids import JiraIssueKey, OpProjectId, OpWorkPackageId
+
+
+class WorkPackageMappingEntry(BaseModel):
+    """Canonical typed representation of a single ``work_package`` mapping row.
+
+    The two required fields (``jira_key`` and ``openproject_id``) are
+    always present after construction. Optional fields mirror what
+    :class:`~src.migrations.work_package_migration.WorkPackageMigration`
+    stores today; see :meth:`from_legacy` for the coercion rules used
+    when normalising persisted user data.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    jira_key: JiraIssueKey
+    """Jira issue key, e.g. ``"PROJ-123"`` — the dict-level mapping key."""
+
+    openproject_id: OpWorkPackageId
+    """OpenProject ``work_packages.id`` primary key for this issue."""
+
+    openproject_project_id: OpProjectId | None = None
+    """OpenProject ``projects.id`` the work package belongs to (if known)."""
+
+    jira_migration_date: str | None = None
+    """ISO-8601 timestamp the entry was last migrated. Kept as ``str``."""
+
+    updated_at: str | None = None
+    """ISO-8601 ``updated_at`` last seen on the OpenProject side."""
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> WorkPackageMappingEntry:
+        """Build an entry from an already-dict-shaped legacy payload."""
+        return cls.model_validate(raw)
+
+    @classmethod
+    def from_legacy(cls, key: str, value: Any) -> WorkPackageMappingEntry:
+        """Coerce either the dict or int legacy shape into a typed entry.
+
+        Args:
+            key: The Jira issue key, i.e. the dict-level mapping key.
+                The legacy ``int`` shape stores the work-package id only,
+                so the Jira key has to come from outside the value.
+            value: The raw mapping value — either an ``int`` (legacy) or
+                a ``dict`` (modern).
+
+        Returns:
+            A fully-validated :class:`WorkPackageMappingEntry`.
+
+        Raises:
+            ValueError: If ``value`` is neither ``int`` nor ``dict``,
+                or if the dict shape is missing the required
+                ``openproject_id`` field. We fail fast at the boundary
+                so corrupt entries surface during normalisation rather
+                than at consumption time.
+
+        """
+        # ``bool`` is an ``int`` subclass in Python, so we explicitly reject
+        # boolean values to avoid silently treating ``True``/``False`` as ids.
+        if isinstance(value, bool):
+            msg = f"Unsupported wp_map entry shape for key {key!r}: bool"
+            raise ValueError(msg)
+        if isinstance(value, int):
+            return cls(
+                jira_key=JiraIssueKey(key),
+                openproject_id=OpWorkPackageId(value),
+            )
+        if isinstance(value, dict):
+            # Allow callers to omit ``jira_key`` from the value because it's
+            # already implicit in the surrounding map; injecting it here
+            # keeps the canonical form complete.
+            payload: dict[str, Any] = {"jira_key": key, **value}
+            return cls.model_validate(payload)
+        msg = f"Unsupported wp_map entry shape for key {key!r}: {type(value).__name__}"
+        raise ValueError(msg)
+
+
+__all__ = ["WorkPackageMappingEntry"]

--- a/src/utils/wp_mapping_normalizer.py
+++ b/src/utils/wp_mapping_normalizer.py
@@ -1,0 +1,84 @@
+"""Normalisation helpers for the polymorphic ``work_package`` mapping.
+
+The persisted ``work_package`` mapping pre-dates ADR-002 phase 3c and
+holds values in two shapes — see
+:mod:`src.models.mapping.work_package_entry` for the history. This
+module provides a single coercion entry point,
+:func:`normalize_wp_mapping`, that flattens both shapes into a uniform
+dict-shape suitable for re-persisting.
+
+The function is intentionally lossy on the *value* axis: malformed
+entries (e.g. strings, lists, ``None``) are *dropped* rather than
+raising, because the caller (a one-shot CLI script in
+``scripts/normalize_wp_mapping.py``) runs against user-owned files
+that may have accumulated corruption from older migrations. The
+dropped count is returned alongside the normalised mapping so the
+caller can surface it in logs.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from src.models.mapping import WorkPackageMappingEntry
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_wp_mapping(
+    raw: Mapping[str, Any],
+) -> tuple[dict[str, dict[str, Any]], int]:
+    """Normalise a legacy ``work_package`` mapping into a uniform dict-shape.
+
+    Each entry is coerced through
+    :meth:`WorkPackageMappingEntry.from_legacy` and then dumped via
+    :meth:`pydantic.BaseModel.model_dump` so the result is a plain
+    ``dict[str, dict[str, Any]]`` — i.e. JSON-serialisable and free of
+    Pydantic objects. ``None``-valued optional fields are preserved in
+    the output to keep the shape uniform across rows; downstream
+    consumers can treat ``None`` and "missing" identically because
+    :class:`WorkPackageMappingEntry` defaults the optional fields to
+    ``None``.
+
+    Args:
+        raw: A flat mapping of ``jira_key -> entry`` where each entry
+            is either an ``int`` (legacy) or a ``dict`` (modern).
+
+    Returns:
+        A two-tuple of ``(normalized, dropped_count)`` where:
+
+        * ``normalized`` is a ``dict[str, dict[str, Any]]`` with one
+          entry per successfully coerced row;
+        * ``dropped_count`` is the number of rows that could not be
+          coerced (logged at ``WARNING`` level with the offending key
+          and shape).
+
+    """
+    normalized: dict[str, dict[str, Any]] = {}
+    dropped = 0
+
+    for key, value in raw.items():
+        try:
+            entry = WorkPackageMappingEntry.from_legacy(key, value)
+        except (ValueError, TypeError) as exc:
+            # Pydantic raises ``ValidationError`` (a ``ValueError``
+            # subclass) on dict shapes that fail validation, and
+            # ``from_legacy`` raises plain ``ValueError`` on unsupported
+            # primitive shapes. ``TypeError`` covers exotic inputs
+            # (e.g. ``model_validate`` choking on a non-mapping arg).
+            logger.warning(
+                "Dropping unsupported wp_map entry for key %r: %s",
+                key,
+                exc,
+            )
+            dropped += 1
+            continue
+
+        normalized[key] = entry.model_dump(mode="json")
+
+    return normalized, dropped
+
+
+__all__ = ["normalize_wp_mapping"]

--- a/tests/unit/test_models_wp_mapping_entry.py
+++ b/tests/unit/test_models_wp_mapping_entry.py
@@ -1,0 +1,132 @@
+"""Tests for :class:`src.models.mapping.WorkPackageMappingEntry`.
+
+ADR-002 phase 3c: the typed entry must accept both legacy shapes
+(``int`` and ``dict``) and reject every other shape at the boundary.
+The round-trip test pins that ``model_dump(by_alias=True)`` produces a
+payload that re-validates without loss — a precondition for the
+forward-only on-disk migration in ``scripts/normalize_wp_mapping.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models.mapping import WorkPackageMappingEntry
+
+
+def test_from_legacy_int_value_yields_typed_entry() -> None:
+    entry = WorkPackageMappingEntry.from_legacy("PROJ-1", 42)
+
+    assert entry.jira_key == "PROJ-1"
+    assert entry.openproject_id == 42
+    # Optional fields default to ``None`` for the int legacy shape because
+    # the ``int`` carries no metadata.
+    assert entry.openproject_project_id is None
+    assert entry.jira_migration_date is None
+    assert entry.updated_at is None
+
+
+def test_from_legacy_full_dict_yields_typed_entry() -> None:
+    entry = WorkPackageMappingEntry.from_legacy(
+        "PROJ-2",
+        {
+            "openproject_id": 99,
+            "openproject_project_id": 7,
+            "jira_migration_date": "2026-04-30T12:00:00Z",
+            "updated_at": "2026-05-01T08:30:00Z",
+        },
+    )
+
+    assert entry.jira_key == "PROJ-2"
+    assert entry.openproject_id == 99
+    assert entry.openproject_project_id == 7
+    assert entry.jira_migration_date == "2026-04-30T12:00:00Z"
+    assert entry.updated_at == "2026-05-01T08:30:00Z"
+
+
+def test_from_legacy_partial_dict_with_required_fields_only() -> None:
+    entry = WorkPackageMappingEntry.from_legacy(
+        "PROJ-3",
+        {"openproject_id": 5},
+    )
+
+    assert entry.jira_key == "PROJ-3"
+    assert entry.openproject_id == 5
+    assert entry.openproject_project_id is None
+    assert entry.jira_migration_date is None
+    assert entry.updated_at is None
+
+
+def test_from_legacy_dict_keeps_explicit_jira_key_when_matching() -> None:
+    """If the dict already carries ``jira_key`` and it matches the outer key,
+    the explicit value is fine — the outer-key injection is harmless because
+    Pydantic uses the latest value for duplicate kwargs.
+    """
+    entry = WorkPackageMappingEntry.from_legacy(
+        "PROJ-4",
+        {"jira_key": "PROJ-4", "openproject_id": 17},
+    )
+
+    assert entry.jira_key == "PROJ-4"
+    assert entry.openproject_id == 17
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["a-string", ["a", "list"], None, 1.5, True, False],
+    ids=["str", "list", "none", "float", "true", "false"],
+)
+def test_from_legacy_unsupported_shape_raises_value_error(value: object) -> None:
+    with pytest.raises(ValueError, match="Unsupported wp_map entry shape"):
+        WorkPackageMappingEntry.from_legacy("PROJ-X", value)
+
+
+def test_from_dict_full_payload_with_extra_keys_are_ignored() -> None:
+    entry = WorkPackageMappingEntry.from_dict(
+        {
+            "jira_key": "PROJ-5",
+            "openproject_id": 10,
+            "openproject_project_id": 11,
+            "jira_migration_date": "2026-04-29T00:00:00Z",
+            "updated_at": "2026-04-29T01:00:00Z",
+            # Extra fields the migration may have written historically:
+            "lockVersion": 0,
+            "_links": {"self": {"href": "/api/v3/work_packages/10"}},
+        },
+    )
+
+    assert entry.jira_key == "PROJ-5"
+    assert entry.openproject_id == 10
+    assert entry.openproject_project_id == 11
+
+    dump = entry.model_dump()
+    assert "lockVersion" not in dump
+    assert "_links" not in dump
+
+
+def test_round_trip_via_model_dump_by_alias() -> None:
+    original = WorkPackageMappingEntry.from_legacy(
+        "PROJ-6",
+        {
+            "openproject_id": 21,
+            "openproject_project_id": 3,
+            "jira_migration_date": "2026-04-15T09:00:00Z",
+            "updated_at": "2026-04-15T09:01:00Z",
+        },
+    )
+
+    payload = original.model_dump(by_alias=True)
+    revived = WorkPackageMappingEntry.model_validate(payload)
+
+    assert revived == original
+    # And dumping again should be byte-identical, proving idempotence:
+    assert revived.model_dump(by_alias=True) == payload
+
+
+def test_from_legacy_dict_missing_required_field_raises() -> None:
+    """Missing ``openproject_id`` in a dict shape should fail validation."""
+    with pytest.raises(ValueError, match="openproject_id"):
+        WorkPackageMappingEntry.from_legacy(
+            "PROJ-7",
+            {"openproject_project_id": 4},
+        )

--- a/tests/unit/test_normalize_wp_mapping_script.py
+++ b/tests/unit/test_normalize_wp_mapping_script.py
@@ -1,0 +1,159 @@
+"""Tests for ``scripts/normalize_wp_mapping.py``.
+
+The script is loaded via :mod:`importlib` because the ``scripts/``
+directory is not a regular package (no ``__init__.py``). Tests cover:
+
+* end-to-end rewrite of a real fixture file with mixed shapes;
+* ``--dry-run`` producing diff output without touching the file;
+* graceful no-ops on missing files and malformed JSON.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "normalize_wp_mapping.py"
+
+
+def _load_script_module() -> ModuleType:
+    """Import ``scripts/normalize_wp_mapping.py`` as a module.
+
+    A fresh import per test keeps argparse state clean and ensures the
+    module-level ``logging.basicConfig`` call inside ``run`` is
+    observable through ``caplog``.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "normalize_wp_mapping_script",
+        SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Cannot load script from {SCRIPT_PATH}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def script_module() -> Iterator[ModuleType]:
+    module = _load_script_module()
+    try:
+        yield module
+    finally:
+        sys.modules.pop("normalize_wp_mapping_script", None)
+
+
+def _write_mapping(data_dir: Path, payload: dict[str, object]) -> Path:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    path = data_dir / "work_package_mapping.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_run_rewrites_file_with_mixed_shapes(
+    tmp_path: Path,
+    script_module: ModuleType,
+) -> None:
+    data_dir = tmp_path / "var" / "data"
+    target = _write_mapping(
+        data_dir,
+        {
+            "PROJ-1": {"openproject_id": 10, "openproject_project_id": 5},
+            "PROJ-2": 20,
+            "PROJ-BAD": "corrupt",
+        },
+    )
+    # Pin a non-default mode so we can assert it survives the rewrite.
+    target.chmod(0o640)
+
+    exit_code = script_module.run(["--data-dir", str(data_dir)])
+
+    assert exit_code == 0
+    rewritten = json.loads(target.read_text(encoding="utf-8"))
+    assert set(rewritten) == {"PROJ-1", "PROJ-2"}
+    assert rewritten["PROJ-1"]["openproject_id"] == 10
+    assert rewritten["PROJ-1"]["openproject_project_id"] == 5
+    assert rewritten["PROJ-2"]["openproject_id"] == 20
+    assert rewritten["PROJ-2"]["openproject_project_id"] is None
+
+    assert (target.stat().st_mode & 0o777) == 0o640
+
+
+def test_dry_run_leaves_file_untouched_but_reports_changes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    script_module: ModuleType,
+) -> None:
+    data_dir = tmp_path / "var" / "data"
+    target = _write_mapping(data_dir, {"PROJ-1": 7})
+    original_text = target.read_text(encoding="utf-8")
+
+    exit_code = script_module.run(["--data-dir", str(data_dir), "--dry-run"])
+
+    assert exit_code == 0
+    # File on disk is unchanged byte-for-byte.
+    assert target.read_text(encoding="utf-8") == original_text
+
+    captured = capsys.readouterr()
+    assert "would update PROJ-1" in captured.out
+
+
+def test_missing_file_exits_zero(
+    tmp_path: Path,
+    script_module: ModuleType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    data_dir = tmp_path / "var" / "data"  # never created
+    with caplog.at_level("INFO", logger="normalize_wp_mapping"):
+        exit_code = script_module.run(["--data-dir", str(data_dir)])
+
+    assert exit_code == 0
+    assert any("nothing to normalise" in rec.getMessage() for rec in caplog.records)
+
+
+def test_malformed_json_exits_zero(
+    tmp_path: Path,
+    script_module: ModuleType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    data_dir = tmp_path / "var" / "data"
+    data_dir.mkdir(parents=True)
+    target = data_dir / "work_package_mapping.json"
+    target.write_text("{not-json", encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="normalize_wp_mapping"):
+        exit_code = script_module.run(["--data-dir", str(data_dir)])
+
+    assert exit_code == 0
+    # File is preserved as-is (we never overwrite malformed input).
+    assert target.read_text(encoding="utf-8") == "{not-json"
+    assert any("malformed JSON" in rec.getMessage() for rec in caplog.records)
+
+
+def test_empty_file_exits_zero(
+    tmp_path: Path,
+    script_module: ModuleType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    data_dir = tmp_path / "var" / "data"
+    data_dir.mkdir(parents=True)
+    target = data_dir / "work_package_mapping.json"
+    target.write_text("   \n", encoding="utf-8")
+
+    with caplog.at_level("INFO", logger="normalize_wp_mapping"):
+        exit_code = script_module.run(["--data-dir", str(data_dir)])
+
+    assert exit_code == 0
+    assert target.read_text(encoding="utf-8") == "   \n"

--- a/tests/unit/test_wp_mapping_normalizer.py
+++ b/tests/unit/test_wp_mapping_normalizer.py
@@ -1,0 +1,106 @@
+"""Tests for :func:`src.utils.wp_mapping_normalizer.normalize_wp_mapping`.
+
+The helper is a pure function with two contracts:
+
+* every input shape that :class:`WorkPackageMappingEntry.from_legacy`
+  accepts must round-trip into a uniform dict-shape;
+* every other shape must be *dropped* (not raised) and counted, so the
+  one-shot CLI script can survive corrupt user data.
+"""
+
+from __future__ import annotations
+
+from src.utils.wp_mapping_normalizer import normalize_wp_mapping
+
+
+def test_all_dict_input_round_trips_with_zero_dropped() -> None:
+    raw = {
+        "PROJ-1": {
+            "openproject_id": 10,
+            "openproject_project_id": 1,
+            "jira_migration_date": "2026-04-30T12:00:00Z",
+            "updated_at": "2026-04-30T12:01:00Z",
+        },
+        "PROJ-2": {
+            "openproject_id": 11,
+            "openproject_project_id": 1,
+        },
+    }
+
+    normalized, dropped = normalize_wp_mapping(raw)
+
+    assert dropped == 0
+    assert set(normalized) == {"PROJ-1", "PROJ-2"}
+    assert normalized["PROJ-1"]["openproject_id"] == 10
+    assert normalized["PROJ-1"]["jira_key"] == "PROJ-1"
+    assert normalized["PROJ-2"]["jira_migration_date"] is None
+    assert normalized["PROJ-2"]["updated_at"] is None
+
+
+def test_all_int_input_is_promoted_to_dict_shape() -> None:
+    raw = {"PROJ-A": 1, "PROJ-B": 2, "PROJ-C": 3}
+
+    normalized, dropped = normalize_wp_mapping(raw)
+
+    assert dropped == 0
+    assert set(normalized) == {"PROJ-A", "PROJ-B", "PROJ-C"}
+    for key, expected_id in (("PROJ-A", 1), ("PROJ-B", 2), ("PROJ-C", 3)):
+        entry = normalized[key]
+        assert entry["jira_key"] == key
+        assert entry["openproject_id"] == expected_id
+        # Optional fields are present-as-None to keep the shape uniform.
+        assert entry["openproject_project_id"] is None
+        assert entry["jira_migration_date"] is None
+        assert entry["updated_at"] is None
+
+
+def test_mixed_input_unifies_to_dict_shape() -> None:
+    raw = {
+        "PROJ-D1": {"openproject_id": 100, "openproject_project_id": 9},
+        "PROJ-I1": 200,
+        "PROJ-D2": {"openproject_id": 300},
+    }
+
+    normalized, dropped = normalize_wp_mapping(raw)
+
+    assert dropped == 0
+    assert normalized["PROJ-D1"]["openproject_id"] == 100
+    assert normalized["PROJ-D1"]["openproject_project_id"] == 9
+    assert normalized["PROJ-I1"]["openproject_id"] == 200
+    assert normalized["PROJ-I1"]["openproject_project_id"] is None
+    assert normalized["PROJ-D2"]["openproject_id"] == 300
+    # Each row carries exactly the same set of keys after normalisation.
+    expected_keys = {
+        "jira_key",
+        "openproject_id",
+        "openproject_project_id",
+        "jira_migration_date",
+        "updated_at",
+    }
+    for value in normalized.values():
+        assert set(value) == expected_keys
+
+
+def test_corrupt_entries_are_dropped_and_counted() -> None:
+    raw = {
+        "PROJ-OK": {"openproject_id": 1},
+        "PROJ-STR": "not-an-id",
+        "PROJ-LIST": [1, 2, 3],
+        "PROJ-NONE": None,
+        "PROJ-MISSING-ID": {"openproject_project_id": 4},  # no openproject_id
+    }
+
+    normalized, dropped = normalize_wp_mapping(raw)
+
+    assert dropped == 4
+    assert set(normalized) == {"PROJ-OK"}
+    # Confirm the dropped keys are absent from the output entirely.
+    for key in ("PROJ-STR", "PROJ-LIST", "PROJ-NONE", "PROJ-MISSING-ID"):
+        assert key not in normalized
+
+
+def test_empty_input_yields_empty_output() -> None:
+    normalized, dropped = normalize_wp_mapping({})
+
+    assert normalized == {}
+    assert dropped == 0


### PR DESCRIPTION
## Summary

Phase 3c of [ADR-002](docs/adr/ADR-002-target-architecture.md) — closes Phase 3 of the architectural decomposition. Unifies the polymorphic \`wp_map[key]: dict | int\` shape into a single typed \`WorkPackageMappingEntry\` model and ships a forward-only normalization script for users' \`var/data/\` JSON.

### The problem

\`self.mappings.get_mapping(\"work_package\")\` returns a dict whose values are EITHER a \`dict\` shape (\`{jira_key, openproject_id, ...}\`) OR a bare \`int\` (just the OP work package ID). 20+ consumers handle both via repetitive \`isinstance(wp_entry, dict)/isinstance(wp_entry, int)\` ladders. Per the ADR's Phase 3 consequence section.

## What ships

- **\`WorkPackageMappingEntry\`** Pydantic v2 model at \`src/models/mapping/work_package_entry.py\` with \`from_legacy(key, value)\` that normalizes both legacy shapes (rejecting \`bool\` explicitly to avoid the \`isinstance(True, int)\` trap)
- **\`normalize_wp_mapping(raw)\`** helper at \`src/utils/wp_mapping_normalizer.py\` returning \`(dict[str, dict], dropped_count)\`. Bad entries are logged and counted, not silently dropped.
- **Forward-only migration script** at \`scripts/normalize_wp_mapping.py\` with \`--data-dir\`, \`--dry-run\`, atomic write (NamedTemporaryFile + os.replace), mode-preserving. Self-bootstraps \`sys.path\` so it runs under bare \`python\` or \`uv run\`.
- **\`estimates_migration.py:96-103\`** demonstrates the typed flow, replacing the \`isinstance\` ladder with \`WorkPackageMappingEntry.from_legacy(key, wp_entry).openproject_id\`. Existing \`test_estimates_migration.py\` passes unmodified.
- **Restructured** \`src/models/mapping.py\` → \`src/models/mapping/\` package (legacy \`JiraToOPMapping\` preserved as \`mapping/jira_to_op.py\`, public API unchanged — verified zero external imports).

The remaining 20+ \`isinstance\`-ladder consumers are deferred to Phase 7 per the ADR scope (\"3 reference components migrated end-to-end\" was satisfied by 3b; this PR adds one more demonstration site as a leading indicator).

## Quality gates
- \`ruff check\` — clean across full \`src/\`
- \`ruff format --check\` — 189/189 files clean
- \`mypy\` — 0 issues on \`src/models\`, \`src/utils/wp_mapping_normalizer.py\`; full \`src/\` mypy 0
- \`pytest tests/unit/\` — **986 passed**, 30 deselected (pre-existing \`Container name is required\` env-bound failures), 0 new failures
- +23 new tests (13 model, 5 normalizer, 5 script)

## Test plan
- [x] All quality gates green locally
- [x] Existing \`estimates_migration\` test still passes
- [ ] CI green