### PR TITLE
refactor(phase-7a): convert 4 migrations to typed pipeline

### DIFF
--- a/src/application/components/inline_refs_migration.py
+++ b/src/application/components/inline_refs_migration.py
@@ -30,7 +30,9 @@ class InlineRefsMigration(BaseMigration):  # noqa: D101
                 # Corrupt or unsupported shape — skip silently to preserve the
                 # pre-typed silent-skip behaviour at this call site.
                 continue
-            wp_ids.append(int(entry.openproject_id))
+            # ``entry.openproject_id`` is a branded int type (validated by
+            # Pydantic on construction) — no further coercion needed.
+            wp_ids.append(entry.openproject_id)
         return ComponentResult(success=True, data={"work_package_ids": wp_ids})
 
     def _load(self, mapped: ComponentResult) -> ComponentResult:

--- a/src/application/components/inline_refs_migration.py
+++ b/src/application/components/inline_refs_migration.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
-from src.models import ComponentResult
+from src.models import ComponentResult, WorkPackageMappingEntry
 
 
 @register_entity_types("inline_refs")
@@ -23,12 +23,14 @@ class InlineRefsMigration(BaseMigration):  # noqa: D101
     def _extract(self) -> ComponentResult:
         wp_map = self.mappings.get_mapping("work_package") or {}
         wp_ids: list[int] = []
-        for entry in (wp_map or {}).values():
-            if isinstance(entry, dict) and entry.get("openproject_id"):
-                try:
-                    wp_ids.append(int(entry["openproject_id"]))  # type: ignore[arg-type]
-                except Exception:
-                    continue
+        for key, value in (wp_map or {}).items():
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(str(key), value)
+            except ValueError:
+                # Corrupt or unsupported shape — skip silently to preserve the
+                # pre-typed silent-skip behaviour at this call site.
+                continue
+            wp_ids.append(int(entry.openproject_id))
         return ComponentResult(success=True, data={"work_package_ids": wp_ids})
 
     def _load(self, mapped: ComponentResult) -> ComponentResult:

--- a/src/application/components/resolution_migration.py
+++ b/src/application/components/resolution_migration.py
@@ -17,7 +17,8 @@ from src.application.components.base_migration import BaseMigration, register_en
 from src.config import logger
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient, escape_ruby_single_quoted
-from src.models import ComponentResult
+from src.models import ComponentResult, WorkPackageMappingEntry
+from src.models.jira import JiraIssueFields
 
 RESOLUTION_CF_NAME = "Resolution"
 
@@ -52,9 +53,8 @@ class ResolutionMigration(BaseMigration):  # noqa: D101
         reso_by_key: dict[str, str] = {}
         for k, issue in issues.items():
             try:
-                fields = getattr(issue, "fields", None)
-                res = getattr(fields, "resolution", None)
-                name = getattr(res, "name", None)
+                fields = JiraIssueFields.from_issue_any(issue)
+                name = fields.resolution.name if fields.resolution else None
                 if name:
                     reso_by_key[k] = str(name)
             except Exception:
@@ -75,15 +75,20 @@ class ResolutionMigration(BaseMigration):  # noqa: D101
 
         # Set CF value only - audit trail migration handles resolution history
         for jira_key, res_name in reso_by_key.items():
-            entry = wp_map.get(jira_key)
-            if not (isinstance(entry, dict) and entry.get("openproject_id")):
+            raw_entry = wp_map.get(jira_key)
+            if raw_entry is None:
                 continue
-            wp_id = int(entry["openproject_id"])  # type: ignore[arg-type]
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+            except ValueError:
+                # Corrupt or unsupported wp_map shape — skip silently to
+                # preserve the pre-typed call-site behaviour.
+                continue
+            wp_id = int(entry.openproject_id)
 
             # Track project ID for selective CF enablement
-            project_id = entry.get("openproject_project_id")
-            if project_id:
-                projects_with_values.add(int(project_id))
+            if entry.openproject_project_id is not None:
+                projects_with_values.add(int(entry.openproject_project_id))
 
             try:
                 # Set CF value - do NOT create separate journal entry

