### PR TITLE
refactor(phase-4b): wire Mappings facade through MappingRepository

### DIFF
--- a/src/infrastructure/persistence/mapping_repo.py
+++ b/src/infrastructure/persistence/mapping_repo.py
@@ -33,10 +33,28 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from pydantic import BaseModel
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
 _module_logger = logging.getLogger(__name__)
+
+
+def _json_default(value: Any) -> Any:
+    """Best-effort encoder for non-JSON-native objects.
+
+    Mirrors :func:`src.utils.data_handler._json_default` so the repository
+    handles the same shapes the legacy ``Mappings.set_mapping`` did.
+    Falling back to ``str(value)`` keeps test fixtures (which sometimes
+    pass ``unittest.mock.MagicMock`` instances through migration
+    bookkeeping) writable rather than raising ``TypeError``.
+    """
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    return str(value)
 
 
 class JsonFileMappingRepository:
@@ -243,7 +261,7 @@ class JsonFileMappingRepository:
                     )
                 raise
             with fh:
-                json.dump(payload, fh, indent=2, sort_keys=True)
+                json.dump(payload, fh, indent=2, sort_keys=True, default=_json_default)
                 fh.write("\n")
                 fh.flush()
                 os.fsync(fh.fileno())

--- a/src/mappings/mappings.py
+++ b/src/mappings/mappings.py
@@ -1,22 +1,58 @@
-"""Mappings module for loading and accessing persisted migration mappings."""
+"""Mappings facade over :class:`MappingRepository` (ADR-002 phase 4b).
+
+Phase 4a introduced :class:`src.domain.repositories.MappingRepository` and a
+JSON-file adapter. Phase 4b makes :class:`Mappings` a thin facade over that
+repository while preserving the legacy public API:
+
+* legacy ``mappings.<name>_mapping`` attribute access (read and write) is
+  served by Python ``property`` descriptors that delegate to the repository
+  on first read and cache the dict for stable identity across subsequent
+  reads;
+* assignment to ``mappings.<name>_mapping = X`` updates the in-memory
+  override without writing to disk — matching the legacy behaviour where
+  only :meth:`set_mapping` persists;
+* :meth:`get_mapping` / :meth:`set_mapping` / :meth:`has_mapping` accept
+  legacy short names ("user", "project", "work_package", …) and resolve
+  them to the repository's full stem ("user_mapping", …) via the
+  :data:`SHORT_NAME_TO_STEM` table.
+
+The op-id helpers (``get_op_user_id`` etc.) intentionally stay on this
+class — they are domain-service convenience composing repository reads
+with name-by-name dict lookups, and the ADR keeps :class:`MappingRepository`
+deliberately minimal.
+
+Tests can inject a :class:`FakeMappingRepository` via the new ``repo=``
+keyword on :meth:`__init__`, bypassing the global ``cfg.mappings`` proxy
+and the ``monkeypatch.setattr(cfg, "mappings", DummyMappings())`` ritual.
+The legacy proxy stays in place; this PR only adds the seam.
+"""
+
+from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from src.config import get_path, logger
-from src.utils import data_handler
+from src.infrastructure.persistence.mapping_repo import JsonFileMappingRepository
 
-# We might need other clients or migration classes later
+if TYPE_CHECKING:
+    from collections.abc import Mapping as MappingABC
+
+    from src.domain.repositories import MappingRepository
 
 
 class Mappings:
-    """Handles loading and accessing various mapping files generated during migration.
+    """Facade exposing migration mappings on top of :class:`MappingRepository`.
 
