### PR TITLE
refactor(phase-4a): introduce MappingRepository Protocol + JSON adapter

### DIFF
--- a/src/domain/__init__.py
+++ b/src/domain/__init__.py
@@ -21,12 +21,14 @@ from src.domain.ids import (
     OpUserId,
     OpWorkPackageId,
 )
+from src.domain.repositories import MappingRepository
 
 __all__ = [
     "JiraAccountId",
     "JiraIssueKey",
     "JiraProjectKey",
     "JiraUserKey",
+    "MappingRepository",
     "OpCustomFieldId",
     "OpPriorityId",
     "OpProjectId",

--- a/src/domain/repositories.py
+++ b/src/domain/repositories.py
@@ -1,0 +1,85 @@
+"""Domain-layer repository Protocols (ADR-002 phase 4a).
+
+Phase 4a of ADR-002 introduces a storage abstraction for migration mappings.
+Today every consumer of mapping state reaches into the global ``cfg.mappings``
+proxy and calls instance methods on :class:`src.mappings.mappings.Mappings`.
+That coupling makes:
+
+* future storage swaps (JSON file → SQLite, S3, …) require touching every
+  call site;
+* unit tests rely on ``monkeypatch.setattr(cfg, "mappings", DummyMappings(),
+  raising=False)`` instead of explicit dependency injection;
+* the public surface of ``Mappings`` (13 methods, 256 LOC) impossible to
+  reason about in isolation from the persistence concern.
+
+The :class:`MappingRepository` Protocol pins down the *minimum* contract a
+backing store must satisfy. Higher-level convenience helpers (``get_op_user_id``,
+``get_op_project_id``, …) are deliberately **not** part of this Protocol —
+they belong on a future ``MappingsService`` that *uses* a repository.
+Keeping the Protocol thin makes the JSON-vs-SQLite swap a one-class
+implementation, not a 13-method rewrite.
+
+Adoption is gradual: this PR ships only the Protocol, a JSON-backed
+adapter, and a Fake for tests. PR 4b rewires consumers and deprecates
+``cfg.mappings``.
+
+The Protocol is :func:`typing.runtime_checkable` so tests can assert
+conformance with ``isinstance(repo, MappingRepository)`` without forcing
+implementations to subclass an ABC.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+@runtime_checkable
+class MappingRepository(Protocol):
+    """Storage abstraction for migration mappings.
+
+    A ``MappingRepository`` is keyed by a *mapping name* (a stable string
+    identifier such as ``"user_mapping"`` or ``"project_mapping"``) and
+    stores an opaque ``dict[str, Any]`` payload per name. The structure of
+    each payload is defined by the migration that owns it, not by the
+    repository — different mappings have different shapes (project mapping
+    is keyed by Jira project key, work-package mapping by issue key, etc.)
+    so the Protocol stays at the lowest common denominator: a JSON-style
+    dict.
+
+    Implementations are free to back the store with files, a database, or
+    in-memory state. They MUST NOT raise on missing-name lookups; they
+    return an empty dict instead so callers can branch on truthiness
+    without try/except boilerplate.
+    """
+
+    def get(self, name: str) -> dict[str, Any]:
+        """Return the named mapping, or an empty dict if it is missing.
+
+        The returned dict is the live payload; callers that intend to
+        mutate it locally without persisting should copy it explicitly.
+        """
+
+    def set(self, name: str, data: Mapping[str, Any]) -> None:
+        """Persist ``data`` under ``name``, overwriting any existing payload.
+
+        Implementations should treat the write as atomic relative to other
+        readers — concurrent ``get`` calls must observe either the old or
+        the new payload, never a partially-written one.
+        """
+
+    def has(self, name: str) -> bool:
+        """Whether a non-empty mapping is stored under ``name``.
+
+        Returns ``False`` for both "no record exists" and "record exists
+        but is an empty dict". Callers wanting to distinguish those cases
+        should use :meth:`all_names` instead.
+        """
+
+    def all_names(self) -> list[str]:
+        """List every mapping name currently known to the repository."""
+
+
+__all__ = ["MappingRepository"]

--- a/src/infrastructure/__init__.py
+++ b/src/infrastructure/__init__.py
@@ -1,0 +1,16 @@
+"""Infrastructure layer for j2o (ADR-002 phases 4+).
+
+This package will host adapters that bridge the domain layer (see
+:mod:`src.domain`) to concrete I/O concerns — filesystems, databases,
+HTTP clients, and so on. Phase 4a starts the tree with the JSON-backed
+mapping repository under :mod:`src.infrastructure.persistence`; later
+phases will move the existing client/persistence modules into their
+target subpackages.
+
+The split between :mod:`src.domain` and :mod:`src.infrastructure` lets
+us keep the Protocols framework-agnostic while concentrating I/O code
+where it can be swapped wholesale (JSON → SQLite, in-process →
+distributed cache, …) without touching domain consumers.
+"""
+
+from __future__ import annotations

--- a/src/infrastructure/persistence/__init__.py
+++ b/src/infrastructure/persistence/__init__.py
@@ -1,0 +1,14 @@
+"""Persistence adapters for j2o (ADR-002 phase 4a).
+
+Concrete implementations of the domain repository Protocols. Today this
+package only ships :class:`JsonFileMappingRepository`; PR 4b will rewire
+consumers to depend on the Protocol instead of the legacy
+``cfg.mappings`` proxy, and a future phase may add a SQLite-backed
+implementation alongside the JSON one.
+"""
+
+from __future__ import annotations
+
+from src.infrastructure.persistence.mapping_repo import JsonFileMappingRepository
+
+__all__ = ["JsonFileMappingRepository"]

--- a/src/infrastructure/persistence/mapping_repo.py
+++ b/src/infrastructure/persistence/mapping_repo.py
@@ -1,0 +1,235 @@
+"""JSON-file-backed :class:`MappingRepository` adapter (ADR-002 phase 4a).
+
+Mappings are stored one-per-file under a configurable data directory
+using the convention::
+
+    <data_dir>/<name>.json
+
+where ``name`` is the *full filename stem* passed to :meth:`get`,
+:meth:`set`, and friends. Today's :class:`src.mappings.mappings.Mappings`
+class hardcodes filenames like ``user_mapping.json`` and
+``project_mapping.json``; this adapter expects callers to pass
+``"user_mapping"`` / ``"project_mapping"`` as the name. PR 4b will
+update consumers to use the full stem; the legacy
+:meth:`Mappings.get_mapping` helper does the ``"user"`` →
+``"user_mapping"`` conversion under the hood today.
+
+Writes go through an atomic ``tempfile + os.replace`` dance that
+mirrors the destination's file mode onto the new file before the
+rename, so file permissions survive the swap. The same pattern is used
+in :mod:`scripts.normalize_wp_mapping`; we keep the implementations
+parallel rather than extracting a shared helper because the script is a
+forward-only one-shot whose semantics we explicitly do not want to
+couple to runtime adapter behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_module_logger = logging.getLogger(__name__)
+
+
+class JsonFileMappingRepository:
+    """Filesystem adapter implementing :class:`MappingRepository`.
+
+    The repository keeps a small in-memory cache: once a mapping has
+    been read or written through this instance, subsequent :meth:`get`
+    calls return the cached payload without touching disk. The cache is
+    invalidated on every :meth:`set` (because we just wrote a fresh
+    value) and on construction (cold start).
+
+    The cache is **per-instance** — multiple processes or instances
+    pointed at the same data directory will not see each other's
+    in-memory writes until the next disk read. That matches the
+    original :class:`Mappings` behaviour and is sufficient for the
+    single-process migration runtime.
+
+    The adapter satisfies :class:`src.domain.repositories.MappingRepository`
+    structurally; we deliberately do not inherit from the Protocol so
+    importers do not pay the runtime cost of Protocol metaclass
+    resolution on every instantiation.
+    """
+
+    JSON_SUFFIX = ".json"
+
+    def __init__(
+        self,
+        data_dir: Path,
+        *,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        """Create a repository pointed at ``data_dir``.
+
+        Args:
+            data_dir: Directory holding ``<name>.json`` files. Created on
+                first :meth:`set` if it does not yet exist.
+            logger: Optional logger for diagnostics. Defaults to a module
+                logger so adapter messages are filterable independently
+                of the rest of the codebase.
+
+        """
+        self._data_dir: Path = data_dir
+        self._logger: logging.Logger = logger or _module_logger
+        # Cache of name → payload. Populated lazily; invalidated on set.
+        self._cache: dict[str, dict[str, Any]] = {}
+
+    # ── Public Protocol surface ──────────────────────────────────────
+
+    def get(self, name: str) -> dict[str, Any]:
+        """Return the named mapping, or an empty dict if missing.
+
+        Caches the result in-memory; subsequent calls for the same
+        ``name`` return the cached payload without re-reading the file.
+        Missing files and malformed JSON both yield an empty dict; the
+        latter is logged at warning level so operators notice corrupt
+        state without crashing the migration.
+        """
+        if name in self._cache:
+            return self._cache[name]
+        payload = self._read_from_disk(name)
+        self._cache[name] = payload
+        return payload
+
+    def set(self, name: str, data: Mapping[str, Any]) -> None:
+        """Persist ``data`` under ``name`` atomically.
+
+        The write goes to a tempfile in the same directory and is
+        promoted with :func:`os.replace`, so concurrent readers see
+        either the previous or the new value, never a half-written
+        file. The destination's file mode is mirrored on the tempfile
+        before the rename so existing permissions survive.
+        """
+        # Defensive copy: the in-memory cache must not alias the
+        # caller's payload, otherwise their mutations would silently
+        # affect future ``get`` results.
+        payload: dict[str, Any] = dict(data)
+        target = self._path_for(name)
+        self._atomic_write_json(target, payload)
+        self._cache[name] = payload
+
+    def has(self, name: str) -> bool:
+        """Whether a non-empty mapping is stored under ``name``.
+
+        We re-use :meth:`get` so the in-memory cache stays consistent
+        with subsequent reads; a slow first call (disk I/O) is the
+        worst case.
+        """
+        return bool(self.get(name))
+
+    def all_names(self) -> list[str]:
+        """List every ``<name>.json`` stem in the data directory.
+
+        Returns the union of in-memory cached names and on-disk files,
+        sorted alphabetically for stable output. The data directory not
+        existing yet is treated as "no mappings", not an error.
+        """
+        names: set[str] = set(self._cache)
+        if self._data_dir.is_dir():
+            for entry in self._data_dir.iterdir():
+                if entry.is_file() and entry.suffix == self.JSON_SUFFIX:
+                    names.add(entry.stem)
+        return sorted(names)
+
+    # ── Internal helpers ─────────────────────────────────────────────
+
+    def _path_for(self, name: str) -> Path:
+        """Resolve ``name`` to ``<data_dir>/<name>.json``."""
+        return self._data_dir / f"{name}{self.JSON_SUFFIX}"
+
+    def _read_from_disk(self, name: str) -> dict[str, Any]:
+        """Read and parse ``<data_dir>/<name>.json``.
+
+        Returns an empty dict for any non-fatal failure (missing file,
+        malformed JSON, non-dict top-level shape). Malformed and
+        wrong-shape payloads emit a warning so the operator can
+        investigate; missing files are intentionally silent because
+        cold-start migrations expect them.
+        """
+        path = self._path_for(name)
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                raw = json.load(fh)
+        except FileNotFoundError:
+            return {}
+        except json.JSONDecodeError as exc:
+            self._logger.warning(
+                "Mapping file %s is malformed JSON: %s",
+                path,
+                exc,
+            )
+            return {}
+        except OSError as exc:
+            self._logger.warning("Could not read mapping file %s: %s", path, exc)
+            return {}
+
+        if not isinstance(raw, dict):
+            self._logger.warning(
+                "Mapping file %s has unexpected top-level shape %s; expected dict.",
+                path,
+                type(raw).__name__,
+            )
+            return {}
+        return raw
+
+    def _atomic_write_json(
+        self,
+        target: Path,
+        payload: dict[str, Any],
+    ) -> None:
+        """Write ``payload`` to ``target`` atomically, preserving file mode.
+
+        Mirrors the helper in :mod:`scripts.normalize_wp_mapping` so the
+        runtime adapter and the one-shot migration script behave
+        identically with respect to permissions and atomicity.
+        """
+        target_dir = target.parent
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        # Capture the existing destination mode (if any) so we can
+        # restore it after the rename. First-run writes have nothing to
+        # mirror.
+        source_mode: int | None
+        try:
+            source_mode = target.stat().st_mode & 0o777
+        except FileNotFoundError:
+            source_mode = None
+
+        fd, tmp_path_str = tempfile.mkstemp(
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            dir=str(target_dir),
+        )
+        tmp_path = Path(tmp_path_str)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2, sort_keys=True)
+                fh.write("\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            if source_mode is not None:
+                tmp_path.chmod(source_mode)
+            tmp_path.replace(target)
+        except Exception:
+            # Best-effort cleanup of the orphaned tempfile if anything
+            # goes wrong before the atomic rename.
+            if tmp_path.exists():
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    self._logger.warning(
+                        "Failed to remove tempfile %s",
+                        tmp_path,
+                    )
+            raise
+
+
+__all__ = ["JsonFileMappingRepository"]

--- a/src/infrastructure/persistence/mapping_repo.py
+++ b/src/infrastructure/persistence/mapping_repo.py
@@ -25,6 +25,7 @@ couple to runtime adapter behaviour.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -43,9 +44,21 @@ class JsonFileMappingRepository:
 
     The repository keeps a small in-memory cache: once a mapping has
     been read or written through this instance, subsequent :meth:`get`
-    calls return the cached payload without touching disk. The cache is
-    invalidated on every :meth:`set` (because we just wrote a fresh
-    value) and on construction (cold start).
+    calls return the cached payload without touching disk. Each
+    :meth:`set` updates only the cache entry for the written name —
+    other names retain their cached values. Missing names are NOT
+    cached (so a transient :meth:`get` of an absent mapping does not
+    pollute :meth:`all_names`).
+
+    :meth:`get` and :meth:`set` deep-copy their payloads at the
+    boundary so mutations on a returned dict cannot leak into the
+    cache, and mutations of a dict passed into :meth:`set` after the
+    call cannot leak in either. The cost is acceptable for migration
+    mappings (sizes typically under 100k entries; deepcopy is
+    micro-second per call at that scale) and the alternative —
+    callers that mutate the live cache and silently corrupt later
+    reads — is the kind of subtle bug a Repository pattern exists to
+    prevent.
 
     The cache is **per-instance** — multiple processes or instances
     pointed at the same data directory will not see each other's
@@ -88,16 +101,20 @@ class JsonFileMappingRepository:
         """Return the named mapping, or an empty dict if missing.
 
         Caches the result in-memory; subsequent calls for the same
-        ``name`` return the cached payload without re-reading the file.
-        Missing files and malformed JSON both yield an empty dict; the
-        latter is logged at warning level so operators notice corrupt
-        state without crashing the migration.
+        ``name`` return a fresh deep copy of the cached payload without
+        re-reading the file. Missing names are NOT cached (so they
+        don't pollute :meth:`all_names`); a future :meth:`set` for the
+        same name still works as expected. Malformed JSON is logged at
+        warning level and yields an empty dict without caching.
         """
         if name in self._cache:
-            return self._cache[name]
+            # Deep copy on read: callers can mutate the returned dict
+            # freely without poisoning the cache for the next call.
+            return copy.deepcopy(self._cache[name])
         payload = self._read_from_disk(name)
-        self._cache[name] = payload
-        return payload
+        if payload:
+            self._cache[name] = payload
+        return copy.deepcopy(payload)
 
     def set(self, name: str, data: Mapping[str, Any]) -> None:
         """Persist ``data`` under ``name`` atomically.
@@ -108,10 +125,11 @@ class JsonFileMappingRepository:
         file. The destination's file mode is mirrored on the tempfile
         before the rename so existing permissions survive.
         """
-        # Defensive copy: the in-memory cache must not alias the
-        # caller's payload, otherwise their mutations would silently
-        # affect future ``get`` results.
-        payload: dict[str, Any] = dict(data)
+        # Deep copy: migration mappings are nested dicts (e.g.
+        # ``{"PROJ-1": {"openproject_id": 7, ...}}``). A shallow
+        # ``dict(data)`` would let a caller mutate a nested value
+        # after :meth:`set` and silently corrupt the cached payload.
+        payload: dict[str, Any] = copy.deepcopy(dict(data))
         target = self._path_for(name)
         self._atomic_write_json(target, payload)
         self._cache[name] = payload
@@ -210,7 +228,21 @@ class JsonFileMappingRepository:
         )
         tmp_path = Path(tmp_path_str)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            try:
+                fh = os.fdopen(fd, "w", encoding="utf-8")
+            except Exception:
+                # ``os.fdopen`` failed before we could hand the fd to
+                # the file object's lifecycle — close it explicitly so
+                # the underlying descriptor isn't leaked.
+                try:
+                    os.close(fd)
+                except OSError:
+                    self._logger.warning(
+                        "Failed to close tempfile fd for %s",
+                        tmp_path,
+                    )
+                raise
+            with fh:
                 json.dump(payload, fh, indent=2, sort_keys=True)
                 fh.write("\n")
                 fh.flush()

--- a/tests/unit/test_fake_mapping_repository.py
+++ b/tests/unit/test_fake_mapping_repository.py
@@ -1,0 +1,143 @@
+"""Unit tests for :class:`FakeMappingRepository` (ADR-002 phase 4a)."""
+
+from __future__ import annotations
+
+from src.domain.repositories import MappingRepository
+from tests.utils.fake_mapping_repository import FakeMappingRepository
+
+
+class TestProtocolConformance:
+    """Structural conformance with the MappingRepository Protocol."""
+
+    def test_satisfies_protocol(self) -> None:
+        fake = FakeMappingRepository()
+        assert isinstance(fake, MappingRepository)
+
+
+class TestConstruction:
+    """Behaviour of :meth:`FakeMappingRepository.__init__`."""
+
+    def test_empty_default(self) -> None:
+        fake = FakeMappingRepository()
+        assert fake.all_names() == []
+        assert fake.get("anything") == {}
+
+    def test_initial_state(self) -> None:
+        fake = FakeMappingRepository(
+            initial={
+                "user_mapping": {"jira-1": {"openproject_id": 42}},
+                "project_mapping": {"ABC": {"openproject_id": 7}},
+            },
+        )
+        assert fake.get("user_mapping") == {"jira-1": {"openproject_id": 42}}
+        assert fake.get("project_mapping") == {"ABC": {"openproject_id": 7}}
+
+    def test_initial_is_defensively_copied(self) -> None:
+        seed: dict[str, dict[str, int]] = {"user_mapping": {"a": 1}}
+        fake = FakeMappingRepository(initial=seed)
+        # Mutating the seed must not bleed into the fake's store.
+        seed["user_mapping"]["a"] = 999
+        assert fake.get("user_mapping") == {"a": 1}
+
+
+class TestGet:
+    """Behaviour of :meth:`FakeMappingRepository.get`."""
+
+    def test_missing_returns_empty_dict(self) -> None:
+        fake = FakeMappingRepository()
+        assert fake.get("nonexistent") == {}
+
+    def test_present_returns_stored_value(self) -> None:
+        fake = FakeMappingRepository(initial={"user_mapping": {"a": 1}})
+        assert fake.get("user_mapping") == {"a": 1}
+
+
+class TestSet:
+    """Behaviour of :meth:`FakeMappingRepository.set`."""
+
+    def test_set_stores_value(self) -> None:
+        fake = FakeMappingRepository()
+        fake.set("user_mapping", {"a": 1})
+        assert fake.get("user_mapping") == {"a": 1}
+
+    def test_set_overwrites_existing(self) -> None:
+        fake = FakeMappingRepository(initial={"user_mapping": {"a": 1}})
+        fake.set("user_mapping", {"b": 2})
+        assert fake.get("user_mapping") == {"b": 2}
+
+    def test_set_does_not_alias_input(self) -> None:
+        fake = FakeMappingRepository()
+        payload: dict[str, int] = {"a": 1}
+        fake.set("user_mapping", payload)
+        payload["a"] = 999
+        assert fake.get("user_mapping") == {"a": 1}
+
+
+class TestHas:
+    """Behaviour of :meth:`FakeMappingRepository.has`."""
+
+    def test_missing_returns_false(self) -> None:
+        fake = FakeMappingRepository()
+        assert fake.has("nonexistent") is False
+
+    def test_empty_dict_returns_false(self) -> None:
+        fake = FakeMappingRepository(initial={"empty_mapping": {}})
+        assert fake.has("empty_mapping") is False
+
+    def test_non_empty_returns_true(self) -> None:
+        fake = FakeMappingRepository(initial={"user_mapping": {"a": 1}})
+        assert fake.has("user_mapping") is True
+
+
+class TestAllNames:
+    """Behaviour of :meth:`FakeMappingRepository.all_names`."""
+
+    def test_empty(self) -> None:
+        fake = FakeMappingRepository()
+        assert fake.all_names() == []
+
+    def test_sorted(self) -> None:
+        fake = FakeMappingRepository(
+            initial={
+                "user_mapping": {"a": 1},
+                "project_mapping": {"b": 2},
+                "issue_type_mapping": {"c": 3},
+            },
+        )
+        assert fake.all_names() == [
+            "issue_type_mapping",
+            "project_mapping",
+            "user_mapping",
+        ]
+
+
+class TestSetAll:
+    """Behaviour of :meth:`FakeMappingRepository.set_all`."""
+
+    def test_replaces_entire_store(self) -> None:
+        fake = FakeMappingRepository(
+            initial={"user_mapping": {"a": 1}, "stale": {"x": 0}},
+        )
+        fake.set_all(
+            {
+                "user_mapping": {"b": 2},
+                "project_mapping": {"c": 3},
+            },
+        )
+        assert fake.all_names() == ["project_mapping", "user_mapping"]
+        assert fake.get("user_mapping") == {"b": 2}
+        assert fake.get("project_mapping") == {"c": 3}
+        # Stale key was dropped, not merged.
+        assert fake.get("stale") == {}
+
+    def test_set_all_does_not_alias_input(self) -> None:
+        fake = FakeMappingRepository()
+        seed: dict[str, dict[str, int]] = {"user_mapping": {"a": 1}}
+        fake.set_all(seed)
+        seed["user_mapping"]["a"] = 999
+        assert fake.get("user_mapping") == {"a": 1}
+
+    def test_set_all_empty_clears_store(self) -> None:
+        fake = FakeMappingRepository(initial={"user_mapping": {"a": 1}})
+        fake.set_all({})
+        assert fake.all_names() == []

--- a/tests/unit/test_repositories_mapping_repo.py
+++ b/tests/unit/test_repositories_mapping_repo.py
@@ -1,0 +1,247 @@
+"""Unit tests for :class:`JsonFileMappingRepository` (ADR-002 phase 4a)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import stat
+from pathlib import Path
+
+import pytest
+
+from src.domain.repositories import MappingRepository
+from src.infrastructure.persistence.mapping_repo import JsonFileMappingRepository
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    """Per-test data directory."""
+    target = tmp_path / "data"
+    target.mkdir()
+    return target
+
+
+@pytest.fixture
+def repo(data_dir: Path) -> JsonFileMappingRepository:
+    """Repository pointed at the per-test data dir."""
+    return JsonFileMappingRepository(data_dir=data_dir)
+
+
+class TestProtocolConformance:
+    """Structural conformance with the MappingRepository Protocol."""
+
+    def test_satisfies_protocol(self, repo: JsonFileMappingRepository) -> None:
+        assert isinstance(repo, MappingRepository)
+
+
+class TestGet:
+    """Behaviour of :meth:`JsonFileMappingRepository.get`."""
+
+    def test_missing_file_returns_empty_dict(
+        self,
+        repo: JsonFileMappingRepository,
+    ) -> None:
+        assert repo.get("nonexistent_mapping") == {}
+
+    def test_present_file_returns_loaded_dict(
+        self,
+        repo: JsonFileMappingRepository,
+        data_dir: Path,
+    ) -> None:
+        payload = {"jira-1": {"openproject_id": 42}, "jira-2": {"openproject_id": 7}}
+        (data_dir / "user_mapping.json").write_text(
+            json.dumps(payload),
+            encoding="utf-8",
+        )
+        assert repo.get("user_mapping") == payload
+
+    def test_get_caches_in_memory(
+        self,
+        repo: JsonFileMappingRepository,
+        data_dir: Path,
+    ) -> None:
+        path = data_dir / "user_mapping.json"
+        path.write_text(json.dumps({"a": 1}), encoding="utf-8")
+
+        first = repo.get("user_mapping")
+        # Mutate the on-disk file; cached call should ignore the change.
+        path.write_text(json.dumps({"a": 999}), encoding="utf-8")
+        second = repo.get("user_mapping")
+
+        assert first == second == {"a": 1}
+
+    def test_malformed_json_returns_empty_and_warns(
+        self,
+        repo: JsonFileMappingRepository,
+        data_dir: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        (data_dir / "broken_mapping.json").write_text(
+            "{not valid json",
+            encoding="utf-8",
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = repo.get("broken_mapping")
+
+        assert result == {}
+        assert any("malformed JSON" in record.message for record in caplog.records)
+
+    def test_non_dict_top_level_returns_empty_and_warns(
+        self,
+        repo: JsonFileMappingRepository,
+        data_dir: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        (data_dir / "list_mapping.json").write_text("[1, 2, 3]", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING):
+            result = repo.get("list_mapping")
+
+        assert result == {}
+        assert any("unexpected top-level shape" in record.message for record in caplog.records)
+
+
+class TestSet:
+    """Behaviour of :meth:`JsonFileMappingRepository.set`."""
+
+    def test_set_then_get_in_process(
+        self,
+        repo: JsonFileMappingRepository,
+    ) -> None:
+        repo.set("user_mapping", {"jira-1": {"openproject_id": 42}})
+        assert repo.get("user_mapping") == {"jira-1": {"openproject_id": 42}}
+
+    def test_set_round_trips_through_disk(
+        self,
+        repo: JsonFileMappingRepository,
+        data_dir: Path,
+    ) -> None:
+        payload = {"jira-1": {"openproject_id": 42}}
+        repo.set("user_mapping", payload)
+
+        # Read directly from disk via a fresh repo instance to bypass
+        # the in-process cache.
+        fresh = JsonFileMappingRepository(data_dir=data_dir)
+        assert fresh.get("user_mapping") == payload
+
+    def test_set_overwrites_existing(
+        self,
+        repo: JsonFileMappingRepository,
+    ) -> None:
+        repo.set("user_mapping", {"jira-1": {"openproject_id": 1}})
+        repo.set("user_mapping", {"jira-2": {"openproject_id": 2}})
+        assert repo.get("user_mapping") == {"jira-2": {"openproject_id": 2}}
+
+    def test_set_does_not_alias_caller_payload(
+        self,
+        repo: JsonFileMappingRepository,
+    ) -> None:
+        payload: dict[str, int] = {"a": 1}
+        repo.set("mapping", payload)
+        payload["a"] = 999
+        # Cached value must not reflect post-set mutations of the input.
+        assert repo.get("mapping") == {"a": 1}
+
+    def test_set_cleans_up_tempfiles(
+        self,
+        repo: JsonFileMappingRepository,
+        data_dir: Path,
+    ) -> None:
+        repo.set("user_mapping", {"a": 1})
+
+        # No leftover ``.tmp`` files from the atomic rename.
+        leftover = [p for p in data_dir.iterdir() if p.suffix == ".tmp"]
+        assert leftover == []
+
+        # The expected file is the only artefact in the directory.
+        assert {p.name for p in data_dir.iterdir()} == {"user_mapping.json"}
+
+    def test_set_preserves_file_mode(
+        self,
+        repo: JsonFileMappingRepository,
+        data_dir: Path,
+    ) -> None:
+        repo.set("user_mapping", {"a": 1})
+        path = data_dir / "user_mapping.json"
+        path.chmod(0o600)
+
+        repo.set("user_mapping", {"a": 2})
+
+        # Mode is mirrored from the previous file before os.replace.
+        actual_mode = stat.S_IMODE(path.stat().st_mode)
+        assert actual_mode == 0o600
+
+    def test_set_creates_data_dir_if_missing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        target_dir = tmp_path / "deep" / "nested" / "data"
+        # Note: directory does not exist yet.
+        repo = JsonFileMappingRepository(data_dir=target_dir)
+        repo.set("user_mapping", {"a": 1})
+
+        assert target_dir.is_dir()
+        assert (target_dir / "user_mapping.json").is_file()
+
+
+class TestHas:
+    """Behaviour of :meth:`JsonFileMappingRepository.has`."""
+
+    def test_missing_returns_false(
+        self,
+        repo: JsonFileMappingRepository,
+    ) -> None:
+        assert repo.has("nonexistent_mapping") is False
+
+    def test_empty_dict_returns_false(
+        self,
+        repo: JsonFileMappingRepository,
+        data_dir: Path,
+    ) -> None:
+        (data_dir / "empty_mapping.json").write_text("{}", encoding="utf-8")
+        assert repo.has("empty_mapping") is False
+
+    def test_non_empty_returns_true(
+        self,
+        repo: JsonFileMappingRepository,
+    ) -> None:
+        repo.set("user_mapping", {"a": 1})
+        assert repo.has("user_mapping") is True
+
+
+class TestAllNames:
+    """Behaviour of :meth:`JsonFileMappingRepository.all_names`."""
+
+    def test_empty_directory(
+        self,
+        repo: JsonFileMappingRepository,
+    ) -> None:
+        assert repo.all_names() == []
+
+    def test_lists_json_stems(
+        self,
+        repo: JsonFileMappingRepository,
+        data_dir: Path,
+    ) -> None:
+        (data_dir / "user_mapping.json").write_text("{}", encoding="utf-8")
+        (data_dir / "project_mapping.json").write_text("{}", encoding="utf-8")
+        # Non-JSON files are ignored.
+        (data_dir / "README.md").write_text("# notes", encoding="utf-8")
+
+        assert repo.all_names() == ["project_mapping", "user_mapping"]
+
+    def test_includes_in_memory_only_writes(
+        self,
+        repo: JsonFileMappingRepository,
+    ) -> None:
+        repo.set("freshly_written", {"a": 1})
+        assert "freshly_written" in repo.all_names()
+
+    def test_missing_data_dir_returns_empty(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # Directory does not exist yet; no error, just nothing to list.
+        repo = JsonFileMappingRepository(data_dir=tmp_path / "ghost")
+        assert repo.all_names() == []

--- a/tests/utils/fake_mapping_repository.py
+++ b/tests/utils/fake_mapping_repository.py
@@ -16,6 +16,7 @@ the system under test.
 
 from __future__ import annotations
 
+import copy
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -39,34 +40,34 @@ class FakeMappingRepository:
 
         Args:
             initial: Optional name → payload mapping to seed the store.
-                The initial mappings are deep-enough copied (one level
-                of dict) so callers can mutate ``initial`` after the
-                constructor without affecting the fake.
+                Each entry is deep-copied so mutations in test fixtures
+                cannot leak into the fake's internal state.
 
         """
         self._store: dict[str, dict[str, Any]] = {}
         if initial is not None:
             for name, payload in initial.items():
-                self._store[name] = dict(payload)
+                self._store[name] = copy.deepcopy(dict(payload))
 
     # ── Protocol surface ─────────────────────────────────────────────
 
     def get(self, name: str) -> dict[str, Any]:
         """Return the named mapping, or an empty dict if missing.
 
-        Returns the live dict from the store (no defensive copy on
-        read). Tests that need an isolated copy should invoke
-        :func:`dict` on the result.
+        Returns a deep copy so callers can mutate the result freely
+        without leaking into the fake's state — symmetric with
+        :class:`JsonFileMappingRepository`.
         """
-        return self._store.get(name, {})
+        return copy.deepcopy(self._store.get(name, {}))
 
     def set(self, name: str, data: Mapping[str, Any]) -> None:
         """Store ``data`` under ``name``, replacing any existing payload.
 
-        The payload is shallow-copied so the test fixture cannot mutate
-        the stored value via the original reference.
+        The payload is deep-copied so the test fixture cannot mutate
+        the stored value via the original reference, even for nested
+        dicts.
         """
-        self._store[name] = dict(data)
+        self._store[name] = copy.deepcopy(dict(data))
 
     def has(self, name: str) -> bool:
         """Whether a non-empty mapping is stored under ``name``."""
@@ -82,10 +83,10 @@ class FakeMappingRepository:
         """Bulk-replace the entire store with ``mappings``.
 
         Existing entries not present in ``mappings`` are dropped; this
-        is "replace", not "merge". Each payload is shallow-copied for
-        the same isolation reason as :meth:`set`.
+        is "replace", not "merge". Each payload is deep-copied for the
+        same isolation reason as :meth:`set`.
         """
-        self._store = {name: dict(payload) for name, payload in mappings.items()}
+        self._store = {name: copy.deepcopy(dict(payload)) for name, payload in mappings.items()}
 
 
 __all__ = ["FakeMappingRepository"]

--- a/tests/utils/fake_mapping_repository.py
+++ b/tests/utils/fake_mapping_repository.py
@@ -1,0 +1,91 @@
+"""In-memory :class:`MappingRepository` for unit tests (ADR-002 phase 4a).
+
+PR 4a introduces the :class:`src.domain.repositories.MappingRepository`
+Protocol; PR 4b will rewire consumers to depend on it explicitly. To
+make that migration tractable, tests need a lightweight implementation
+they can pass into migration constructors instead of monkey-patching
+``cfg.mappings``.
+
+:class:`FakeMappingRepository` is that implementation: a single
+``dict[str, dict[str, Any]]`` backing store with no I/O, no caching
+quirks, and no atomicity story to worry about. It is intentionally
+chatty about its semantics — :meth:`set` and :meth:`set_all` defensively
+copy their inputs so test fixtures cannot accidentally share state with
+the system under test.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class FakeMappingRepository:
+    """In-memory ``MappingRepository`` for unit tests.
+
+    The fake satisfies :class:`src.domain.repositories.MappingRepository`
+    structurally — Protocol conformance can be asserted with
+    ``isinstance(fake, MappingRepository)`` because the Protocol is
+    declared ``@runtime_checkable``.
+    """
+
+    def __init__(
+        self,
+        initial: Mapping[str, Mapping[str, Any]] | None = None,
+    ) -> None:
+        """Create a fake repository, optionally pre-populated.
+
+        Args:
+            initial: Optional name → payload mapping to seed the store.
+                The initial mappings are deep-enough copied (one level
+                of dict) so callers can mutate ``initial`` after the
+                constructor without affecting the fake.
+
+        """
+        self._store: dict[str, dict[str, Any]] = {}
+        if initial is not None:
+            for name, payload in initial.items():
+                self._store[name] = dict(payload)
+
+    # ── Protocol surface ─────────────────────────────────────────────
+
+    def get(self, name: str) -> dict[str, Any]:
+        """Return the named mapping, or an empty dict if missing.
+
+        Returns the live dict from the store (no defensive copy on
+        read). Tests that need an isolated copy should invoke
+        :func:`dict` on the result.
+        """
+        return self._store.get(name, {})
+
+    def set(self, name: str, data: Mapping[str, Any]) -> None:
+        """Store ``data`` under ``name``, replacing any existing payload.
+
+        The payload is shallow-copied so the test fixture cannot mutate
+        the stored value via the original reference.
+        """
+        self._store[name] = dict(data)
+
+    def has(self, name: str) -> bool:
+        """Whether a non-empty mapping is stored under ``name``."""
+        return bool(self._store.get(name))
+
+    def all_names(self) -> list[str]:
+        """Sorted list of every name stored in the fake."""
+        return sorted(self._store)
+
+    # ── Test convenience ─────────────────────────────────────────────
+
+    def set_all(self, mappings: Mapping[str, Mapping[str, Any]]) -> None:
+        """Bulk-replace the entire store with ``mappings``.
+
+        Existing entries not present in ``mappings`` are dropped; this
+        is "replace", not "merge". Each payload is shallow-copied for
+        the same isolation reason as :meth:`set`.
+        """
+        self._store = {name: dict(payload) for name, payload in mappings.items()}
+
+
+__all__ = ["FakeMappingRepository"]


### PR DESCRIPTION
## Summary

Phase 4a of [ADR-002](docs/adr/ADR-002-target-architecture.md) — kicks off the Repository pattern that ADR-002 cites as a key future-storage-swap seam:

> "Future storage swap is one file. \`JsonFileMappingRepository → SQLiteMappingRepository\` is a Protocol implementation, not a rewrite."
>
> "FakeMappingRepository and Protocol-based stubs replace global monkeypatching of \`cfg.mappings\`."

## What ships

**Protocol** (\`src/domain/repositories.py\`): \`MappingRepository\` — minimal surface (\`get\`, \`set\`, \`has\`, \`all_names\`). Marked \`@runtime_checkable\` so tests can \`isinstance(repo, MappingRepository)\`. Convenience helpers like \`get_op_project_id\` deliberately stay on the legacy \`Mappings\` class — they're domain-service operations, not repository operations.

**JSON adapter** (\`src/infrastructure/persistence/mapping_repo.py\`): \`JsonFileMappingRepository\`. Lazy-loaded in-memory cache, atomic writes (NamedTemporaryFile + os.replace), mode-preserving (chmod the tempfile to source mode before rename), and the malformed-JSON / missing-file behavior matches the legacy \`Mappings._load_mapping\` exactly.

**Fake** (\`tests/utils/fake_mapping_repository.py\`): \`FakeMappingRepository\` with \`set_all\` for bulk test setup. Replaces \`monkeypatch.setattr(cfg, \"mappings\", DummyMappings(), raising=False)\` once consumers are wired (PR 4b).

## Directory choice

The ADR's Phase 5 calls for layer reorganization (\`migrations/ → application/components/\`, \`clients/ → infrastructure/\`). Phase 4a starts the \`src/infrastructure/persistence/\` tree now — new modules can land in their target layer immediately, so Phase 5's move is smaller. \`src/domain/\` already exists from Phase 3a (\`domain/ids.py\` for branded IDs); \`domain/repositories.py\` joins it.

## Filename-stem convention

The Protocol's \`name\` parameter is the filename's stem without \`.json\` (e.g. \`get(\"user_mapping\")\` reads \`<data_dir>/user_mapping.json\`). This avoids the legacy \`Mappings\` class's hardcoded-name → filename split. PR 4b will rewrite call sites to pass full stems; today's callers route through \`Mappings.get_mapping(name)\` which does the conversion under the hood.

## Quality gates

- \`ruff check\` (new files) — clean
- \`ruff format --check .\` — 365 files clean
- \`mypy src/domain src/infrastructure\` — 0 errors on 6 files
- \`pytest\` (new tests) — **37 passed** (20 adapter + 17 fake)
- \`pytest tests/unit/\` — **1038 passed**, 30 deselected (pre-existing env-config failures unchanged from baseline)

## Pure-addition discipline

- Did not modify \`src/mappings/mappings.py\`, \`src/config/__init__.py\`, \`src/migrations/base_migration.py\`, or any consumer of \`self.mappings\` / \`config.mappings\`. Those are PR 4b's scope.

## Test plan
- [x] All quality gates green locally
- [ ] CI green
- [ ] At least one human review pass