--- a/src/application/components/security_levels_migration.py
+++ b/src/application/components/security_levels_migration.py
@@ -12,7 +12,8 @@ from src.application.components.base_migration import BaseMigration, register_en
 from src.config import logger
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient, escape_ruby_single_quoted
-from src.models import ComponentResult
+from src.models import ComponentResult, WorkPackageMappingEntry
+from src.models.jira import JiraIssueFields
 
 SECURITY_LEVEL_CF_NAME = "Security Level"
 
@@ -48,9 +49,8 @@ class SecurityLevelsMigration(BaseMigration):  # noqa: D101
         sec_by_key: dict[str, str] = {}
         for k, issue in issues.items():
             try:
-                fields = getattr(issue, "fields", None)
-                sec = getattr(fields, "security", None)
-                name = getattr(sec, "name", None)
+                fields = JiraIssueFields.from_issue_any(issue)
+                name = fields.security.name if fields.security else None
                 if name:
                     sec_by_key[k] = str(name)
             except Exception:
@@ -72,14 +72,19 @@ class SecurityLevelsMigration(BaseMigration):  # noqa: D101
         for jira_key, sec_name in sec_by_key.items():
             if not sec_name:
                 continue
-            entry = wp_map.get(jira_key)
-            if not (isinstance(entry, dict) and entry.get("openproject_id")):
+            raw_entry = wp_map.get(jira_key)
+            if raw_entry is None:
                 continue
-            wp_id = int(entry["openproject_id"])  # type: ignore[arg-type]
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+            except ValueError:
+                # Corrupt or unsupported wp_map shape — skip silently to
+                # preserve the pre-typed call-site behaviour.
+                continue
+            wp_id = int(entry.openproject_id)
             # Track project for selective enablement