-    Also provides methods that utilize these mappings, like preparing work packages.
-
+    The public API matches the pre-phase-4b class for backward compatibility:
+    legacy attribute reads (``self.user_mapping``), dict-style access
+    (``self["user_mapping"]``), the ``get_mapping`` / ``set_mapping`` /
+    ``has_mapping`` / ``get_all_mappings`` helpers, and the op-id lookup
+    helpers (``get_op_user_id`` etc.). Internally, all reads and writes are
+    served by the injected (or default-constructed) repository.
     """
 
-    # Define constants as class attributes
+    # Define filename constants as class attributes.
     USER_MAPPING_FILE = Path("user_mapping.json")
     PROJECT_MAPPING_FILE = Path("project_mapping.json")
     ACCOUNT_MAPPING_FILE = Path("account_mapping.json")  # For parent project ID info
@@ -37,10 +73,78 @@ class Mappings:
     OP_PROJECTS_FILE = Path("openproject_projects.json")
     TEMPO_COMPANIES_FILE = Path("tempo_companies.json")
 
+    _JSON_SUFFIX: ClassVar[str] = ".json"
+
+    # Legacy short-name → repository stem table.
+    #
+    # Callers historically pass either the bare entity name ("user",
+    # "project", …) or the legacy "<name>_mapping" attribute name to
+    # ``get_mapping`` / ``set_mapping`` / ``has_mapping``. The repository
+    # is keyed by full filename stems ("user_mapping.json" → stem
+    # "user_mapping"), so we resolve here. Names not in the table fall
+    # through to ``"<name>_mapping"`` so adding a new mapping does not
+    # require a code change to the table.
+    SHORT_NAME_TO_STEM: ClassVar[dict[str, str]] = {
+        "user": "user_mapping",
+        "project": "project_mapping",
+        "account": "account_mapping",
+        "company": "company_mapping",
+        "issue_type": "issue_type_mapping",
+        "issue_type_id": "issue_type_id_mapping",
+        "status": "status_mapping",
+        "link_type": "link_type_mapping",
+        "custom_field": "custom_field_mapping",
+        "sprint": "sprint_mapping",
+        "priority": "priority_mapping",
+        "work_package": "work_package_mapping",
+    }
+
+    # Names checked by :meth:`_warn_missing_essentials`. Kept narrow to
+    # match legacy ``__init__`` warnings; expand only when ops actually
+    # need a runtime alarm.
+    _ESSENTIAL_STEMS: ClassVar[tuple[tuple[str, Path], ...]] = (
+        ("project_mapping", PROJECT_MAPPING_FILE),
+        ("issue_type_mapping", ISSUE_TYPE_MAPPING_FILE),
+    )
+
+    # Legacy mapping attribute stems exposed by :meth:`get_all_mappings`.
+    # Hard-coded to preserve the legacy contract of always including
+    # essentials (e.g. ``user_mapping``) even when absent from the
+    # repository — older call sites rely on the dict shape rather than
+    # truthy checks.
+    _ALL_MAPPING_STEMS: ClassVar[tuple[str, ...]] = (
+        "user_mapping",
+        "project_mapping",
+        "account_mapping",
+        "company_mapping",
+        "issue_type_mapping",
+        "status_mapping",
+        "link_type_mapping",
+        "custom_field_mapping",
+        "sprint_mapping",
+        "issue_type_id_mapping",
+        "work_package_mapping",
+        "priority_mapping",
+    )
+
     def __init__(
         self,
         data_dir: Path | None = None,
+        *,
+        repo: MappingRepository | None = None,
     ) -> None:
+        """Construct a facade backed by ``repo`` (or a default JSON adapter).
+
+        Args:
+            data_dir: Directory the default repository should read/write
+                under. Ignored when ``repo`` is supplied. Falls back to
+                ``config.get_path("data")`` and finally to ``"data"``.
+            repo: Optional repository to inject. Tests pass a
+                :class:`tests.utils.fake_mapping_repository.FakeMappingRepository`
+                here to avoid touching the filesystem and the global
+                ``cfg.mappings`` proxy.
+
+        """
         if data_dir is None:
             try:
                 data_dir = get_path("data")
@@ -48,77 +152,151 @@ class Mappings:
                 data_dir = Path("data")
         self.data_dir: Path = data_dir
 
-        # Load all mappings using class attributes for filenames
-        self.user_mapping = self._load_mapping(self.USER_MAPPING_FILE)
-        self.project_mapping = self._load_mapping(self.PROJECT_MAPPING_FILE)
-        self.account_mapping = self._load_mapping(self.ACCOUNT_MAPPING_FILE)
-        self.company_mapping = self._load_mapping(self.COMPANY_MAPPING_FILE)
-        self.issue_type_mapping = self._load_mapping(self.ISSUE_TYPE_MAPPING_FILE)
-        self.status_mapping = self._load_mapping(self.STATUS_MAPPING_FILE)
-        self.link_type_mapping = self._load_mapping(self.LINK_TYPE_MAPPING_FILE)
-        self.custom_field_mapping = self._load_mapping(self.CUSTOM_FIELD_MAPPING_FILE)
-        self.sprint_mapping = self._load_mapping(self.SPRINT_MAPPING_FILE)
-        self.priority_mapping = self._load_mapping(self.PRIORITY_MAPPING_FILE)
+        # Eagerly construct a default repository when none is injected so
+        # tests that monkeypatch ``cfg.mappings`` with a plain ``Mappings``
+        # subclass keep working without additional plumbing.
+        self._repo: MappingRepository = repo if repo is not None else JsonFileMappingRepository(data_dir)
 
-        # Additional mappings that might be added during runtime
-        self.issue_type_id_mapping = self._load_mapping(self.ISSUE_TYPE_ID_MAPPING_FILE)
-        self.work_package_mapping = self._load_mapping(self.WORK_PACKAGE_MAPPING_FILE)
+        # In-memory overrides for the legacy ``self.<name>_mapping``
+        # attribute setter. Hydrating lazily from the repo on first read
+        # gives the ``self.user_mapping["x"] = ...`` mutation pattern
+        # stable identity across calls without touching disk.
+        self._overrides: dict[str, dict[str, Any]] = {}
 
-        # Check essential mappings
-        if not self.project_mapping:
-            logger.notice(
-                "Project mapping (%s) is missing or empty!",
-                self.PROJECT_MAPPING_FILE,
-            )
-        if not self.issue_type_mapping:
-            logger.notice(
-                "Issue type mapping (%s) is missing or empty!",
-                self.ISSUE_TYPE_MAPPING_FILE,
-            )
-        # Add checks for other critical mappings as needed
+        # Surface the legacy "essentials missing" notice via repository
+        # ``has`` checks, separated from ``__init__`` so the lazy-load
+        # property reads stay free of side effects.
+        self._warn_missing_essentials()
+
+    # ── Private helpers ─────────────────────────────────────────────────
+
+    def _warn_missing_essentials(self) -> None:
+        """Log a notice for each essential mapping that is missing or empty.
+
+        Matches the legacy ``__init__`` warnings (project + issue type)
+        but uses :meth:`MappingRepository.has` instead of eager-loaded
+        attributes, so the check itself does not pre-populate the
+        in-memory override cache.
+        """
+        for stem, filename in self._ESSENTIAL_STEMS:
+            if not self._repo.has(stem):
+                logger.notice(
+                    "%s (%s) is missing or empty!",
+                    stem.replace("_", " ").capitalize(),
+                    filename,
+                )
+
+    def _resolve_stem(self, name: str | Path) -> str:
+        """Map a legacy short name (or already-full stem) to a repo stem.
+
+        Accepts:
+
+        * a bare entity name (``"user"``) — looked up in
+          :data:`SHORT_NAME_TO_STEM`;
+        * an already-full stem (``"user_mapping"``) — returned unchanged;
+        * a :class:`pathlib.Path` or filename string
+          (``Path("account_mapping.json")`` / ``"account_mapping.json"``)
+          — the ``.json`` suffix is stripped so callers that pass the
+          legacy ``Mappings.*_FILE`` constants (which are :class:`Path`
+          instances) keep working.
+
+        Anything else falls through to ``"<name>_mapping"`` so adding a
+        new mapping does not require updating the resolution table.
+        """
+        # Normalise Path / filename inputs to a bare stem first.
+        if isinstance(name, Path):
+            name = name.stem
+        elif isinstance(name, str) and name.endswith(self._JSON_SUFFIX):
+            name = name[: -len(self._JSON_SUFFIX)]
+
+        if name in self.SHORT_NAME_TO_STEM:
+            return self.SHORT_NAME_TO_STEM[name]
+        if name.endswith("_mapping"):
+            return name
+        return f"{name}_mapping"
+
+    def _read(self, stem: str) -> dict[str, Any]:
+        """Return the cached or freshly-loaded payload for ``stem``.
+
+        Once a stem has been read or written through this facade, the
+        same dict object is returned on every call so legacy mutation
+        patterns (``self.user_mapping["k"] = v``) are visible to later
+        readers without an explicit ``set_mapping`` round-trip.
+        """
+        if stem not in self._overrides:
+            self._overrides[stem] = self._repo.get(stem)
+        return self._overrides[stem]
+
+    def _write_override(self, stem: str, value: dict[str, Any]) -> None:
+        """Replace the in-memory override for ``stem`` without touching disk.
+
+        Mirrors the legacy ``self.<name>_mapping = X`` semantics: the new
+        dict is what subsequent reads see, but it is not persisted until
+        :meth:`set_mapping` is called explicitly.
+        """
+        self._overrides[stem] = value
+
+    @staticmethod
+    def _make_mapping_property(stem: str) -> property:
+        """Build a property descriptor backed by the override cache."""
+
+        def _getter(self: Mappings) -> dict[str, Any]:
+            return self._read(stem)
+
+        def _setter(self: Mappings, value: dict[str, Any]) -> None:
+            self._write_override(stem, value)
+
+        return property(_getter, _setter)
+
+    # ── Dict-style access (legacy __getitem__/__setitem__) ──────────────
 
     def __setitem__(self, key: str, value: Any) -> None:
-        """Support dictionary-style item assignment for compatibility with migration modules.
+        """Set a mapping by attribute-style key.
 
-        Args:
-            key: The mapping key to set (e.g., 'issue_type_id_mapping')
-            value: The value to set for this mapping
-
+        Recognised keys hit the in-memory override cache (no disk write,
+        matching legacy behaviour); unknown keys fall back to setting a
+        plain attribute and emit a warning so the call site is visible.
         """
