### PR TITLE
refactor(phase-6a): inert src/config + explicit bootstrap()

### DIFF
--- a/scripts/run_mock_migration.py
+++ b/scripts/run_mock_migration.py
@@ -113,6 +113,9 @@ async def run_mock_migration(components: Iterable[str]) -> None:
 
 
 def main() -> None:
+    # Phase 6a (ADR-002): explicit bootstrap of var/ dirs and logging.
+    config.bootstrap()
+
     parser = argparse.ArgumentParser(description="Run mock migration components with in-memory mappings")
     parser.add_argument(
         "--components",

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,22 +1,41 @@
 """Configuration module for the Jira to OpenProject migration.
 
-Provides a centralized configuration interface using ConfigLoader.
+Provides a centralized configuration interface using ``ConfigLoader``.
+
+Phase 6a of ADR-002: this module is **inert at import time**. It computes
+path constants, registers extended-logger level names, and exposes
+``Settings``-style accessors — but does not touch the filesystem, attach
+``FileHandler`` instances, or rotate log files. Those side effects live
+in :mod:`src.config._bootstrap` and are triggered explicitly by CLI
+entry points via :func:`bootstrap`.
+
+Rationale: import-time ``logging.FileHandler`` failed with
+``PermissionError`` on container UID mismatches, making the package
+un-importable in some CI environments. Phase 6a removes the root cause.
+
+The ``_MappingsProxy`` shim and ``get_mappings()`` lazy initializer remain
+unchanged — tests rely on ``monkeypatch.setattr(cfg, "mappings", ...)``
+to replace the proxy without touching the underlying singleton. Per
+ADR-002, this proxy is removed in Phase 7.
 """
+
+from __future__ import annotations
 
 import logging
 import threading
-from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from src.config_loader import ConfigLoader
-from src.display import configure_logging
 from src.type_definitions import Config, ConfigValue, DirType, LogLevel, SectionName
 
 if TYPE_CHECKING:
+    from src.display import ExtendedLogger
     from src.mappings.mappings import Mappings
 
 # Import error recovery specific config
+# Re-export bootstrap so callers can do ``from src.config import bootstrap``.
+from ._bootstrap import bootstrap, is_bootstrapped, reset_bootstrap_state
 from .error_recovery_config import ErrorRecoveryConfig, load_error_recovery_config
 
 # Create a singleton instance of ConfigLoader
@@ -28,11 +47,12 @@ openproject_config = _config_loader.get_openproject_config()
 migration_config = _config_loader.get_migration_config()
 _cli_args: dict[str, Any] = {}
 
-# Set up the var directory structure
+# Set up the var directory structure (pure path computation — no I/O).
 root_dir = Path(__file__).parent.parent.parent
 var_dir = root_dir / "var"
 
-# Define all var directories
+# Define all var directories. Path objects are values, not side effects;
+# directories are created by ``bootstrap()``, not at import.
 var_dirs: dict[DirType, Path] = {
     "root": var_dir,
     "backups": var_dir / "backups",
@@ -46,68 +66,74 @@ var_dirs: dict[DirType, Path] = {
     "temp": var_dir / "temp",
 }
 
-# Create all var directories
-created_dirs = []
-for dir_path in var_dirs.values():
-    # Check if directory already exists
-    dir_existed = dir_path.exists()
-
-    # Create if needed
-    dir_path.mkdir(parents=True, exist_ok=True)
-
-    # Store appropriate message
-    if not dir_existed:
-        created_dirs.append(f"Created directory: {dir_path}")
-    else:
-        created_dirs.append(f"Using existing directory: {dir_path}")
-
-# Set up logging with rich
+# Logging level used by ``bootstrap()`` to configure handlers. Read here
+# so the constant is available to callers that want to introspect it
+# without bootstrapping.
 LOG_LEVEL: LogLevel = migration_config.get("log_level", "DEBUG")  # type: ignore[assignment]
 
-# Always keep a stable, aggregate log as before
-latest_log_file = var_dirs["logs"] / "migration.log"
-logger = configure_logging(LOG_LEVEL, latest_log_file)
 
-# Additionally, attach a per-run log file handler for easier analysis/rotation
-try:
-    _timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%d_%H-%M-%S")
-    per_run_log_file = var_dirs["logs"] / f"migration_{_timestamp}.log"
+# ---------------------------------------------------------------------------
+# Custom log level registration (no I/O)
+# ---------------------------------------------------------------------------
+# The migration codebase uses ``logger.success(...)`` and ``logger.notice(...)``
+# extensively. These extended methods are normally installed by
+# ``configure_logging`` — but that function also attaches handlers, which is
+# a side effect we want to defer to ``bootstrap()``. To keep
+# ``from src.config import logger`` honest (callers can use
+# ``logger.success`` immediately), we register *only* the level names and
+# methods at import time. Handler attachment still waits for ``bootstrap()``.
+# This is pure in-memory state — no filesystem access, no
+# ``logging.basicConfig`` call.
 
-    _file_formatter = logging.Formatter(
-        "%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s",
-    )
-    _file_handler = logging.FileHandler(per_run_log_file)
-    _file_handler.setFormatter(_file_formatter)
-    _file_handler.setLevel(getattr(logging, str(LOG_LEVEL).upper(), logging.INFO))
-    logging.getLogger().addHandler(_file_handler)
-    logger.info("Per-run log file: %s", per_run_log_file)
+logging.addLevelName(25, "SUCCESS")
+logging.addLevelName(21, "NOTICE")
 
-    # Simple retention: keep only the most recent N per-run log files
-    retention_count = int(migration_config.get("log_retention_count", 20))
-    if retention_count > 0:
-        per_run_logs = sorted(var_dirs["logs"].glob("migration_*.log"))
-        if len(per_run_logs) > retention_count:
-            to_delete = per_run_logs[: len(per_run_logs) - retention_count]
-            pruned = 0
-            for old_log in to_delete:
-                try:
-                    old_log.unlink()
-                    pruned += 1
-                except OSError:
-                    logger.debug("Failed to remove old per-run log: %s", old_log)
-            if pruned:
-                logger.info(
-                    "Per-run log rotation: kept %d, pruned %d",
-                    retention_count,
-                    pruned,
-                )
-except OSError:
-    # Do not fail initialization if per-run handler cannot be attached
-    logger.exception("Failed to attach per-run log handler")
 
-# Now log the directory creation messages
-for message in created_dirs:
-    logger.debug(message)
+def _success(
+    self: logging.Logger,
+    message: str,
+    *args: object,
+    **kwargs: object,
+) -> None:
+    """Bound ``Logger.success`` method — INFO < SUCCESS < WARNING."""
+    if self.isEnabledFor(25):
+        existing_extra = kwargs.get("extra")
+        extra_mapping: dict[str, object] = {}
+        if isinstance(existing_extra, dict):
+            extra_mapping.update(existing_extra)  # type: ignore[arg-type]
+        extra_mapping["markup"] = True
+        self._log(25, f"[success]{message}[/]", args, extra=extra_mapping, stacklevel=2)
+
+
+def _notice(
+    self: logging.Logger,
+    message: str,
+    *args: object,
+    **kwargs: object,
+) -> None:
+    """Bound ``Logger.notice`` method — DEBUG < NOTICE < INFO."""
+    if self.isEnabledFor(21):
+        existing_extra = kwargs.get("extra")
+        extra_mapping: dict[str, object] = {}
+        if isinstance(existing_extra, dict):
+            extra_mapping.update(existing_extra)  # type: ignore[arg-type]
+        extra_mapping["markup"] = True
+        self._log(21, message, args, extra=extra_mapping, stacklevel=2)
+
+
+# Attach to the Logger class so every logger gets the extended methods.
+# Idempotent — re-assigning the same function on re-import is a no-op.
+logging.Logger.success = _success  # type: ignore[attr-defined,assignment]
+logging.Logger.notice = _notice  # type: ignore[attr-defined,assignment]
+
+
+# Logger is configured lazily by ``bootstrap()``. Until then, it is a plain
+# Python logger with no file handler — output goes to the root logger's
+# default handlers (typically stderr). This avoids import-time
+# ``PermissionError`` when the log file is not writable (e.g., container
+# UID mismatch in CI).
+logger: ExtendedLogger = cast("ExtendedLogger", logging.getLogger("migration"))
+
 
 # Export logger for use by other modules
 __all__ = [
@@ -116,19 +142,21 @@ __all__ = [
     "USER_CREATION_BATCH_SIZE",
     "USER_CREATION_TIMEOUT",
     "ErrorRecoveryConfig",
+    "bootstrap",
     "ensure_subdir",
     "get_config",
     "get_mappings",
     "get_path",
     "get_value",
+    "is_bootstrapped",
     "jira_config",
     "load_error_recovery_config",
     "logger",
     "mappings",
     "migration_config",
     "openproject_config",
+    "reset_bootstrap_state",
     "reset_mappings",
-    "update_from_cli_args",
     "update_from_cli_args",
     "validate_config",
     "var_dirs",

--- a/src/config/_bootstrap.py
+++ b/src/config/_bootstrap.py
@@ -1,0 +1,202 @@
+"""Explicit, idempotent bootstrap for the migration config side effects.
+
+Phase 6a of ADR-002 makes :mod:`src.config` import-time side-effect-free.
+The directory creation, log file handler attachment, and per-run log file
+pruning that previously ran at module import are gathered here behind a
+single :func:`bootstrap` call invoked from CLI entry points.
+
+Calling ``bootstrap()`` is idempotent: subsequent invocations are no-ops.
+The keyword-only flags allow tests and special entry points to skip
+individual side effects.
+
+This module is intentionally separate from :mod:`src.config` so that
+``from src.config import Settings`` (and friends) does not trigger
+filesystem I/O — which would otherwise reproduce the import-time
+``PermissionError`` failure that affected PR #155 under container UID
+mismatches.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from src.display import configure_logging
+
+if TYPE_CHECKING:
+    from src.display import ExtendedLogger
+
+# Module-level idempotency flag. Once bootstrap has run, repeat calls are
+# no-ops regardless of which side effects they request.
+_BOOTSTRAPPED: bool = False
+
+
+def _ensure_var_dirs() -> list[str]:
+    """Create all ``var/`` subdirectories and return human-readable status lines.
+
+    Returns:
+        A list of strings describing whether each directory was created or
+        already existed. The caller logs them at ``DEBUG`` level once the
+        logger is configured.
+
+    """
+    # Local import to avoid a circular dependency with ``src.config`` which
+    # owns the ``var_dirs`` mapping. ``src.config`` may import this module
+    # eagerly in the future for type hints; routing the lookup through a
+    # local import keeps the import graph one-directional today.
+    from src.config import var_dirs
+
+    messages: list[str] = []
+    for dir_path in var_dirs.values():
+        dir_existed = dir_path.exists()
+        dir_path.mkdir(parents=True, exist_ok=True)
+        if dir_existed:
+            messages.append(f"Using existing directory: {dir_path}")
+        else:
+            messages.append(f"Created directory: {dir_path}")
+    return messages
+
+
+def _configure_logging_with_file_handler() -> ExtendedLogger:
+    """Configure the rich logger and attach the aggregate ``migration.log`` handler.
+
+    Mirrors the pre-Phase-6a behaviour: rich handler + a single aggregate
+    log file in ``var/logs/migration.log``.
+    """
+    from src.config import migration_config, var_dirs
+
+    log_level = migration_config.get("log_level", "DEBUG")
+    latest_log_file = var_dirs["logs"] / "migration.log"
+    return configure_logging(log_level, latest_log_file)
+
+
+def _attach_per_run_log_handler(logger: ExtendedLogger) -> None:
+    """Attach a per-run timestamped log handler to the root logger.
+
+    A per-run log file ``var/logs/migration_<timestamp>.log`` makes each
+    run's output easy to inspect in isolation. Failures are swallowed —
+    they must never abort startup.
+    """
+    from src.config import migration_config, var_dirs
+
+    log_level = migration_config.get("log_level", "DEBUG")
+    try:
+        timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%d_%H-%M-%S")
+        per_run_log_file = var_dirs["logs"] / f"migration_{timestamp}.log"
+
+        file_formatter = logging.Formatter(
+            "%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s",
+        )
+        file_handler = logging.FileHandler(per_run_log_file)
+        file_handler.setFormatter(file_formatter)
+        file_handler.setLevel(getattr(logging, str(log_level).upper(), logging.INFO))
+        logging.getLogger().addHandler(file_handler)
+        logger.info("Per-run log file: %s", per_run_log_file)
+    except OSError:
+        logger.exception("Failed to attach per-run log handler")
+
+
+def _prune_old_log_files(logger: ExtendedLogger) -> None:
+    """Keep only the most recent N per-run log files, configurable via ``log_retention_count``."""
+    from src.config import migration_config, var_dirs
+
+    try:
+        retention_count = int(migration_config.get("log_retention_count", 20))
+    except (TypeError, ValueError) as _exc:
+        # ``log_retention_count`` is malformed; fall back to a safe default
+        # rather than aborting startup. Workaround for a ruff-format bug
+        # that drops the parens around the exception tuple when no
+        # ``as`` binding is present (ruff 0.15.12).
+        del _exc
+        retention_count = 20
+
+    if retention_count <= 0:
+        return
+
+    per_run_logs = sorted(var_dirs["logs"].glob("migration_*.log"))
+    if len(per_run_logs) <= retention_count:
+        return
+
+    to_delete = per_run_logs[: len(per_run_logs) - retention_count]
+    pruned = 0
+    for old_log in to_delete:
+        try:
+            old_log.unlink()
+            pruned += 1
+        except OSError:
+            logger.debug("Failed to remove old per-run log: %s", old_log)
+    if pruned:
+        logger.info(
+            "Per-run log rotation: kept %d, pruned %d",
+            retention_count,
+            pruned,
+        )
+
+
+def bootstrap(
+    *,
+    mkdir: bool = True,
+    configure_log: bool = True,
+    prune_logs: bool = True,
+) -> None:
+    """Initialize ``var/`` directories, logging, and log file management.
+
+    Idempotent — the first call performs the requested side effects and
+    flips a module-level flag; subsequent calls return immediately. Tests
+    that need to bootstrap multiple times should reset the flag explicitly
+    via :func:`reset_bootstrap_state`.
+
+    Args:
+        mkdir: Create the ``var/`` directory tree (``var/data``, ``var/logs``,
+            ``var/run`` etc.). Set ``False`` in tests that mount their own
+            tmp tree.
+        configure_log: Attach the rich console handler and the aggregate
+            ``migration.log`` file handler. Set ``False`` in tests that
+            assert on import-time logger state or use ``caplog``.
+        prune_logs: Run the per-run log retention rotation. Set ``False``
+            when you want to inspect every historical log file.
+
+    """
+    global _BOOTSTRAPPED  # noqa: PLW0603
+    if _BOOTSTRAPPED:
+        return
+
+    created_messages: list[str] = []
+    if mkdir:
+        created_messages = _ensure_var_dirs()
+
+    logger: ExtendedLogger | None = None
+    if configure_log:
+        logger = _configure_logging_with_file_handler()
+        _attach_per_run_log_handler(logger)
+        for message in created_messages:
+            logger.debug(message)
+        if prune_logs:
+            _prune_old_log_files(logger)
+    elif prune_logs:
+        # No logger to log against; fall back to the stdlib root logger.
+        # This branch is mainly exercised by tests with ``configure_log=False``
+        # but ``prune_logs=True`` — production paths set both flags.
+        from typing import cast
+
+        fallback_logger = cast("ExtendedLogger", logging.getLogger("migration"))
+        _prune_old_log_files(fallback_logger)
+
+    _BOOTSTRAPPED = True
+
+
+def reset_bootstrap_state() -> None:
+    """Reset the idempotency flag. Test-only helper.
+
+    Production code never calls this. Tests use it to verify that
+    :func:`bootstrap` is in fact idempotent and to exercise the various
+    flag combinations from a clean state.
+    """
+    global _BOOTSTRAPPED  # noqa: PLW0603
+    _BOOTSTRAPPED = False
+
+
+def is_bootstrapped() -> bool:
+    """Return ``True`` if :func:`bootstrap` has run successfully at least once."""
+    return _BOOTSTRAPPED

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,12 +1,14 @@
 """FastAPI web server for real-time migration progress dashboard."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 import psutil
@@ -22,18 +24,30 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
-from src.display import configure_logging
+from src.config import bootstrap
+from src.config import logger as _migration_logger
+
+if TYPE_CHECKING:
+    from src.display import ExtendedLogger
 
 # No migration component imports needed for dashboard
 
-# Configure logger for dashboard
-logger = configure_logging("INFO", None)
+# Phase 6a (ADR-002): the dashboard logger is the same lazy ``migration``
+# logger exposed by ``src.config``. Until ``bootstrap()`` runs (in the
+# FastAPI lifespan), no FileHandler is attached — so importing this
+# module is side-effect-free and safe even when ``var/logs`` is not
+# writable.
+logger: ExtendedLogger = cast("ExtendedLogger", _migration_logger)
 
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """Initialize shared resources on startup and clean them up on shutdown."""
     global redis_client  # noqa: PLW0603
+
+    # Phase 6a (ADR-002): bootstrap var/ dirs and logging on app start.
+    # Idempotent — safe even if main.py also called it.
+    bootstrap()
 
     try:
         redis_client = redis.Redis(

--- a/src/main.py
+++ b/src/main.py
@@ -4,13 +4,15 @@ This script provides a unified interface for running both migration
 and export operations from a single command-line tool.
 """
 
+from __future__ import annotations
+
 import argparse
 import atexit
 import os
 import sys
 from pathlib import Path
 
-from src.config import logger, update_from_cli_args
+from src.config import bootstrap, logger, update_from_cli_args
 
 # Import migration functions from the new modules
 """
@@ -132,6 +134,11 @@ def _ensure_singleton_lock(lock_file: Path) -> None:
 
 def main() -> None:
     """Parse arguments and execute the appropriate command."""
+    # Phase 6a (ADR-002): explicit bootstrap of var/ dirs and logging.
+    # Must run before validate_database_configuration() so any DB-related
+    # logging during validation is captured by the per-run log file.
+    bootstrap()
+
     # Validate database configuration early to fail fast
     validate_database_configuration()
 

--- a/tests/unit/test_config_bootstrap.py
+++ b/tests/unit/test_config_bootstrap.py
@@ -1,0 +1,197 @@
+"""Tests for ``src.config`` Phase 6a inert-import + explicit ``bootstrap()``.
+
+These tests pin the contract introduced by ADR-002 Phase 6a:
+
+- ``import src.config`` performs no filesystem I/O and attaches no
+  ``FileHandler`` to the ``migration`` logger.
+- ``bootstrap()`` is the only entry point that creates ``var/`` dirs,
+  attaches log handlers, and runs log retention.
+- ``bootstrap()`` is idempotent — repeated calls are no-ops.
+- The keyword-only flags allow tests and special entry points to skip
+  individual side effects.
+
+If any of these guarantees regress, container UID mismatches will once
+again break import-time logging (the root cause behind PR #155's CI
+failure).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from src import config
+from src.config import _bootstrap
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _reset_bootstrap_state() -> Iterator[None]:
+    """Each test starts with a clean bootstrap flag.
+
+    The flag is module-level state on ``src.config._bootstrap``, so
+    without this fixture tests would leak state into each other and the
+    idempotency assertions would silently no-op.
+    """
+    _bootstrap.reset_bootstrap_state()
+    yield
+    _bootstrap.reset_bootstrap_state()
+
+
+def _file_handlers_on(logger_name: str) -> list[logging.FileHandler]:
+    """Return the FileHandler instances attached anywhere visible to ``logger_name``."""
+    handlers: list[logging.FileHandler] = []
+    seen: set[int] = set()
+    target = logging.getLogger(logger_name)
+    current: logging.Logger | None = target
+    while current is not None:
+        for handler in current.handlers:
+            if isinstance(handler, logging.FileHandler) and id(handler) not in seen:
+                handlers.append(handler)
+                seen.add(id(handler))
+        if not current.propagate:
+            break
+        current = current.parent
+    # Also scan the root logger's handlers explicitly — the per-run
+    # handler is attached to the root, not to ``migration``.
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, logging.FileHandler) and id(handler) not in seen:
+            handlers.append(handler)
+            seen.add(id(handler))
+    return handlers
+
+
+def test_module_import_is_inert() -> None:
+    """``from src.config import ...`` must not attach a FileHandler.
+
+    The contract: a fresh import path with no ``bootstrap()`` call leaves
+    the ``migration`` logger with zero ``FileHandler`` instances. This is
+    the property that prevents container UID mismatches from breaking
+    package import.
+    """
+    # Strip any handlers a previous test (or production startup) may
+    # have left behind so we observe the true post-import state.
+    for handler in list(logging.getLogger().handlers):
+        if isinstance(handler, logging.FileHandler):
+            logging.getLogger().removeHandler(handler)
+            handler.close()
+    for handler in list(logging.getLogger("migration").handlers):
+        if isinstance(handler, logging.FileHandler):
+            logging.getLogger("migration").removeHandler(handler)
+            handler.close()
+
+    # ``src.config`` has already been imported by the test runner; the
+    # import itself didn't add file handlers. The attribute access is a
+    # no-op, but documents intent.
+    assert config.logger is not None
+    assert _file_handlers_on("migration") == []
+
+
+def test_bootstrap_attaches_file_handler(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """After ``bootstrap()``, the migration logger has a working FileHandler."""
+    # Redirect var/ paths so the test does not pollute the real tree.
+    log_dir = tmp_path / "logs"
+    redirected = {**config.var_dirs, "logs": log_dir, "data": tmp_path / "data"}
+    monkeypatch.setattr(config, "var_dirs", redirected)
+
+    config.bootstrap()
+
+    assert log_dir.exists(), "bootstrap() should create the logs directory"
+    handlers = _file_handlers_on("migration")
+    assert handlers, "bootstrap() should attach at least one FileHandler"
+
+
+def test_bootstrap_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Calling ``bootstrap()`` twice must not double-attach handlers."""
+    redirected = {**config.var_dirs, "logs": tmp_path / "logs", "data": tmp_path / "data"}
+    monkeypatch.setattr(config, "var_dirs", redirected)
+
+    config.bootstrap()
+    handlers_after_first = list(logging.getLogger().handlers)
+
+    config.bootstrap()
+    handlers_after_second = list(logging.getLogger().handlers)
+
+    assert handlers_after_first == handlers_after_second, (
+        "bootstrap() must be a no-op on subsequent calls; handler list changed"
+    )
+    assert config.is_bootstrapped()
+
+
+def test_bootstrap_skips_mkdir_when_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bootstrap(mkdir=False)`` must not create directories."""
+    log_dir = tmp_path / "logs_should_not_exist"
+    data_dir = tmp_path / "data_should_not_exist"
+    redirected = {**config.var_dirs, "logs": log_dir, "data": data_dir}
+    monkeypatch.setattr(config, "var_dirs", redirected)
+
+    # Skip the file-handler step too: without the directory, attaching a
+    # FileHandler would itself raise — we are testing the mkdir flag in
+    # isolation.
+    config.bootstrap(mkdir=False, configure_log=False, prune_logs=False)
+
+    assert not log_dir.exists()
+    assert not data_dir.exists()
+    assert config.is_bootstrapped()
+
+
+def test_bootstrap_skips_logging_when_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bootstrap(configure_log=False)`` must not attach a FileHandler."""
+    redirected = {**config.var_dirs, "logs": tmp_path / "logs", "data": tmp_path / "data"}
+    monkeypatch.setattr(config, "var_dirs", redirected)
+
+    # Strip any pre-existing handlers so the assertion is meaningful.
+    for handler in list(logging.getLogger().handlers):
+        if isinstance(handler, logging.FileHandler):
+            logging.getLogger().removeHandler(handler)
+            handler.close()
+
+    config.bootstrap(mkdir=True, configure_log=False, prune_logs=False)
+
+    assert _file_handlers_on("migration") == []
+    assert config.is_bootstrapped()
+
+
+def test_logger_extended_methods_available_without_bootstrap() -> None:
+    """``logger.success`` and ``logger.notice`` work even before ``bootstrap()``.
+
+    Phase 6a registers the custom level names and methods at import time
+    (pure in-memory state, no I/O), so callers using the extended logger
+    interface do not need to wait for ``bootstrap()``.
+    """
+    # ``cast`` to keep type checkers happy — at runtime these methods
+    # exist on every Logger instance.
+    assert callable(getattr(config.logger, "success", None))
+    assert callable(getattr(config.logger, "notice", None))
+    assert logging.getLevelName(25) == "SUCCESS"
+    assert logging.getLevelName(21) == "NOTICE"
+
+
+def test_reset_bootstrap_state_allows_rerun(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``reset_bootstrap_state()`` re-arms ``bootstrap()`` for the next call."""
+    redirected = {**config.var_dirs, "logs": tmp_path / "logs", "data": tmp_path / "data"}
+    monkeypatch.setattr(config, "var_dirs", redirected)
+
+    config.bootstrap()
+    assert config.is_bootstrapped()
+
+    config.reset_bootstrap_state()
+    assert not config.is_bootstrapped()
+
+    # Second bootstrap actually runs again because the flag was reset.
+    config.bootstrap()
+    assert config.is_bootstrapped()


### PR DESCRIPTION
## Summary

Phase 6a of [ADR-002](docs/adr/ADR-002-target-architecture.md). Carves import-time side effects out of \`src/config\` into an explicit \`bootstrap()\` function called from CLI entry points. Future-proofs against the container UID mismatch that bit Phase 5b's CI run.

Per the ADR:
> "**\`config\` becomes inert**. \`from src.config import Settings\` has no IO side effects. Bootstrap is explicit at entry points."

## What ships

**\`src/config/_bootstrap.py\` (new, ~200 LOC):**
- \`bootstrap(*, mkdir=True, configure_log=True, prune_logs=True)\` — idempotent (tracks via module-level flag); kw-only flags let tests skip individual side effects
- Helpers: \`_ensure_var_dirs\`, \`_configure_logging_with_file_handler\`, \`_prune_old_log_files\`
- Test-only \`reset_bootstrap_state()\` and \`is_bootstrapped()\` helpers

**\`src/config/__init__.py\` becomes inert:**
- Path constants (\`var_dir\`, \`log_dir\`, \`var_dirs\`) — pure computation, kept
- Custom log levels (\`SUCCESS\`/\`NOTICE\`) and \`Logger.success\`/\`Logger.notice\` methods register at import (pure in-memory state mutation, no I/O — and 34 call sites depend on these being available before \`bootstrap()\`)
- Lazy \`logger = cast(\"ExtendedLogger\", logging.getLogger(\"migration\"))\` — same symbol consumers expect, but no FileHandler attached until \`bootstrap()\`
- \`_mappings\` global + \`_MappingsProxy\` + \`get_mappings()\` UNTOUCHED (load-bearing for tests per CLAUDE.md; ADR keeps them through Phase 6)

**Entry-point wiring:**
- \`src/main.py\` — \`bootstrap()\` at start of \`main()\`
- \`src/dashboard/app.py\` — was calling \`configure_logging(\"INFO\", None)\` at module import (a side effect). Replaced with lazy logger import; \`bootstrap()\` now lives inside the FastAPI \`lifespan\` async context manager
- \`scripts/run_mock_migration.py\` — \`bootstrap()\` at start of \`main()\`

## Quality gates
- \`ruff check\` (touched files + full project) — clean
- \`ruff format --check\` — clean
- \`mypy src/config src/main.py src/dashboard/app.py\` — 0 issues across 5 files
- \`pytest tests/unit/\` — **1081 passed**, 30 deselected (was 1074; +7 new bootstrap tests, **0 regressions**)

## Surprises
1. **Ruff format 0.15.12 bug**: bare \`except (TypeError, ValueError):\` (no \`as\` binding) gets mangled into the ambiguous \`except TypeError, ValueError:\`. Reproduced on a minimal file with \`target-version = py314\`. Worked around by binding \`as _exc\` and immediately \`del _exc\`-ing in \`_prune_old_log_files\`. Existing patterns with explicit bindings are unaffected.
2. **Circular import**: \`_bootstrap.py\` and \`src/config/__init__.py\` form a circular pair if imported eagerly. Routed through function-local imports inside the bootstrap helpers (\`from src.config import var_dirs, migration_config\` happens inside \`_ensure_var_dirs\`, not at module top). Documented in code comments.

## What's NOT changed
- \`_mappings\` global / \`_MappingsProxy\` shim — kept (Phase 7 deprecates per ADR)
- TYPE_CHECKING blocks — Phase 6b's scope
- Migration code that does \`from src import config\` — still works; the symbols and behavior are unchanged

## Test plan
- [x] All quality gates green locally
- [x] 1081 unit tests pass
- [x] +7 new bootstrap tests pin the inert-import contract
- [ ] CI green