### PR TITLE
refactor(phase-6b): drop TYPE_CHECKING blocks now made unneeded by inert config

### DIFF
--- a/src/application/components/account_migration.py
+++ b/src/application/components/account_migration.py
@@ -7,17 +7,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.infrastructure.jira.jira_client import JiraApiError, JiraAuthenticationError
+from src.infrastructure.jira.jira_client import JiraApiError, JiraAuthenticationError, JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.mappings.mappings import Mappings
 from src.models import ComponentResult, MigrationError
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 # Constants for filenames
 ACCOUNT_MAPPING_FILE = "account_mapping.json"

--- a/src/application/components/admin_scheme_migration.py
+++ b/src/application/components/admin_scheme_migration.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from typing import Any
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
 
 ROLE_NAME_MAPPING = {

--- a/src/application/components/affects_versions_migration.py
+++ b/src/application/components/affects_versions_migration.py
@@ -6,17 +6,11 @@ comma-separated version names from Jira `versions` (distinct from `fixVersions`)
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.infrastructure.openproject.openproject_client import escape_ruby_single_quoted
-from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient, escape_ruby_single_quoted
+from src.models import ComponentResult
 
 AFFECTS_VERSIONS_CF_NAME = "Affects Versions"
 

--- a/src/application/components/agile_board_migration.py
+++ b/src/application/components/agile_board_migration.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from typing import Any
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
 
 

--- a/src/application/components/attachment_provenance_migration.py
+++ b/src/application/components/attachment_provenance_migration.py
@@ -7,16 +7,13 @@ author and created_at.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.models import ComponentResult
 
 
 @register_entity_types("attachment_provenance")

--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -13,17 +13,14 @@ import hashlib
 import json
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from typing import Any
 
 from src import config
+from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.models import ComponentResult
 
 
 @register_entity_types("attachments")

--- a/src/application/components/category_defaults_migration.py
+++ b/src/application/components/category_defaults_migration.py
@@ -6,16 +6,13 @@ matching Category by name in the corresponding OP project, and set assigned_to.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
-from src.infrastructure.openproject.openproject_client import escape_ruby_single_quoted
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient, escape_ruby_single_quoted
 from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 @register_entity_types("category_defaults")

--- a/src/application/components/components_migration.py
+++ b/src/application/components/components_migration.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.models import ComponentResult
 
 
 @register_entity_types("components")

--- a/src/application/components/custom_field_migration.py
+++ b/src/application/components/custom_field_migration.py
@@ -9,7 +9,7 @@ import json
 import pathlib
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
@@ -17,11 +17,9 @@ from src.application.components.base_migration import BaseMigration, register_en
 # Import RailsConsolePexpect to handle direct Rails console execution
 from src.display import ProgressTracker
 from src.infrastructure.jira.jira_client import JiraApiError, JiraAuthenticationError, JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.rails_console_client import RailsConsoleClient
 from src.models import ComponentResult, MigrationError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-    from src.infrastructure.openproject.rails_console_client import RailsConsoleClient
 
 # Rich console instance imported from base_migration
 

--- a/src/application/components/customfields_generic_migration.py
+++ b/src/application/components/customfields_generic_migration.py
@@ -7,16 +7,13 @@ are created, then sets values on corresponding work packages.
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.models import ComponentResult
 
 
 @register_entity_types("customfields_generic")

--- a/src/application/components/estimates_migration.py
+++ b/src/application/components/estimates_migration.py
@@ -11,15 +11,13 @@ Maps to OpenProject attributes:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult, WorkPackageMappingEntry
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 HOURS_PER_DAY = 8
 DAYS_PER_WEEK = 5

--- a/src/application/components/inline_refs_migration.py
+++ b/src/application/components/inline_refs_migration.py
@@ -9,14 +9,10 @@ A minimal Rails script is used to, per work package:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 @register_entity_types("inline_refs")

--- a/src/application/components/issue_type_migration.py
+++ b/src/application/components/issue_type_migration.py
@@ -9,17 +9,14 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.display import console
-from src.infrastructure.openproject.openproject_client import escape_ruby_single_quoted
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient, escape_ruby_single_quoted
 from src.models import ComponentResult, MigrationError
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 @register_entity_types("issue_types", "work_package_types")

--- a/src/application/components/labels_migration.py
+++ b/src/application/components/labels_migration.py
@@ -6,17 +6,15 @@ WorkPackage custom field named "Labels" storing a comma-separated list.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
+from src.domain.repositories import MappingRepository
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
 from src.models.jira import JiraIssueFields
-
-if TYPE_CHECKING:
-    from src.domain.repositories import MappingRepository
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 LABELS_CF_NAME = "Labels"
 

--- a/src/application/components/native_tags_migration.py
+++ b/src/application/components/native_tags_migration.py
@@ -8,14 +8,12 @@ attribute, set a deterministic color from the tag name hash.
 from __future__ import annotations
 
 import hashlib
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 @register_entity_types("native_tags")

--- a/src/application/components/priority_migration.py
+++ b/src/application/components/priority_migration.py
@@ -2,18 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.config import logger
+from src.domain.repositories import MappingRepository
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult, JiraPriority
 from src.models.jira import JiraIssueFields
-
-if TYPE_CHECKING:
-    from src.domain.repositories import MappingRepository
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
-from src.config import logger
 
 
 @register_entity_types("priorities")

--- a/src/application/components/project_migration.py
+++ b/src/application/components/project_migration.py
@@ -8,21 +8,19 @@ import json
 import re
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
 from src.infrastructure.exceptions import QueryExecutionError
+from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import (
     OpenProjectClient,
     escape_ruby_single_quoted,
 )
 from src.mappings.mappings import Mappings
 from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
 
 # Constants for filenames
 JIRA_PROJECTS_FILE = "jira_projects.json"

--- a/src/application/components/relation_migration.py
+++ b/src/application/components/relation_migration.py
@@ -7,16 +7,13 @@ with direction-safe mapping and idempotent creation via client helpers.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.models import ComponentResult
 
 
 @register_entity_types("relations", "issue_links")

--- a/src/application/components/remote_links_migration.py
+++ b/src/application/components/remote_links_migration.py
@@ -6,15 +6,13 @@ This avoids CF proliferation and presents links inline for users.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 SECTION_TITLE = "Remote Links"
 

--- a/src/application/components/reporting_migration.py
+++ b/src/application/components/reporting_migration.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from typing import Any
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
 
 REPORTING_PROJECT_IDENTIFIER_DEFAULT = "j2o-reporting"

--- a/src/application/components/resolution_migration.py
+++ b/src/application/components/resolution_migration.py
@@ -11,17 +11,13 @@ duplicate journal entries.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.infrastructure.openproject.openproject_client import escape_ruby_single_quoted
-from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient, escape_ruby_single_quoted
+from src.models import ComponentResult
 
 RESOLUTION_CF_NAME = "Resolution"
 

--- a/src/application/components/security_levels_migration.py
+++ b/src/application/components/security_levels_migration.py
@@ -6,16 +6,13 @@ the Jira `fields.security.name` for mapped issues.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
-from src.infrastructure.openproject.openproject_client import escape_ruby_single_quoted
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient, escape_ruby_single_quoted
 from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 SECURITY_LEVEL_CF_NAME = "Security Level"
 

--- a/src/application/components/simpletasks_migration.py
+++ b/src/application/components/simpletasks_migration.py
@@ -6,17 +6,14 @@ Default behavior: render as Markdown checklist in a marked section of WP descrip
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from typing import Any
 
 from src import config
+from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.models import ComponentResult
 
 
 @register_entity_types("simpletasks")

--- a/src/application/components/sprint_epic_migration.py
+++ b/src/application/components/sprint_epic_migration.py
@@ -9,18 +9,14 @@ Approach:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.infrastructure.openproject.openproject_client import escape_ruby_single_quoted
-from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from typing import Any
 
 from src import config
+from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient, escape_ruby_single_quoted
+from src.models import ComponentResult
 
 SPRINT_CF_NAME = "Sprint"
 

--- a/src/application/components/status_migration.py
+++ b/src/application/components/status_migration.py
@@ -13,19 +13,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
 from src.display import ProgressTracker
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.mappings.mappings import Mappings
 from src.models import ComponentResult
 from src.models.migration_error import MigrationError
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-    from src.mappings.mappings import Mappings
 
 
 @register_entity_types("statuses", "status_types")

--- a/src/application/components/story_points_migration.py
+++ b/src/application/components/story_points_migration.py
@@ -12,16 +12,13 @@ Detection strategy:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
-from src.infrastructure.openproject.openproject_client import escape_ruby_single_quoted
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient, escape_ruby_single_quoted
 from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 STORY_POINTS_CF_NAME = "Story Points"
 

--- a/src/application/components/time_entry_migration.py
+++ b/src/application/components/time_entry_migration.py
@@ -11,17 +11,15 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
 from src.utils.time_entry_migrator import TimeEntryMigrator
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 @register_entity_types("time_entries", "work_logs")

--- a/src/application/components/user_migration.py
+++ b/src/application/components/user_migration.py
@@ -14,17 +14,15 @@ import re
 import uuid
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from urllib.parse import quote
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.display import ProgressTracker
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult, MigrationError
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 @register_entity_types("users", "user_accounts")

--- a/src/application/components/versions_migration.py
+++ b/src/application/components/versions_migration.py
@@ -8,17 +8,14 @@ Strategy:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
 from src.models.jira import JiraIssueFields
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
-from src.config import logger
 
 
 @register_entity_types("versions")

--- a/src/application/components/votes_migration.py
+++ b/src/application/components/votes_migration.py
@@ -6,15 +6,11 @@ Jira `fields.votes.votes` count for mapped issues.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 VOTES_CF_NAME = "Votes"
 

--- a/src/application/components/watcher_migration.py
+++ b/src/application/components/watcher_migration.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.models import ComponentResult
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
 from src.config import logger
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.models import ComponentResult
 
 
 @register_entity_types("watchers")

--- a/src/application/components/workflow_migration.py
+++ b/src/application/components/workflow_migration.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from typing import Any
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
 
 

--- a/src/cleanup_openproject.py
+++ b/src/cleanup_openproject.py
@@ -6,14 +6,12 @@ This script removes all existing work packages, projects, and custom fields from
 
 import argparse
 import sys
-from typing import TYPE_CHECKING, TypeVar
+from pathlib import Path
+from typing import TypeVar
 
 from src import config
 from src.display import configure_logging
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 # Set up logger
 logger = configure_logging("INFO", None)

--- a/src/config/_bootstrap.py
+++ b/src/config/_bootstrap.py
@@ -20,12 +20,8 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
 
-from src.display import configure_logging
-
-if TYPE_CHECKING:
-    from src.display import ExtendedLogger
+from src.display import ExtendedLogger, configure_logging
 
 # Module-level idempotency flag. Once bootstrap has run, repeat calls are
 # no-ops regardless of which side effects they request.

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 from uuid import uuid4
 
 import psutil
@@ -26,9 +26,7 @@ from pydantic import BaseModel, Field
 
 from src.config import bootstrap
 from src.config import logger as _migration_logger
-
-if TYPE_CHECKING:
-    from src.display import ExtendedLogger
+from src.display import ExtendedLogger
 
 # No migration component imports needed for dashboard
 

--- a/src/domain/repositories.py
+++ b/src/domain/repositories.py
@@ -30,10 +30,8 @@ implementations to subclass an ABC.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
+from collections.abc import Mapping
+from typing import Any, Protocol, runtime_checkable
 
 
 @runtime_checkable

--- a/src/infrastructure/jira/jira_agile_service.py
+++ b/src/infrastructure/jira/jira_agile_service.py
@@ -13,18 +13,16 @@ no Ruby-script escaping to worry about.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from requests import exceptions
 
 from src.infrastructure.jira.jira_client import (
     HTTP_BAD_REQUEST_MIN,
     JiraApiError,
+    JiraClient,
     JiraConnectionError,
 )
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
 
 
 class JiraAgileService:

--- a/src/infrastructure/jira/jira_field_service.py
+++ b/src/infrastructure/jira/jira_field_service.py
@@ -13,17 +13,15 @@ go through the ``jira`` SDK or the client's ``_make_request`` helper
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.jira.jira_client import (
     HTTP_OK,
     JiraApiError,
+    JiraClient,
     JiraConnectionError,
     JiraResourceNotFoundError,
 )
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
 
 
 class JiraFieldService:

--- a/src/infrastructure/jira/jira_group_service.py
+++ b/src/infrastructure/jira/jira_group_service.py
@@ -13,18 +13,16 @@ Ruby-script escaping to worry about.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.jira.jira_client import (
     HTTP_OK,
     JiraApiError,
     JiraAuthenticationError,
     JiraCaptchaError,
+    JiraClient,
     JiraConnectionError,
 )
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
 
 
 class JiraGroupService:

--- a/src/infrastructure/jira/jira_project_service.py
+++ b/src/infrastructure/jira/jira_project_service.py
@@ -13,7 +13,7 @@ there is no Ruby-script escaping to worry about.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.jira.jira_client import (
     HTTP_NOT_FOUND,
@@ -21,12 +21,10 @@ from src.infrastructure.jira.jira_client import (
     JiraApiError,
     JiraAuthenticationError,
     JiraCaptchaError,
+    JiraClient,
     JiraConnectionError,
 )
 from src.utils.performance_optimizer import cached
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
 
 
 class JiraProjectService:

--- a/src/infrastructure/jira/jira_search_service.py
+++ b/src/infrastructure/jira/jira_search_service.py
@@ -13,17 +13,15 @@ go through the ``jira`` SDK or the client's ``_make_request`` helper
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.jira.jira_client import (
     HTTP_OK,
     JiraApiError,
+    JiraClient,
     JiraConnectionError,
     JiraResourceNotFoundError,
 )
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
 
 
 class JiraSearchService:

--- a/src/infrastructure/jira/jira_tempo_service.py
+++ b/src/infrastructure/jira/jira_tempo_service.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import time
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.jira.jira_client import (
     HTTP_NOT_FOUND,
@@ -29,13 +29,11 @@ from src.infrastructure.jira.jira_client import (
     JiraApiError,
     JiraAuthenticationError,
     JiraCaptchaError,
+    JiraClient,
     JiraConnectionError,
     JiraResourceNotFoundError,
 )
 from src.utils.timezone import UTC
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
 
 
 class JiraTempoService:

--- a/src/infrastructure/jira/jira_user_service.py
+++ b/src/infrastructure/jira/jira_user_service.py
@@ -13,15 +13,13 @@ Ruby-script escaping to worry about.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.jira.jira_client import (
     JiraApiError,
+    JiraClient,
     JiraConnectionError,
 )
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
 
 
 class JiraUserService:

--- a/src/infrastructure/jira/jira_workflow_service.py
+++ b/src/infrastructure/jira/jira_workflow_service.py
@@ -13,7 +13,7 @@ no Ruby-script escaping to worry about.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from urllib.parse import quote
 
 from requests import exceptions
@@ -22,11 +22,9 @@ from src import config
 from src.infrastructure.jira.jira_client import (
     HTTP_NOT_FOUND,
     JiraApiError,
+    JiraClient,
     JiraConnectionError,
 )
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
 
 
 class JiraWorkflowService:

--- a/src/infrastructure/jira/jira_worklog_service.py
+++ b/src/infrastructure/jira/jira_worklog_service.py
@@ -15,17 +15,15 @@ worry about.
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.jira.jira_client import (
     HTTP_NOT_FOUND,
     HTTP_OK,
     JiraApiError,
+    JiraClient,
     JiraResourceNotFoundError,
 )
-
-if TYPE_CHECKING:
-    from src.infrastructure.jira.jira_client import JiraClient
 
 
 class JiraWorklogService:

--- a/src/infrastructure/openproject/enhanced_openproject_client.py
+++ b/src/infrastructure/openproject/enhanced_openproject_client.py
@@ -12,11 +12,9 @@ import os
 import pathlib
 import subprocess
 import tempfile
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:  # pragma: no cover - typing only
-    from collections.abc import Iterable
+from typing import Any
 
 import requests
 

--- a/src/infrastructure/openproject/openproject_admin_cleanup_service.py
+++ b/src/infrastructure/openproject/openproject_admin_cleanup_service.py
@@ -41,12 +41,8 @@ it was extracted in Phase 2a/2b) — no further move needed.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectAdminCleanupService:

--- a/src/infrastructure/openproject/openproject_associations_service.py
+++ b/src/infrastructure/openproject/openproject_associations_service.py
@@ -28,12 +28,10 @@ sites work unchanged.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectAssociationsService:

--- a/src/infrastructure/openproject/openproject_bulk_create_service.py
+++ b/src/infrastructure/openproject/openproject_bulk_create_service.py
@@ -50,13 +50,11 @@ import time
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src import config
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectBulkCreateService:

--- a/src/infrastructure/openproject/openproject_content_service.py
+++ b/src/infrastructure/openproject/openproject_content_service.py
@@ -24,10 +24,9 @@ keeps thin delegators for the same method names so existing call sites
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectContentService:

--- a/src/infrastructure/openproject/openproject_custom_field_service.py
+++ b/src/infrastructure/openproject/openproject_custom_field_service.py
@@ -40,12 +40,10 @@ from __future__ import annotations
 
 import json
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.exceptions import QueryExecutionError, RecordNotFoundError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectCustomFieldService:

--- a/src/infrastructure/openproject/openproject_file_transfer_service.py
+++ b/src/infrastructure/openproject/openproject_file_transfer_service.py
@@ -34,10 +34,9 @@ import secrets
 import shlex
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectFileTransferService:

--- a/src/infrastructure/openproject/openproject_issue_priority_service.py
+++ b/src/infrastructure/openproject/openproject_issue_priority_service.py
@@ -18,12 +18,10 @@ work unchanged.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectIssuePriorityService:

--- a/src/infrastructure/openproject/openproject_membership_service.py
+++ b/src/infrastructure/openproject/openproject_membership_service.py
@@ -31,12 +31,10 @@ import secrets
 import time
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectMembershipService:

--- a/src/infrastructure/openproject/openproject_project_attribute_service.py
+++ b/src/infrastructure/openproject/openproject_project_attribute_service.py
@@ -37,12 +37,10 @@ sites work unchanged.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectProjectAttributeService:

--- a/src/infrastructure/openproject/openproject_project_service.py
+++ b/src/infrastructure/openproject/openproject_project_service.py
@@ -32,17 +32,15 @@ import json
 import os
 import shlex
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src import config
 from src.infrastructure.exceptions import (
     QueryExecutionError,
     RecordNotFoundError,
 )
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.utils.idempotency_decorators import batch_idempotent
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectProjectService:

--- a/src/infrastructure/openproject/openproject_project_setup_service.py
+++ b/src/infrastructure/openproject/openproject_project_setup_service.py
@@ -40,12 +40,10 @@ import secrets
 import time
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectProjectSetupService:

--- a/src/infrastructure/openproject/openproject_provenance_service.py
+++ b/src/infrastructure/openproject/openproject_provenance_service.py
@@ -24,12 +24,10 @@ work unchanged.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectProvenanceService:

--- a/src/infrastructure/openproject/openproject_rails_runner_service.py
+++ b/src/infrastructure/openproject/openproject_rails_runner_service.py
@@ -40,7 +40,7 @@ import subprocess
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src import config
 from src.infrastructure.exceptions import JsonParseError, QueryExecutionError
@@ -55,9 +55,7 @@ from src.infrastructure.openproject.rails_console_client import (
 # ``openproject_client``.
 BATCH_SIZE_DEFAULT: int = 50
 SAFE_OFFSET_LIMIT: int = 5000
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectRailsRunnerService:

--- a/src/infrastructure/openproject/openproject_records_service.py
+++ b/src/infrastructure/openproject/openproject_records_service.py
@@ -33,19 +33,16 @@ work unchanged.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.exceptions import (
     JsonParseError,
     QueryExecutionError,
     RecordNotFoundError,
 )
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.infrastructure.openproject.rails_console_client import RubyError
 from src.utils.idempotency_decorators import batch_idempotent
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
 
 # Sample size used when building log labels for batch operations
 # ("Batch fetch User records [1, 2, 3, ...]"); kept here rather than

--- a/src/infrastructure/openproject/openproject_status_type_service.py
+++ b/src/infrastructure/openproject/openproject_status_type_service.py
@@ -41,13 +41,11 @@ import os
 import shlex
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src import config
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectStatusTypeService:

--- a/src/infrastructure/openproject/openproject_time_entry_service.py
+++ b/src/infrastructure/openproject/openproject_time_entry_service.py
@@ -30,12 +30,10 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectTimeEntryService:

--- a/src/infrastructure/openproject/openproject_user_service.py
+++ b/src/infrastructure/openproject/openproject_user_service.py
@@ -28,19 +28,15 @@ unchanged.
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 
 from src.infrastructure.exceptions import (
     QueryExecutionError,
     RecordNotFoundError,
 )
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.utils.idempotency_decorators import batch_idempotent
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
 
 # Cache TTL: 5 minutes. Single definition (was previously duplicated on
 # the client until Phase 2j; the client copy was unused after the move).

--- a/src/infrastructure/openproject/openproject_work_package_content_service.py
+++ b/src/infrastructure/openproject/openproject_work_package_content_service.py
@@ -24,10 +24,9 @@ work unchanged.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectWorkPackageContentService:

--- a/src/infrastructure/openproject/openproject_work_package_custom_field_service.py
+++ b/src/infrastructure/openproject/openproject_work_package_custom_field_service.py
@@ -26,10 +26,9 @@ sites (migrations, tests) work unchanged.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectWorkPackageCustomFieldService:

--- a/src/infrastructure/openproject/openproject_work_package_service.py
+++ b/src/infrastructure/openproject/openproject_work_package_service.py
@@ -49,14 +49,11 @@ from __future__ import annotations
 
 import json
 import re
-from typing import TYPE_CHECKING, Any
+from collections.abc import Iterator
+from typing import Any
 
 from src.infrastructure.exceptions import QueryExecutionError
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
-
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectWorkPackageService:

--- a/src/infrastructure/persistence/mapping_repo.py
+++ b/src/infrastructure/persistence/mapping_repo.py
@@ -30,13 +30,11 @@ import json
 import logging
 import os
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pydantic import BaseModel
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
 
 _module_logger = logging.getLogger(__name__)
 

--- a/src/mappings/mappings.py
+++ b/src/mappings/mappings.py
@@ -29,16 +29,13 @@ The legacy proxy stays in place; this PR only adds the seam.
 
 from __future__ import annotations
 
+from collections.abc import Mapping as MappingABC
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from src.config import get_path, logger
+from src.domain.repositories import MappingRepository
 from src.infrastructure.persistence.mapping_repo import JsonFileMappingRepository
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping as MappingABC
-
-    from src.domain.repositories import MappingRepository
 
 
 class Mappings:

--- a/src/migration.py
+++ b/src/migration.py
@@ -14,7 +14,7 @@ import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from rich.console import Console
 
@@ -25,6 +25,7 @@ from src.application.components.affects_versions_migration import AffectsVersion
 from src.application.components.agile_board_migration import AgileBoardMigration
 from src.application.components.attachment_provenance_migration import AttachmentProvenanceMigration
 from src.application.components.attachments_migration import AttachmentsMigration
+from src.application.components.base_migration import BaseMigration
 from src.application.components.category_defaults_migration import CategoryDefaultsMigration
 from src.application.components.company_migration import CompanyMigration
 from src.application.components.components_migration import ComponentsMigration
@@ -66,9 +67,6 @@ from src.infrastructure.openproject.ssh_client import SSHClient
 from src.models import ComponentResult, MigrationResult
 from src.type_definitions import BackupDir, ComponentName
 from src.utils import data_handler
-
-if TYPE_CHECKING:
-    from src.application.components.base_migration import BaseMigration
 
 console = Console()
 
@@ -133,7 +131,6 @@ DEFAULT_COMPONENT_SEQUENCE: list[ComponentName] = [
     "admin_schemes",
     "reporting",
 ]
-
 
 PREDEFINED_PROFILES: dict[str, list[ComponentName]] = {
     "full": DEFAULT_COMPONENT_SEQUENCE.copy(),

--- a/src/utils/custom_field_project_enablement.py
+++ b/src/utils/custom_field_project_enablement.py
@@ -15,10 +15,7 @@ Usage:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class CustomFieldProjectTracker:

--- a/src/utils/entity_cache.py
+++ b/src/utils/entity_cache.py
@@ -21,11 +21,8 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import TYPE_CHECKING, Any, ClassVar
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
+from collections.abc import Callable
+from typing import Any, ClassVar
 
 _module_logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Phase 6b of [ADR-002](docs/adr/ADR-002-target-architecture.md) — closes Phase 6. Phase 6a (#156, merged) made \`src/config\` import-side-effect-free; this PR drops the \`TYPE_CHECKING\` blocks that previously hid imports just to avoid triggering those side effects.

Per the ADR's success criteria:
> "Cyclic-import pressure drops. TYPE_CHECKING blocks reduce from 49 in the orchestrator to ≤ 5; from 42 files codebase-wide to ≤ 10."

## Numbers

| Metric | Before | After |
|---|---|---|
| Files with \`if TYPE_CHECKING:\` | 80 | 9 |
| Reduction | — | -71 files (-88%) |
| Net lines | — | -176 (188 ins / 364 del) |
| ADR target | ≤ 10 | **met (9)** |

## What stayed in TYPE_CHECKING (9 files) and why

**Optional \`jira\` library — runtime stub fallback (typing-only is correct):**
- \`src/infrastructure/jira/jira_client.py\` (\`AtlassianJIRAError = Exception\` at runtime)
- \`src/infrastructure/jira/enhanced_jira_client.py\`
- \`src/infrastructure/jira/jira_issue_service.py\`
- \`src/infrastructure/jira/jira_reporting_service.py\`
- \`src/application/components/work_package_content_migration.py\`
- \`src/application/components/work_package_skeleton_migration.py\`

**True circular imports unrelated to inert-config (reverted after test-discovered regressions):**
- \`src/config/__init__.py\` — config ↔ mappings circular boundary
- \`src/utils/change_aware_runner.py\` — base_migration ↔ change_aware_runner

**Pre-existing dead annotations (out of scope, flagged for follow-up):**
- \`src/infrastructure/health_check_client.py\` — TYPE_CHECKING block has stale relative paths (\`.docker_client\`, \`.ssh_client\`) that don't resolve since Phase 5b moved those modules. Promoting to runtime crashes; pre-existing condition.

## Iteration

The batch transform produced 2 test-discovered regressions (config↔mappings and base_migration↔change_aware_runner circular imports). Each was cleanly isolated and reverted per file. After three reverts (including the pre-existing health_check_client issue), gates went from red to green.

## Quality gates
- \`ruff check .\` — clean
- \`ruff format --check .\` — 370 files clean
- \`mypy src/\` — 0 issues across 150 source files
- \`pytest tests/unit/\` — **1081 passed**, 30 deselected (exact match to post-PR-156 baseline; 0 regressions)

## Hard constraints respected
- No behavior change (test count unchanged)
- \`AtlassianJIRAError\` runtime fallback preserved
- \`_MappingsProxy\` shim preserved (load-bearing for test monkeypatching per CLAUDE.md)
- \`from __future__ import annotations\` preserved on every modified file (Python 3.14 PEP 649)

## Test plan
- [x] All quality gates green locally
- [x] 1081 unit tests pass (exact baseline match)
- [ ] CI green