-        if hasattr(self, key):
-            setattr(self, key, value)
-        else:
-            logger.warning("Setting unknown mapping attribute: %s", key)
-            setattr(self, key, value)
+        if key in self._ALL_MAPPING_STEMS:
+            self._write_override(key, value)
+            return
+        # Property setters defined at class level handle the recognised
+        # legacy attribute names; anything else is treated as an opaque
+        # attribute set so callers that stash auxiliary state on the
+        # facade (e.g. tests) keep working.
+        logger.warning("Setting unknown mapping attribute: %s", key)
+        object.__setattr__(self, key, value)
 
     def __getitem__(self, key: str) -> Any:
-        """Support dictionary-style item access for compatibility with migration modules.
+        """Get a mapping by attribute-style key.
 
-        Args:
-            key: The mapping key to get (e.g., 'issue_type_id_mapping')
-
-        Returns:
-            The mapping value or raises KeyError if not found
-
+        Raises :class:`KeyError` for unknown keys to preserve legacy
+        contract; callers that want a soft lookup should use
+        :meth:`get_mapping`.
         """
+        if key in self._ALL_MAPPING_STEMS:
+            return self._read(key)
         if hasattr(self, key):
             return getattr(self, key)
         msg = f"Mapping '{key}' not found"
         raise KeyError(msg)
 
+    # ── Compatibility shim retained for callers that still use it ───────
+
     def _load_mapping(self, filename: Path) -> dict[str, Any]:
-        """Load a specific mapping file from the data directory."""
-        file_path = self.data_dir / filename
-        mapping = data_handler.load_dict(file_path)
-        if mapping is None:
-            logger.notice("Mapping file not found or invalid: %s", filename)
-            return {}
-        logger.notice("Loaded mapping '%s' with %d entries.", filename, len(mapping))
-        return mapping
+        """Load a mapping by filename via the repository.
+
+        Kept for source-level compatibility with any out-of-tree caller
+        that imported the helper directly. Internally now delegates to
+        :meth:`MappingRepository.get` keyed by the file stem.
+        """
+        return self._repo.get(filename.stem)
+
+    # ── Op-id helpers (domain-service helpers, intentionally on facade) ──
 
     def get_op_project_id(self, jira_project_key: str) -> int | None:
         """Get the mapped OpenProject project ID for a Jira project key."""
-        entry = self.project_mapping.get(jira_project_key)
+        entry = self._read("project_mapping").get(jira_project_key)
         if entry and entry.get("openproject_id"):
             return entry["openproject_id"]
         logger.debug(
@@ -129,11 +307,10 @@ class Mappings:
 
     def get_op_user_id(self, jira_user_id: str) -> int | None:
         """Get the mapped OpenProject user ID for a Jira user ID."""
-        # User mapping keys might be jira_user_id or jira_account_id
-        entry = self.user_mapping.get(jira_user_id)
+        # User mapping keys might be jira_user_id or jira_account_id.
+        entry = self._read("user_mapping").get(jira_user_id)
         if entry and entry.get("openproject_id"):
             return entry["openproject_id"]
-        # Add fallback logic if key format varies
         logger.debug(
             "No OpenProject ID found in mapping for Jira user ID: %s",
             jira_user_id,
@@ -142,7 +319,7 @@ class Mappings:
 
     def get_op_type_id(self, jira_issue_type_name: str) -> int | None:
         """Get the mapped OpenProject type ID for a Jira issue type name."""
-        entry = self.issue_type_mapping.get(jira_issue_type_name)
+        entry = self._read("issue_type_mapping").get(jira_issue_type_name)
         if entry and entry.get("openproject_id"):
             return entry["openproject_id"]
         logger.debug(
@@ -153,7 +330,7 @@ class Mappings:
 
     def get_op_status_id(self, jira_status_name: str) -> int | None:
         """Get the mapped OpenProject status ID for a Jira status name."""
-        entry = self.status_mapping.get(jira_status_name)
+        entry = self._read("status_mapping").get(jira_status_name)
         if entry and entry.get("openproject_id"):
             return entry["openproject_id"]
         logger.debug(
@@ -162,95 +339,84 @@ class Mappings:
         )
         return None
 
-    def has_mapping(self, mapping_name: str) -> bool:
-        """Check if a mapping exists and has entries.
+    # ── Generic mapping accessors ───────────────────────────────────────
 
-        Args:
-            mapping_name: Name of the mapping (e.g., 'projects', 'users', etc.)
+    def has_mapping(self, mapping_name: str | Path) -> bool:
+        """Check whether the named mapping is present and non-empty.
 
-        Returns:
-            True if the mapping exists and has entries, False otherwise
-
+        Accepts legacy short names ("project"), full stems
+        ("project_mapping"), and the ``Mappings.*_FILE`` :class:`Path`
+        constants. See :meth:`_resolve_stem` for the resolution rules.
         """
-        mapping_attr = f"{mapping_name}_mapping"
-        if hasattr(self, mapping_attr):
-            mapping = getattr(self, mapping_attr)
-            return bool(mapping)
-        return False
+        stem = self._resolve_stem(mapping_name)
+        # Honour in-memory overrides first so a setter that has not yet
+        # been persisted is observable here, matching legacy semantics.
+        if stem in self._overrides:
+            return bool(self._overrides[stem])
+        return self._repo.has(stem)
 
-    def get_mapping(self, mapping_name: str) -> dict[str, Any]:
-        """Get a specific mapping.
+    def get_mapping(self, mapping_name: str | Path) -> dict[str, Any]:
+        """Return the named mapping (or an empty dict if missing).
 