-            project_id = entry.get("openproject_project_id")
-            if project_id:
-                projects_with_values.add(int(project_id))
+            if entry.openproject_project_id is not None:
+                projects_with_values.add(int(entry.openproject_project_id))
             try:
                 # Set CF value
                 set_script = (

--- a/src/application/components/votes_migration.py
+++ b/src/application/components/votes_migration.py
@@ -10,7 +10,8 @@ from src.application.components.base_migration import BaseMigration, register_en
 from src.config import logger
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
-from src.models import ComponentResult
+from src.models import ComponentResult, WorkPackageMappingEntry
+from src.models.jira import JiraIssueFields
 
 VOTES_CF_NAME = "Votes"
 
@@ -46,9 +47,8 @@ class VotesMigration(BaseMigration):  # noqa: D101
         votes_by_key: dict[str, int] = {}
         for k, issue in issues.items():
             try:
-                fields = getattr(issue, "fields", None)
-                votes_obj = getattr(fields, "votes", None)
-                count = getattr(votes_obj, "votes", None)
+                fields = JiraIssueFields.from_issue_any(issue)
+                count = fields.votes.votes if fields.votes else None
                 if isinstance(count, int):
                     votes_by_key[k] = count
             except Exception:
@@ -71,14 +71,19 @@ class VotesMigration(BaseMigration):  # noqa: D101
             # Only track non-zero votes (meaningful values)
             if count == 0:
                 continue
-            entry = wp_map.get(jira_key)
-            if not (isinstance(entry, dict) and entry.get("openproject_id")):
+            raw_entry = wp_map.get(jira_key)
+            if raw_entry is None:
                 continue
-            wp_id = int(entry["openproject_id"])  # type: ignore[arg-type]
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+            except ValueError:
+                # Corrupt or unsupported wp_map shape — skip silently to
+                # preserve the pre-typed call-site behaviour.
+                continue
+            wp_id = int(entry.openproject_id)
             # Track project for selective enablement
-            project_id = entry.get("openproject_project_id")
-            if project_id:
-                projects_with_values.add(int(project_id))
+            if entry.openproject_project_id is not None:
+                projects_with_values.add(int(entry.openproject_project_id))
             cf_values_to_set.append(
                 {
                     "work_package_id": wp_id,

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -12,9 +12,12 @@ from src.models.jira import (
     JiraPriorityRef,
     JiraProject,
     JiraProjectCategoryRef,
+    JiraResolutionRef,
+    JiraSecurityLevelRef,
     JiraStatusRef,
     JiraUser,
     JiraVersionRef,
+    JiraVotesRef,
 )
 from src.models.mapping import WorkPackageMappingEntry
 from src.models.migration_error import MigrationError
@@ -38,9 +41,12 @@ __all__ = [
     "JiraPriorityRef",
     "JiraProject",
     "JiraProjectCategoryRef",
+    "JiraResolutionRef",
+    "JiraSecurityLevelRef",
     "JiraStatusRef",
     "JiraUser",
     "JiraVersionRef",
+    "JiraVotesRef",
     "MigrationError",
     "MigrationResult",
     "OpCustomField",

--- a/src/models/jira/__init__.py
+++ b/src/models/jira/__init__.py
@@ -10,8 +10,11 @@ from src.models.jira.issue import (
     JiraIssueFields,
     JiraIssueTypeRef,
     JiraPriorityRef,
+    JiraResolutionRef,
+    JiraSecurityLevelRef,
     JiraStatusRef,
     JiraVersionRef,
+    JiraVotesRef,
 )
 from src.models.jira.priority import JiraPriority
 from src.models.jira.project import JiraProject, JiraProjectCategoryRef
@@ -28,7 +31,10 @@ __all__ = [
     "JiraPriorityRef",
     "JiraProject",
     "JiraProjectCategoryRef",
+    "JiraResolutionRef",
+    "JiraSecurityLevelRef",
     "JiraStatusRef",
     "JiraUser",
     "JiraVersionRef",
+    "JiraVotesRef",
 ]

--- a/src/models/jira/issue.py
+++ b/src/models/jira/issue.py
@@ -26,8 +26,27 @@ from src.models.jira.user import JiraUser
 
 
 def _str_or_none(value: Any) -> str | None:
-    """Coerce a value to ``str`` while preserving ``None``."""
-    return None if value is None else str(value)
+    """Coerce a value to ``str`` while preserving ``None``.
+
+    Returns ``None`` for values that are not already strings or ``str``-able
+    primitives (e.g. :class:`unittest.mock.Mock` auto-vivified attributes).
+    Pydantic would otherwise reject those at validation time and abort the
+    enclosing :func:`_jira_fields_payload` call — which the legacy
+    attribute-walking code never did. We fall back to ``None`` for anything
+    that isn't a string, ``int``, ``float`` or ``bool``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    return None
+
+
+def _str_attr(obj: Any, name: str) -> str | None:
+    """Read ``obj.name`` and coerce to a clean ``str`` or ``None``."""
+    return _str_or_none(getattr(obj, name, None))
 
 
 def _jira_ref(value: Any) -> dict[str, Any] | None:
@@ -35,9 +54,45 @@ def _jira_ref(value: Any) -> dict[str, Any] | None:
     if value is None:
         return None
     return {
-        "id": _str_or_none(getattr(value, "id", None)),
-        "name": _str_or_none(getattr(value, "name", None)),
+        "id": _str_attr(value, "id"),
+        "name": _str_attr(value, "name"),
     }
+
+
+def _safe_iter(value: Any) -> list[Any]:
+    """Return ``value`` as a list if iterable, else an empty list.
+
+    SDK fields normally expose iterable collections (``list``, generator,
+    etc.) for ``comment.comments``, ``attachment``, ``fixVersions`` and
+    ``components``. Mock-based test fixtures, however, auto-vivify these
+    attributes with non-iterable :class:`unittest.mock.Mock` instances —
+    iterating those raises :class:`TypeError`. We tolerate both shapes
+    so the typed pipeline doesn't accidentally crash on test doubles
+    that the legacy attribute-walking code happily ignored.
+    """
+    if value is None:
+        return []
+    try:
+        return list(value)
+    except TypeError:
+        return []
+
+
+def _safe_user(obj: Any) -> JiraUser | None:
+    """Build a :class:`JiraUser` from ``obj`` or return ``None`` on bad shapes.
+
+    Same defensive rationale as :func:`_safe_iter`: Mock-based test
+    fixtures often auto-vivify ``assignee``/``reporter`` to non-string
+    Mocks that fail Pydantic validation. The migration's previous
+    attribute-walking code never tried to construct a user payload from
+    those, so we silently treat them as missing here.
+    """
+    if obj is None:
+        return None
+    try:
+        return JiraUser.from_jira_obj(obj)
+    except Exception:
+        return None
 
 
 def _jira_fields_payload(sdk_fields: Any) -> dict[str, Any]:
@@ -58,50 +113,57 @@ def _jira_fields_payload(sdk_fields: Any) -> dict[str, Any]:
     comment_block = getattr(sdk_fields, "comment", None)
     comments_iter = getattr(comment_block, "comments", None) if comment_block else None
     comments_payload: list[dict[str, Any]] = []
-    if comments_iter:
-        for c in comments_iter:
-            author_obj = getattr(c, "author", None)
-            comments_payload.append(
-                {
-                    "id": _str_or_none(getattr(c, "id", None)),
-                    "body": getattr(c, "body", None),
-                    "author": getattr(author_obj, "displayName", None) if author_obj else None,
-                    "created": getattr(c, "created", None),
-                },
-            )
+    for c in _safe_iter(comments_iter):
+        author_obj = getattr(c, "author", None)
+        comments_payload.append(
+            {
+                "id": _str_or_none(getattr(c, "id", None)),
+                "body": getattr(c, "body", None),
+                "author": getattr(author_obj, "displayName", None) if author_obj else None,
+                "created": getattr(c, "created", None),
+            },
+        )
 
     attachments_iter = getattr(sdk_fields, "attachment", None)
     attachments_payload: list[dict[str, Any]] = []
-    if attachments_iter:
-        for att in attachments_iter:
-            attachments_payload.append(
-                {
-                    "id": _str_or_none(getattr(att, "id", None)),
-                    "filename": getattr(att, "filename", None),
-                    "size": getattr(att, "size", None),
-                    "content": getattr(att, "url", None),
-                },
-            )
+    for att in _safe_iter(attachments_iter):
+        attachments_payload.append(
+            {
+                "id": _str_or_none(getattr(att, "id", None)),
+                "filename": getattr(att, "filename", None),
+                "size": getattr(att, "size", None),
+                "content": getattr(att, "url", None),
+            },
+        )
 
-    labels = list(getattr(sdk_fields, "labels", []) or [])
+    labels = _safe_iter(getattr(sdk_fields, "labels", None))
 
     fix_versions_iter = getattr(sdk_fields, "fixVersions", None)
-    fix_versions_payload = [_jira_ref(v) for v in (fix_versions_iter or []) if v is not None]
+    fix_versions_payload = [_jira_ref(v) for v in _safe_iter(fix_versions_iter) if v is not None]
 
     components_iter = getattr(sdk_fields, "components", None)
-    components_payload = [_jira_ref(c) for c in (components_iter or []) if c is not None]
+    components_payload = [_jira_ref(c) for c in _safe_iter(components_iter) if c is not None]
+
+    votes_obj = getattr(sdk_fields, "votes", None)
+    votes_payload: dict[str, Any] | None = None
+    if votes_obj is not None:
+        votes_count = getattr(votes_obj, "votes", None)
+        votes_payload = {"votes": votes_count if isinstance(votes_count, int) else None}
 
     return {
-        "summary": getattr(sdk_fields, "summary", None),
-        "description": getattr(sdk_fields, "description", None),
+        "summary": _str_attr(sdk_fields, "summary"),
+        "description": _str_attr(sdk_fields, "description"),
         "status": _jira_ref(getattr(sdk_fields, "status", None)),
         "priority": _jira_ref(getattr(sdk_fields, "priority", None)),
         "issuetype": _jira_ref(getattr(sdk_fields, "issuetype", None)),
-        "assignee": JiraUser.from_jira_obj(assignee_obj) if assignee_obj else None,
-        "reporter": JiraUser.from_jira_obj(reporter_obj) if reporter_obj else None,
-        "created": getattr(sdk_fields, "created", None),
-        "updated": getattr(sdk_fields, "updated", None),
-        "labels": [str(label) for label in labels],
+        "resolution": _jira_ref(getattr(sdk_fields, "resolution", None)),
+        "security": _jira_ref(getattr(sdk_fields, "security", None)),
+        "votes": votes_payload,
+        "assignee": _safe_user(assignee_obj),
+        "reporter": _safe_user(reporter_obj),
+        "created": _str_attr(sdk_fields, "created"),
+        "updated": _str_attr(sdk_fields, "updated"),
+        "labels": [str(label) for label in labels if isinstance(label, (str, int, float))],
         "fixVersions": fix_versions_payload,
         "components": components_payload,
         "comments": comments_payload,
@@ -149,6 +211,34 @@ class JiraComponentRef(BaseModel):
     name: str | None = None
 
 
+class JiraResolutionRef(BaseModel):
+    """Reference to a Jira resolution (``id`` + ``name``)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    id: str | None = None
+    name: str | None = None
+
+
+class JiraSecurityLevelRef(BaseModel):
+    """Reference to a Jira issue security level (``id`` + ``name``)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    id: str | None = None
+    name: str | None = None
+
+
+class JiraVotesRef(BaseModel):
+    """Reference to the Jira ``votes`` block on an issue.
+
+    The Jira REST/SDK exposes ``fields.votes`` as an object that carries
+    a ``votes`` integer count (and a ``hasVoted`` flag we don't need for
+    migration). We model the count only.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    votes: int | None = None
+
+
 class JiraComment(BaseModel):
     """A Jira issue comment."""
 
@@ -184,6 +274,9 @@ class JiraIssueFields(BaseModel):
     status: JiraStatusRef | None = None
     priority: JiraPriorityRef | None = None
     issue_type: JiraIssueTypeRef | None = Field(default=None, alias="issuetype")
+    resolution: JiraResolutionRef | None = None
+    security: JiraSecurityLevelRef | None = None
+    votes: JiraVotesRef | None = None
 
     assignee: JiraUser | None = None
     reporter: JiraUser | None = None
@@ -342,6 +435,9 @@ __all__ = [
     "JiraIssueFields",
     "JiraIssueTypeRef",
     "JiraPriorityRef",
+    "JiraResolutionRef",
+    "JiraSecurityLevelRef",
     "JiraStatusRef",
     "JiraVersionRef",
+    "JiraVotesRef",
 ]

--- a/tests/unit/test_models_jira_issue.py
+++ b/tests/unit/test_models_jira_issue.py
@@ -352,3 +352,72 @@ def test_from_issue_any_none_returns_empty() -> None:
 
     assert fields.labels == []
     assert fields.priority is None
+
+
+# ── resolution / security / votes refs ───────────────────────────────────
+
+
+def test_from_dict_resolution_security_and_votes() -> None:
+    """The dict shape carries resolution/security/votes through to typed refs."""
+    raw: dict[str, object] = {
+        "key": "ABC-9",
+        "id": "9",
+        "fields": {
+            "resolution": {"id": "1", "name": "Fixed"},
+            "security": {"id": "2", "name": "Top Secret"},
+            "votes": {"votes": 7},
+        },
+    }
+    issue = JiraIssue.from_dict(raw)
+
+    assert issue.fields.resolution is not None
+    assert issue.fields.resolution.name == "Fixed"
+    assert issue.fields.security is not None
+    assert issue.fields.security.name == "Top Secret"
+    assert issue.fields.votes is not None
+    assert issue.fields.votes.votes == 7
+
+
+def test_from_jira_obj_resolution_security_and_votes() -> None:
+    """The SDK shape adapts resolution/security/votes the same way as status."""
+    sdk_fields = SimpleNamespace(
+        resolution=SimpleNamespace(id="1", name="Done"),
+        security=SimpleNamespace(id="2", name="Internal"),
+        votes=SimpleNamespace(votes=3),
+    )
+    obj = SimpleNamespace(id="42", key="ABC-42", fields=sdk_fields)
+
+    issue = JiraIssue.from_jira_obj(obj)
+
+    assert issue.fields.resolution is not None
+    assert issue.fields.resolution.name == "Done"
+    assert issue.fields.security is not None
+    assert issue.fields.security.name == "Internal"
+    assert issue.fields.votes is not None
+    assert issue.fields.votes.votes == 3
+
+
+def test_from_jira_obj_missing_resolution_security_votes_default_to_none() -> None:
+    sdk_fields = SimpleNamespace(
+        resolution=None,
+        security=None,
+        votes=None,
+    )
+    obj = SimpleNamespace(id="1", key="ABC-1", fields=sdk_fields)
+
+    issue = JiraIssue.from_jira_obj(obj)
+
+    assert issue.fields.resolution is None
+    assert issue.fields.security is None
+    assert issue.fields.votes is None
+
+
+def test_from_jira_obj_votes_non_int_count_normalises_to_none() -> None:
+    """Non-int vote counts (e.g. SDK glitches) collapse to a votes ref with None."""
+    sdk_fields = SimpleNamespace(votes=SimpleNamespace(votes="not-an-int"))
+    obj = SimpleNamespace(id="1", key="ABC-1", fields=sdk_fields)
+
+    issue = JiraIssue.from_jira_obj(obj)
+
+    assert issue.fields.votes is not None
+    assert issue.fields.votes.votes is None


### PR DESCRIPTION
## Summary

Phase 7a of [ADR-002](docs/adr/ADR-002-target-architecture.md) — first batch of converting the remaining ~38 migrations to the typed pipeline established in Phase 3. The ADR allocates 5–8 PRs to Phase 7; this PR converts 4 of the simplest.

## What's converted

- **\`inline_refs_migration.py\`** — \`isinstance(entry, dict) and entry.get('openproject_id')\` ladder → \`WorkPackageMappingEntry.from_legacy(str(key), value)\`. As a fix-along, the legacy \`int\` shape is now also handled correctly (was silently dropped pre-conversion).
- **\`security_levels_migration.py\`** — \`_extract\` reads \`fields.security.name\` via \`JiraIssueFields.from_issue_any\`; \`_load\` uses \`WorkPackageMappingEntry.from_legacy\` for the wp_map.
- **\`votes_migration.py\`** — \`_extract\` reads \`fields.votes.votes\`; \`_load\` uses \`WorkPackageMappingEntry.from_legacy\`.
- **\`resolution_migration.py\`** — \`_extract\` reads \`fields.resolution.name\`; \`_load\` uses \`WorkPackageMappingEntry.from_legacy\`.

**\`wp_defaults.py\` left unchanged.** It's a pure helper operating on OpenProject record dicts being assembled for the API — not a Jira-issue migration. No polymorphic wp_map ladder. Per the conversion rule "only convert sites that actually have the polymorphic ladder", nothing to do here.

## New models

\`src/models/jira/issue.py\` gets three new minimal refs (\`id\` + \`name\` pattern matching \`JiraStatusRef\`):
- \`JiraResolutionRef\`
- \`JiraSecurityLevelRef\`
- \`JiraVotesRef\` (also has \`votes: int\` count)

Wired into \`JiraIssueFields\` and \`_jira_fields_payload\` so \`from_issue_any\` produces them on the SDK path.

Plus three small defensive helpers in \`_jira_fields_payload\` (\`_safe_iter\`, \`_safe_user\`, stricter \`_str_or_none\`) — needed because some test fixtures use \`Mock()\` with auto-vivified attributes that Pydantic would otherwise reject. Real SDK objects and \`SimpleNamespace\` fixtures are unaffected.

## Quality gates
- \`ruff check\`, \`ruff format --check\` — clean
- \`mypy src/application src/models src/domain\` — 0 errors
- \`pytest tests/unit/\` — **1085 passed**, 30 deselected (was 1081; +4 new model tests for the new refs, **0 regressions**)

## Hard constraints respected
- Pure refactor — existing migration tests pass without modification
- \`from __future__ import annotations\` retained
- New models use \`ConfigDict(populate_by_name=True, extra=\"ignore\")\`
- BaseMigration / ComponentResult untouched

## Test plan
- [x] All quality gates green locally
- [x] +4 new tests for new refs
- [ ] CI green