-        Args:
-            mapping_name: Name of the mapping (e.g., 'projects', 'users', etc.)
-
-        Returns:
-            The mapping dictionary or an empty dict if not found
-
+        Accepts legacy short names, full stems, and the
+        ``Mappings.*_FILE`` :class:`Path` constants. Returned dict
+        identity is stable across calls so callers can mutate it
+        in-place — the legacy contract.
         """
-        mapping_attr = f"{mapping_name}_mapping"
-        if hasattr(self, mapping_attr):
-            return getattr(self, mapping_attr)
-        logger.notice("Mapping '%s' not found", mapping_name)
-        return {}
+        return self._read(self._resolve_stem(mapping_name))
 
     def get_all_mappings(self) -> dict[str, Any]:
-        """Get all mappings as a dictionary.
+        """Return all known mappings keyed by stem.
 
-        Returns:
-            Dictionary containing all mappings with their names as keys
-
+        Always includes the legacy "essentials" (user, project, etc.)
+        even when absent from the repository, plus any extra names the
+        repository surfaces via :meth:`MappingRepository.all_names`. This
+        preserves the legacy shape while letting new mappings appear
+        without code changes.
         """
-        mappings = {}
-        mapping_attrs = [
-            "user_mapping",
-            "project_mapping",
-            "account_mapping",
-            "company_mapping",
-            "issue_type_mapping",
-            "status_mapping",
-            "link_type_mapping",
-            "custom_field_mapping",
-            "sprint_mapping",
-            "issue_type_id_mapping",
-            "work_package_mapping",
-            "priority_mapping",
-        ]
+        # Start with the legacy hardcoded list so missing essentials
+        # appear as empty dicts rather than disappearing entirely —
+        # several call sites read keys directly without a containment
+        # check.
+        result: dict[str, Any] = {stem: self._read(stem) for stem in self._ALL_MAPPING_STEMS}
+        # Layer any additional repository names on top so newly-added
+        # mappings (not in the legacy list) are visible.
+        for stem in self._repo.all_names():
+            if stem not in result:
+                result[stem] = self._read(stem)
+        return result
 
-        for attr in mapping_attrs:
-            if hasattr(self, attr):
-                mappings[attr] = getattr(self, attr)
+    def set_mapping(self, mapping_name: str | Path, mapping_data: MappingABC[str, Any]) -> None:
+        """Persist ``mapping_data`` under ``mapping_name`` and update cache.
 
-        return mappings
-
-    def set_mapping(self, mapping_name: str, mapping_data: dict[str, Any]) -> None:
-        """Set or update a specific mapping and save it to file.
-
-        Args:
-            mapping_name: Name of the mapping (e.g., 'projects', 'users', etc.)
-            mapping_data: The mapping dictionary to save
-
+        Writes through to the repository (which round-trips to disk for
+        the JSON adapter, or to memory for the fake) and refreshes the
+        in-memory override so subsequent property reads see the new
+        value without re-reading the underlying store.
         """
-        # First update the instance variable
-        mapping_attr = f"{mapping_name}_mapping"
-        filename = Path(f"{mapping_name}_mapping.json")
-
-        # Use the constant filename if available
-        if hasattr(self, f"{mapping_name.upper()}_MAPPING_FILE"):
-            filename = getattr(self, f"{mapping_name.upper()}_MAPPING_FILE")
-
-        # Update the attribute
-        setattr(self, mapping_attr, mapping_data)
-
-        # Save to file
-        file_path = self.data_dir / filename
+        stem = self._resolve_stem(mapping_name)
         try:
-            data_handler.save_dict(mapping_data, file_path)
+            data = dict(mapping_data)
+            self._repo.set(stem, data)
+            # Replace the override entry so legacy attribute reads match
+            # what was just written. We use the same dict the repository
+            # accepted to keep memory parity with the legacy "set
+            # attribute then save" sequence.
+            self._overrides[stem] = data
             logger.info(
                 "Saved mapping '%s' with %d entries",
                 mapping_name,
-                len(mapping_data),
+                len(data),
             )
         except Exception:
             logger.exception("Error saving mapping '%s'", mapping_name)
             raise
+
+
+# Attach property descriptors for each legacy mapping attribute. We do
+# this after class definition so the descriptor table is generated from
+# the same constant the rest of the class consults, avoiding a 12-line
+# block of near-identical property definitions.
+for _stem in Mappings._ALL_MAPPING_STEMS:
+    setattr(Mappings, _stem, Mappings._make_mapping_property(_stem))
+del _stem

--- a/src/migrations/base_migration.py
+++ b/src/migrations/base_migration.py
@@ -10,6 +10,8 @@ from src import config
 from src.clients.jira_client import JiraClient
 from src.clients.openproject_client import OpenProjectClient
 from src.display import configure_logging
+from src.domain.repositories import MappingRepository
+from src.infrastructure.persistence.mapping_repo import JsonFileMappingRepository
 from src.models import ComponentResult
 
 # Import dependencies
@@ -203,12 +205,19 @@ class BaseMigration:
     2. BaseMigration - Uses OpenProjectClient for migrations
     """
 
+    # Class-level annotation for the repository seam. Phase 4b wires this
+    # up alongside ``self.mappings``; later phases will route mapping
+    # access through ``_mapping_repo`` exclusively and retire the proxy.
+    _mapping_repo: MappingRepository
+
     def __init__(
         self,
         jira_client: JiraClient | None = None,
         op_client: OpenProjectClient | None = None,
         change_detector: ChangeDetector | None = None,
         entity_cache: EntityCache | None = None,
+        *,
+        mapping_repo: MappingRepository | None = None,
     ) -> None:
         """Initialize the base migration with common attributes.
 
@@ -218,6 +227,11 @@ class BaseMigration:
             change_detector: Initialized change detector for idempotent operations
             entity_cache: Optional pre-built entity cache; otherwise a fresh one
                 is created.
+            mapping_repo: Optional :class:`MappingRepository` to inject. When
+                provided, the migration reads mappings through this
+                repository directly, bypassing the global ``cfg.mappings``
+                proxy. Tests use this seam to avoid monkey-patching
+                ``cfg.mappings`` (see ADR-002 phase 4b).
 
         """
         # Initialize clients using dependency injection
@@ -245,6 +259,23 @@ class BaseMigration:
         # The _MappingsProxy delegates to get_mappings() in production;
         # tests replace it via monkeypatch.setattr(cfg, "mappings", DummyMappings()).
         self.mappings = config.mappings
+
+        # Repository seam for ADR-002 phase 4b. Order of preference:
+        # 1) explicit ``mapping_repo`` injection (tests, future callers);
+        # 2) the underlying repo on ``self.mappings`` (production path —
+        #    the facade exposes its repo as ``_repo``);
+        # 3) a fresh JSON adapter rooted at ``self.data_dir`` so tests
+        #    that monkeypatch ``cfg.mappings`` with a Dummy lacking
+        #    ``_repo`` still get a working repository.
+        if mapping_repo is not None:
+            self._mapping_repo = mapping_repo
+        else:
+            existing_repo = getattr(self.mappings, "_repo", None)
+            self._mapping_repo = (
+                existing_repo
+                if isinstance(existing_repo, MappingRepository)
+                else JsonFileMappingRepository(self.data_dir)
+            )
 
         self.entity_cache = entity_cache or EntityCache(self.logger)
         self.json_store = JsonStore(self.data_dir, self.logger)

--- a/src/migrations/labels_migration.py
+++ b/src/migrations/labels_migration.py
@@ -16,14 +16,25 @@ from src.models.jira import JiraIssueFields
 if TYPE_CHECKING:
     from src.clients.jira_client import JiraClient
     from src.clients.openproject_client import OpenProjectClient
+    from src.domain.repositories import MappingRepository
 
 LABELS_CF_NAME = "Labels"
 
 
 @register_entity_types("labels")
 class LabelsMigration(BaseMigration):  # noqa: D101
-    def __init__(self, jira_client: JiraClient, op_client: OpenProjectClient) -> None:
-        super().__init__(jira_client=jira_client, op_client=op_client)
+    def __init__(
+        self,
+        jira_client: JiraClient,
+        op_client: OpenProjectClient,
+        *,
+        mapping_repo: MappingRepository | None = None,
+    ) -> None:
+        super().__init__(
+            jira_client=jira_client,
+            op_client=op_client,
+            mapping_repo=mapping_repo,
+        )
 
     def _get_current_entities_for_type(self, entity_type: str) -> list[dict[str, Any]]:
         """Get current entities for change detection.

--- a/src/migrations/priority_migration.py
+++ b/src/migrations/priority_migration.py
@@ -11,6 +11,7 @@ from src.models.jira import JiraIssueFields
 if TYPE_CHECKING:
     from src.clients.jira_client import JiraClient
     from src.clients.openproject_client import OpenProjectClient
+    from src.domain.repositories import MappingRepository
 
 from src.config import logger
 
@@ -19,8 +20,18 @@ from src.config import logger
 class PriorityMigration(BaseMigration):
     """Migrate priorities and set on work packages."""
 
-    def __init__(self, jira_client: JiraClient, op_client: OpenProjectClient) -> None:
-        super().__init__(jira_client=jira_client, op_client=op_client)
+    def __init__(
+        self,
+        jira_client: JiraClient,
+        op_client: OpenProjectClient,
+        *,
+        mapping_repo: MappingRepository | None = None,
+    ) -> None:
+        super().__init__(
+            jira_client=jira_client,
+            op_client=op_client,
+            mapping_repo=mapping_repo,
+        )
 
     def _get_current_entities_for_type(self, entity_type: str) -> list[dict[str, Any]]:
         """Get current entities from Jira for a specific type.

--- a/tests/unit/test_mappings_facade.py
+++ b/tests/unit/test_mappings_facade.py
@@ -1,0 +1,543 @@
+"""Tests for the :class:`Mappings` facade over :class:`MappingRepository`.
+
+Phase 4b of ADR-002 makes :class:`src.mappings.mappings.Mappings` a thin
+facade over the repository introduced in PR 4a. These tests exercise the
+new injection seam and verify that the legacy public API (attribute
+reads, ``get_mapping`` / ``set_mapping`` / ``has_mapping`` /
+``get_all_mappings``, the op-id helpers) is preserved.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from src.domain.repositories import MappingRepository
+from src.infrastructure.persistence.mapping_repo import JsonFileMappingRepository
+from src.mappings.mappings import Mappings
+from tests.utils.fake_mapping_repository import FakeMappingRepository
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    """Per-test data directory."""
+    target = tmp_path / "data"
+    target.mkdir()
+    return target
+
+
+@pytest.fixture
+def fake_repo() -> FakeMappingRepository:
+    """In-memory repository with no pre-population."""
+    return FakeMappingRepository()
+
+
+@pytest.fixture
+def seeded_repo() -> FakeMappingRepository:
+    """In-memory repository pre-populated with realistic payloads."""
+    return FakeMappingRepository(
+        initial={
+            "user_mapping": {"alice": {"openproject_id": 7}},
+            "project_mapping": {"PROJ": {"openproject_id": 42}},
+            "issue_type_mapping": {"Bug": {"openproject_id": 3}},
+            "status_mapping": {"Open": {"openproject_id": 1}},
+        },
+    )
+
+
+# ── Construction & repository plumbing ────────────────────────────────────
+
+
+class TestConstruction:
+    """:meth:`Mappings.__init__` repository wiring."""
+
+    def test_default_construction_uses_json_repo(self, data_dir: Path) -> None:
+        """Without an injected repo, a JSON adapter is created at ``data_dir``."""
+        m = Mappings(data_dir=data_dir)
+        # Internal access is acceptable here — the test asserts on the
+        # documented seam contract used by :class:`BaseMigration`.
+        assert isinstance(m._repo, JsonFileMappingRepository)
+
+    def test_injected_repo_is_used(self, fake_repo: FakeMappingRepository) -> None:
+        """An injected repository replaces the default JSON adapter."""
+        m = Mappings(repo=fake_repo)
+        assert m._repo is fake_repo
+
+    def test_injected_repo_satisfies_protocol(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        """The injection accepts any structural :class:`MappingRepository`."""
+        m = Mappings(repo=fake_repo)
+        assert isinstance(m._repo, MappingRepository)
+
+    def test_init_does_not_eagerly_load(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        """Construction must not pre-populate every mapping into memory.
+
+        Phase 4b moves to lazy reads — the override cache should only be
+        populated on first access of a given mapping.
+        """
+        Mappings(repo=fake_repo)
+        # ``_warn_missing_essentials`` calls ``has`` (cheap), not ``get``;
+        # nothing should be cached just from constructing the facade.
+        # Re-construct to inspect overrides without triggering reads.
+        m = Mappings(repo=fake_repo)
+        assert m._overrides == {}
+
+
+# ── get_mapping / set_mapping / has_mapping (legacy short names) ─────────
+
+
+class TestGetMapping:
+    """:meth:`Mappings.get_mapping` short-name resolution."""
+
+    def test_short_name_resolves_to_stem(
+        self,
+        seeded_repo: FakeMappingRepository,
+    ) -> None:
+        """``get_mapping("user")`` reads the ``user_mapping`` stem."""
+        m = Mappings(repo=seeded_repo)
+        assert m.get_mapping("user") == {"alice": {"openproject_id": 7}}
+
+    def test_full_stem_also_works(
+        self,
+        seeded_repo: FakeMappingRepository,
+    ) -> None:
+        """Full stems pass through unchanged for back-compat."""
+        m = Mappings(repo=seeded_repo)
+        assert m.get_mapping("user_mapping") == {"alice": {"openproject_id": 7}}
+
+    def test_missing_mapping_returns_empty_dict(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        """Missing names yield ``{}`` — no exception, matches legacy."""
+        m = Mappings(repo=fake_repo)
+        assert m.get_mapping("user") == {}
+
+    def test_returns_stable_identity(
+        self,
+        seeded_repo: FakeMappingRepository,
+    ) -> None:
+        """Repeated calls return the same dict so in-place mutation is visible.
+
+        Legacy callers do ``m.get_mapping("project")["X"] = {...}`` and
+        expect the next call to see the new key.
+        """
+        m = Mappings(repo=seeded_repo)
+        first = m.get_mapping("project")
+        first["NEW_KEY"] = {"openproject_id": 99}
+        second = m.get_mapping("project")
+        assert second["NEW_KEY"] == {"openproject_id": 99}
+
+    def test_unknown_short_name_falls_through_to_stem(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        """Names not in the resolution table get a ``"_mapping"`` suffix."""
+        fake_repo.set("custom_thing_mapping", {"k": "v"})
+        m = Mappings(repo=fake_repo)
+        assert m.get_mapping("custom_thing") == {"k": "v"}
+
+    def test_path_constant_resolves_to_stem(
+        self,
+        seeded_repo: FakeMappingRepository,
+    ) -> None:
+        """The legacy ``Mappings.*_FILE`` :class:`Path` constants are accepted.
+
+        ``account_migration.py`` and friends pass these directly into
+        ``get_mapping``; the resolver must strip the ``.json`` suffix.
+        """
+        m = Mappings(repo=seeded_repo)
+        assert m.get_mapping(Mappings.USER_MAPPING_FILE) == {
+            "alice": {"openproject_id": 7},
+        }
+
+    def test_filename_string_resolves_to_stem(
+        self,
+        seeded_repo: FakeMappingRepository,
+    ) -> None:
+        """A ``"foo_mapping.json"`` filename string also works."""
+        m = Mappings(repo=seeded_repo)
+        assert m.get_mapping("user_mapping.json") == {
+            "alice": {"openproject_id": 7},
+        }
+
+
+class TestSetMapping:
+    """:meth:`Mappings.set_mapping` writes to repo + cache."""
+
+    def test_set_mapping_routes_to_repository(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        m = Mappings(repo=fake_repo)
+        m.set_mapping("project", {"PROJ-1": {"openproject_id": 7}})
+        assert fake_repo.get("project_mapping") == {"PROJ-1": {"openproject_id": 7}}
+
+    def test_set_mapping_updates_cached_view(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        """After ``set_mapping``, ``get_mapping`` returns the new payload.
+
+        Important: this must hold even if ``get_mapping`` was called
+        beforehand (priming the override cache with the empty default).
+        """
+        m = Mappings(repo=fake_repo)
+        # Prime the cache with the empty default.
+        assert m.get_mapping("project") == {}
+        m.set_mapping("project", {"PROJ-1": {"openproject_id": 7}})
+        assert m.get_mapping("project") == {"PROJ-1": {"openproject_id": 7}}
+
+    def test_set_mapping_updates_attribute_view(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        """Legacy attribute reads see what ``set_mapping`` just wrote."""
+        m = Mappings(repo=fake_repo)
+        m.set_mapping("user", {"u": {"openproject_id": 1}})
+        assert m.user_mapping == {"u": {"openproject_id": 1}}
+
+
+class TestHasMapping:
+    """:meth:`Mappings.has_mapping` short-name resolution."""
+
+    def test_has_mapping_present(
+        self,
+        seeded_repo: FakeMappingRepository,
+    ) -> None:
+        m = Mappings(repo=seeded_repo)
+        assert m.has_mapping("user") is True
+
+    def test_has_mapping_missing(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        m = Mappings(repo=fake_repo)
+        assert m.has_mapping("user") is False
+
+    def test_has_mapping_empty_override_is_false(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        """In-memory override of an empty dict counts as absent.
+
+        The legacy implementation used ``bool(getattr(self, attr))``;
+        empty dicts were falsy, so a fresh in-memory ``{}`` should still
+        report ``False``.
+        """
+        m = Mappings(repo=fake_repo)
+        m.user_mapping = {}  # in-memory only, no disk write
+        assert m.has_mapping("user") is False
+
+
+# ── Op-id helpers (kept on facade per ADR) ───────────────────────────────
+
+
+class TestOpIdHelpers:
+    """Op-id helpers compose repository reads with attribute lookups."""
+
+    def test_get_op_project_id(self, seeded_repo: FakeMappingRepository) -> None:
+        m = Mappings(repo=seeded_repo)
+        assert m.get_op_project_id("PROJ") == 42
+
+    def test_get_op_project_id_missing(
+        self,
+        seeded_repo: FakeMappingRepository,
+    ) -> None:
+        m = Mappings(repo=seeded_repo)
+        assert m.get_op_project_id("does-not-exist") is None
+
+    def test_get_op_user_id(self, seeded_repo: FakeMappingRepository) -> None:
+        m = Mappings(repo=seeded_repo)
+        assert m.get_op_user_id("alice") == 7
+
+    def test_get_op_type_id(self, seeded_repo: FakeMappingRepository) -> None:
+        m = Mappings(repo=seeded_repo)
+        assert m.get_op_type_id("Bug") == 3
+
+    def test_get_op_status_id(self, seeded_repo: FakeMappingRepository) -> None:
+        m = Mappings(repo=seeded_repo)
+        assert m.get_op_status_id("Open") == 1
+
+
+# ── get_all_mappings ─────────────────────────────────────────────────────
+
+
+class TestGetAllMappings:
+    """:meth:`Mappings.get_all_mappings` includes essentials + extras."""
+
+    def test_includes_legacy_essentials_even_when_missing(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        """Empty essentials show up as ``{}`` rather than disappearing."""
+        m = Mappings(repo=fake_repo)
+        result = m.get_all_mappings()
+        # Every entry from the legacy hardcoded list is present.
+        assert "user_mapping" in result
+        assert "project_mapping" in result
+        assert "issue_type_mapping" in result
+        assert "work_package_mapping" in result
+        # Each value is at least an empty dict.
+        assert all(isinstance(v, dict) for v in result.values())
+
+    def test_includes_repository_extras(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        """Names known to the repo but not the legacy list are included."""
+        fake_repo.set("custom_extra_mapping", {"k": "v"})
+        m = Mappings(repo=fake_repo)
+        result = m.get_all_mappings()
+        assert result["custom_extra_mapping"] == {"k": "v"}
+
+    def test_reflects_seeded_payloads(
+        self,
+        seeded_repo: FakeMappingRepository,
+    ) -> None:
+        m = Mappings(repo=seeded_repo)
+        result = m.get_all_mappings()
+        assert result["user_mapping"] == {"alice": {"openproject_id": 7}}
+        assert result["project_mapping"] == {"PROJ": {"openproject_id": 42}}
+
+
+# ── Legacy attribute access semantics ────────────────────────────────────
+
+
+class TestAttributeAccess:
+    """Property descriptors preserving the legacy attribute API."""
+
+    def test_attribute_read_lazy_loads_from_repo(
+        self,
+        seeded_repo: FakeMappingRepository,
+    ) -> None:
+        m = Mappings(repo=seeded_repo)
+        assert m.user_mapping == {"alice": {"openproject_id": 7}}
+
+    def test_attribute_assign_does_not_persist(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        """``self.x_mapping = v`` updates memory only, mirroring legacy.
+
+        Only :meth:`set_mapping` is a persistent operation; bare
+        assignment was always an in-memory override in the legacy
+        implementation.
+        """
+        m = Mappings(repo=fake_repo)
+        m.user_mapping = {"alice": {"openproject_id": 7}}
+        # Visible to subsequent reads…
+        assert m.user_mapping == {"alice": {"openproject_id": 7}}
+        # …but not in the repo.
+        assert fake_repo.get("user_mapping") == {}
+
+    def test_dict_style_get(self, seeded_repo: FakeMappingRepository) -> None:
+        m = Mappings(repo=seeded_repo)
+        assert m["user_mapping"] == {"alice": {"openproject_id": 7}}
+
+    def test_dict_style_set(self, fake_repo: FakeMappingRepository) -> None:
+        m = Mappings(repo=fake_repo)
+        m["user_mapping"] = {"alice": {"openproject_id": 1}}
+        assert m.user_mapping == {"alice": {"openproject_id": 1}}
+
+    def test_dict_style_get_missing_raises(
+        self,
+        fake_repo: FakeMappingRepository,
+    ) -> None:
+        m = Mappings(repo=fake_repo)
+        with pytest.raises(KeyError):
+            _ = m["definitely_unknown_attr"]
+
+
+# ── Default JSON adapter round-trip (no injection) ───────────────────────
+
+
+class TestJsonAdapterRoundTrip:
+    """:class:`Mappings` with the default JSON adapter still round-trips.
+
+    Sanity check that the facade-without-injection path mirrors the old
+    behaviour from ``test_mappings_controller``.
+    """
+
+    def test_set_mapping_writes_to_disk(self, data_dir: Path) -> None:
+        m = Mappings(data_dir=data_dir)
+        payload = {"PROJ": {"openproject_id": 1}}
+        m.set_mapping("project", payload)
+        on_disk = json.loads((data_dir / "project_mapping.json").read_text())
+        assert on_disk == payload
+
+
+# ── Essentials warning ───────────────────────────────────────────────────
+
+
+class TestEssentialsWarning:
+    """:meth:`_warn_missing_essentials` mirrors the legacy ``__init__`` notice."""
+
+    def test_warns_when_essentials_absent(
+        self,
+        fake_repo: FakeMappingRepository,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # The notice level is custom; capture at INFO so we always see it.
+        with caplog.at_level("INFO"):
+            Mappings(repo=fake_repo)
+        # We do not pin the exact log level (legacy used ``logger.notice``);
+        # we only assert that the warning text is emitted.
+        messages = " ".join(record.getMessage() for record in caplog.records)
+        assert "project_mapping" in messages.lower() or "project mapping" in messages.lower()
+
+    def test_no_warn_when_essentials_present(
+        self,
+        seeded_repo: FakeMappingRepository,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level("INFO"):
+            Mappings(repo=seeded_repo)
+        messages = " ".join(record.getMessage() for record in caplog.records)
+        assert "missing or empty" not in messages
+
+
+# ── BaseMigration injection seam (the demo) ──────────────────────────────
+
+
+class TestBaseMigrationInjection:
+    """The new ``mapping_repo=`` kwarg on migrations bypasses the proxy."""
+
+    @pytest.fixture
+    def _quiet_clients(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> Iterator[None]:
+        """Stub out the heavy clients so migrations construct cleanly.
+
+        ``BaseMigration.__init__`` instantiates ``JiraClient`` /
+        ``OpenProjectClient`` on the fall-through paths; in unit tests
+        we always pass explicit dummies and never want the real
+        constructors firing. The fixture asserts that path is taken.
+        """
+        from src.clients import jira_client as jc_mod
+        from src.clients import openproject_client as op_mod
+
+        def _boom(*_a: object, **_k: object) -> None:
+            msg = "real client constructed in unit test"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(jc_mod, "JiraClient", _boom)
+        monkeypatch.setattr(op_mod, "OpenProjectClient", _boom)
+        return
+
+    def test_priority_migration_reads_from_injected_repo(
+        self,
+        _quiet_clients: None,
+    ) -> None:
+        """``PriorityMigration`` constructed with a fake repo reads from it.
+
+        This is the proof-of-concept for the phase-4b seam: tests no
+        longer need ``monkeypatch.setattr(cfg, "mappings", DummyMappings())``
+        to wire mapping data into a migration.
+        """
+        from src.migrations.priority_migration import PriorityMigration
+
+        fake = FakeMappingRepository(
+            initial={
+                "work_package_mapping": {"PROJ-1": {"openproject_id": 7}},
+            },
+        )
+
+        # Minimal client doubles so ``BaseMigration.__init__`` does not
+        # try to connect to anything.
+        class _Jira:
+            pass
+
+        class _Op:
+            pass
+
+        mig = PriorityMigration(
+            jira_client=_Jira(),  # type: ignore[arg-type]
+            op_client=_Op(),  # type: ignore[arg-type]
+            mapping_repo=fake,
+        )
+
+        # The seam: ``self._mapping_repo`` IS the injected fake.
+        assert mig._mapping_repo is fake
+        assert mig._mapping_repo.get("work_package_mapping") == {
+            "PROJ-1": {"openproject_id": 7},
+        }
+
+    def test_labels_migration_accepts_injected_repo(
+        self,
+        _quiet_clients: None,
+    ) -> None:
+        """``LabelsMigration`` exposes the same seam."""
+        from src.migrations.labels_migration import LabelsMigration
+
+        fake = FakeMappingRepository(
+            initial={"work_package_mapping": {"J1": {"openproject_id": 99}}},
+        )
+
+        class _Jira:
+            pass
+
+        class _Op:
+            pass
+
+        mig = LabelsMigration(
+            jira_client=_Jira(),  # type: ignore[arg-type]
+            op_client=_Op(),  # type: ignore[arg-type]
+            mapping_repo=fake,
+        )
+
+        assert mig._mapping_repo is fake
+
+    def test_falls_back_when_proxy_lacks_repo(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        _quiet_clients: None,
+    ) -> None:
+        """Tests that monkeypatch ``cfg.mappings`` with a Dummy keep working.
+
+        The Dummy will not have ``_repo``, so :class:`BaseMigration`
+        falls back to a fresh JSON adapter rooted at ``data_dir``. This
+        is the safety net described in the phase-4b plan.
+        """
+        from src import config as cfg
+        from src.migrations.priority_migration import PriorityMigration
+
+        # Redirect ``data_dir`` to a temp tree so the fall-back JSON
+        # adapter writes nowhere interesting.
+        monkeypatch.setattr(cfg, "var_dirs", {**cfg.var_dirs, "data": tmp_path})
+
+        class DummyMappings:
+            def get_mapping(self, _name: str) -> dict[str, object]:
+                return {}
+
+        monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+
+        class _Jira:
+            pass
+
+        class _Op:
+            pass
+
+        mig = PriorityMigration(
+            jira_client=_Jira(),  # type: ignore[arg-type]
+            op_client=_Op(),  # type: ignore[arg-type]
+        )
+
+        # No injection, no _repo on the Dummy → fresh JSON adapter.
+        assert isinstance(mig._mapping_repo, JsonFileMappingRepository)

--- a/tests/unit/test_mappings_facade.py
+++ b/tests/unit/test_mappings_facade.py
@@ -429,15 +429,19 @@ class TestBaseMigrationInjection:
         we always pass explicit dummies and never want the real
         constructors firing. The fixture asserts that path is taken.
         """
-        from src.clients import jira_client as jc_mod
-        from src.clients import openproject_client as op_mod
+        # ``BaseMigration`` does ``from src.clients... import JiraClient/
+        # OpenProjectClient`` so the local binding is what
+        # ``self.jira_client = jira_client or JiraClient()`` resolves.
+        # Patching the source modules wouldn't intercept those calls;
+        # patch the symbols on ``base_migration`` itself.
+        from src.migrations import base_migration as bm_mod
 
         def _boom(*_a: object, **_k: object) -> None:
             msg = "real client constructed in unit test"
             raise AssertionError(msg)
 
-        monkeypatch.setattr(jc_mod, "JiraClient", _boom)
-        monkeypatch.setattr(op_mod, "OpenProjectClient", _boom)
+        monkeypatch.setattr(bm_mod, "JiraClient", _boom)
+        monkeypatch.setattr(bm_mod, "OpenProjectClient", _boom)
         return
 
     def test_priority_migration_reads_from_injected_repo(


### PR DESCRIPTION
## Summary

Phase 4b of [ADR-002](docs/adr/ADR-002-target-architecture.md) — closes Phase 4. PR 4a (#152, merged) introduced the \`MappingRepository\` Protocol + \`JsonFileMappingRepository\` adapter + \`FakeMappingRepository\`. PR 4b makes the legacy \`Mappings\` class a thin facade over the repository and adds an injection seam to \`BaseMigration\`.

The result: production code goes through one storage layer (the repo), and tests can inject a \`FakeMappingRepository\` instead of monkeypatching the global \`config.mappings\`.

## What changed

**\`src/mappings/mappings.py\`** rewritten as a facade:
- Constructor accepts optional \`repo: MappingRepository\` for injection; falls back to \`JsonFileMappingRepository(data_dir)\`
- Eager loading dropped — each \`<name>_mapping\` attribute is now a property descriptor (generated post-class via \`_ALL_MAPPING_STEMS\`) that lazy-reads from the repo on first access
- Stable dict identity preserved across reads (cached in \`_overrides\` on first read; \`set_mapping\` replaces the cached entry)
- \`_resolve_stem\` accepts both legacy short names ("user", "work_package") AND \`Path\` constants like \`Mappings.ACCOUNT_MAPPING_FILE\` — fixes a latent bug in \`account_migration.py\` where passing a Path silently returned \`{}\`
- \`_warn_missing_essentials\` now uses \`repo.has()\` instead of attribute reads, so the warn check doesn't pre-populate the override cache (preserving lazy-load)
- Op-id helpers (\`get_op_project_id\`/\`get_op_user_id\`/\`get_op_type_id\`/\`get_op_status_id\`) stay on \`Mappings\` — they're domain-service composers, not repository operations

**\`src/migrations/base_migration.py\`** adds \`mapping_repo: MappingRepository | None = None\` keyword:
- Three-tier resolution: explicit injection > \`self.mappings._repo\` (when wrapping the standard facade) > new \`JsonFileMappingRepository(self.data_dir)\`
- The fallback keeps tests that monkeypatch \`cfg.mappings\` with non-facade dummies working
- Stored as \`self._mapping_repo\` for migrations that want to use the repo directly

**\`PriorityMigration\` + \`LabelsMigration\`** forward \`mapping_repo=\` to \`super().__init__()\`. New tests demonstrate the seam by injecting a \`FakeMappingRepository\` directly — no \`monkeypatch.setattr(cfg, "mappings", ...)\` ritual.

## Quality gates
- \`ruff check\` (touched modules + new tests): clean
- \`ruff format --check\`: clean
- \`mypy src/domain src/infrastructure src/mappings src/migrations/base_migration.py\`: 0 errors on 9 files
- \`pytest tests/unit/\`: **1074 passed**, 30 deselected (env-config failures unchanged from baseline) — **0 regressions** vs the 1038 baseline; +36 new facade tests

## Pure facade discipline
- \`config.mappings\` proxy and \`_MappingsProxy\` untouched (CLAUDE.md tests rely on them)
- \`src/utils/json_store.py\` and \`src/utils/data_handler.py\` untouched (separate from mapping persistence)
- 39 of 41 migrations unchanged — they still work via the auto-derived \`_mapping_repo\` from \`self.mappings._repo\`. Phase 7 territory.

## Test plan
- [x] All quality gates green locally
- [x] Existing 1038 tests still pass
- [x] +36 new facade tests demonstrate injection seam works
- [ ] CI green
- [ ] At least one human review pass