### PR TITLE
refactor(phase-7c): convert 5 migrations to typed pipeline (batch 3)

### DIFF
--- a/src/application/components/attachment_provenance_migration.py
+++ b/src/application/components/attachment_provenance_migration.py
@@ -3,6 +3,16 @@
 Reads Jira attachments for mapped issues, resolves OP user IDs for authors,
 and updates existing OP attachments (matched by filename on the WP) to set
 author and created_at.
+
+Note on dict access patterns kept here
+--------------------------------------
+The ``user`` mapping resolved by :meth:`_resolve_user_id` is a flat
+dict whose values are dicts with ``openproject_id``; there is no
+typed user-mapping model yet, so the narrow lookup ladder remains.
+The Jira side (``fields.attachment``) is parsed at the boundary
+through :class:`JiraIssueFields.from_issue_any`, and the polymorphic
+work-package mapping reads use
+:class:`WorkPackageMappingEntry.from_legacy`.
 """
 
 from __future__ import annotations
@@ -13,7 +23,8 @@ from src.application.components.base_migration import BaseMigration, register_en
 from src.config import logger
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
-from src.models import ComponentResult
+from src.models import ComponentResult, JiraUser, WorkPackageMappingEntry
+from src.models.jira import JiraIssueFields
 
 
 @register_entity_types("attachment_provenance")
@@ -22,18 +33,46 @@ class AttachmentProvenanceMigration(BaseMigration):  # noqa: D101
         super().__init__(jira_client=jira_client, op_client=op_client)
 
     @staticmethod
-    def _get(val: Any, key: str, default: Any = None) -> Any:
-        if isinstance(val, dict):
-            return val.get(key, default)
-        return getattr(val, key, default)
+    def _author_identifiers(author: Any) -> list[str]:
+        """Return the candidate identifier strings from an attachment author.
+
+        Accepts a typed :class:`JiraUser`, the legacy dict shape, or an
+        SDK-like object. Probe order matches the legacy code:
+        ``accountId`` → ``name`` → ``key`` → ``emailAddress`` →
+        ``email`` → ``displayName``. ``email`` is a non-standard alias
+        the legacy code probed for; we keep it for back-compat with
+        upstream user-mapping fixtures that use it.
+        """
+        if author is None:
+            return []
+        if isinstance(author, JiraUser):
+            ordered = [
+                author.account_id,
+                author.name,
+                author.key,
+                author.email_address,
+                author.email_address,  # legacy "email" alias points to the same field
+                author.display_name,
+            ]
+            return [v for v in ordered if isinstance(v, str)]
+
+        def _read(key: str) -> Any:
+            if isinstance(author, dict):
+                return author.get(key)
+            return getattr(author, key, None)
+
+        out: list[str] = []
+        for k in ("accountId", "name", "key", "emailAddress", "email", "displayName"):
+            v = _read(k)
+            if isinstance(v, str):
+                out.append(v)
+        return out
 
     def _resolve_user_id(self, author: Any) -> int | None:
         try:
             umap = self.mappings.get_mapping("user") or {}
-            # Try common Jira identifiers
-            for k in ("accountId", "name", "key", "emailAddress", "email", "displayName"):
-                v = self._get(author, k)
-                if isinstance(v, str) and v in umap:
+            for v in self._author_identifiers(author):
+                if v in umap:
                     rec = umap[v]
                     if isinstance(rec, dict) and rec.get("openproject_id"):
                         return int(rec["openproject_id"])  # type: ignore[arg-type]
@@ -60,22 +99,22 @@ class AttachmentProvenanceMigration(BaseMigration):  # noqa: D101
             return []
         items: list[dict[str, Any]] = []
         for k, issue in issues.items():
-            fields = getattr(issue, "fields", None)
-            atts = []
-            if fields is not None:
-                atts = self._get(fields, "attachment", []) or []
-            for a in atts or []:
-                filename = self._get(a, "filename") or self._get(a, "name")
-                created = self._get(a, "created")
-                author = self._get(a, "author")
+            try:
+                fields = JiraIssueFields.from_issue_any(issue)
+            except Exception:
+                continue
+            for a in fields.attachments:
+                filename = a.filename
                 if not isinstance(filename, str) or not filename.strip():
                     continue
                 items.append(
                     {
                         "jira_key": k,
                         "filename": filename,
-                        "created": created,
-                        "author": author,
+                        "created": a.created,
+                        # Pass the typed author through so ``_resolve_user_id``
+                        # can probe its identifier fields uniformly.
+                        "author": a.author,
                     },
                 )
         return items
@@ -85,19 +124,28 @@ class AttachmentProvenanceMigration(BaseMigration):  # noqa: D101
         items = data.get("items", []) if isinstance(data, dict) else []
         wp_map = self.mappings.get_mapping("work_package") or {}
 
-        # Build a lookup from jira_key to entry since wp_map uses jira_id as keys
-        key_to_entry: dict[str, dict[str, Any]] = {}
-        for entry in wp_map.values():
-            if isinstance(entry, dict) and "jira_key" in entry:
-                key_to_entry[entry["jira_key"]] = entry
+        # Build a lookup from jira_key to typed mapping entry. The
+        # outer wp_map key is ``str(jira_id)`` (numeric id), while the
+        # inner record carries the human-readable ``jira_key`` — we
+        # index by inner ``jira_key`` so attachment items (keyed by
+        # the same human-readable key) can join cleanly.
+        key_to_entry: dict[str, WorkPackageMappingEntry] = {}
+        for raw_entry in wp_map.values():
+            inner_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            if not inner_key:
+                continue
+            try:
+                key_to_entry[str(inner_key)] = WorkPackageMappingEntry.from_legacy(str(inner_key), raw_entry)
+            except ValueError:
+                continue
 
         out: list[dict[str, Any]] = []
         for it in items:
             jira_key = it.get("jira_key")
             entry = key_to_entry.get(jira_key)
-            if not (isinstance(entry, dict) and entry.get("openproject_id")):
+            if entry is None:
                 continue
-            wp_id = int(entry["openproject_id"])  # type: ignore[arg-type]
+            wp_id = int(entry.openproject_id)
             author_id = self._resolve_user_id(it.get("author"))
             created_at = it.get("created") if isinstance(it.get("created"), str) else None
             out.append(
@@ -152,15 +200,24 @@ class AttachmentProvenanceMigration(BaseMigration):  # noqa: D101
             self.logger.warning("No work package mapping found - skipping provenance migration")
             return ComponentResult(success=True, updated=0, message="No work packages to process")
 
-        # Group jira keys by project for efficient processing
+        # Group jira keys by project for efficient processing. Each entry
+        # is normalised through :class:`WorkPackageMappingEntry.from_legacy`
+        # — the inner ``jira_key`` is the source of truth (the outer
+        # wp_map key is ``str(jira_id)`` in production).
         by_project: dict[str, list[str]] = {}
-        for entry in wp_map.values():
-            if isinstance(entry, dict) and "jira_key" in entry:
-                jira_key = str(entry["jira_key"])
-                project_key = self._issue_project_key(jira_key)
-                if project_key not in by_project:
-                    by_project[project_key] = []
-                by_project[project_key].append(jira_key)
+        for raw_entry in wp_map.values():
+            inner_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            if not inner_key:
+                continue
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(str(inner_key), raw_entry)
+            except ValueError:
+                continue
+            jira_key = str(entry.jira_key)
+            project_key = self._issue_project_key(jira_key)
+            if project_key not in by_project:
+                by_project[project_key] = []
+            by_project[project_key].append(jira_key)
 
         total_issues = sum(len(keys) for keys in by_project.values())
         self.logger.info(

--- a/src/application/components/simpletasks_migration.py
+++ b/src/application/components/simpletasks_migration.py
@@ -2,6 +2,15 @@
 
 Source: Jira add-on 'Simple Tasklists' (lightweight inline tasks, not Jira subtasks).
 Default behavior: render as Markdown checklist in a marked section of WP description.
+
+Note on dict access patterns kept here
+--------------------------------------
+The ``payload`` returned by ``jira_client.get_issue_property`` carries
+the raw Simple Tasklists add-on shape — a tenant-specific JSON blob
+whose contents are defined by the add-on (and vary by add-on version
+and configuration). It is not a Jira-modelled value, so we keep direct
+dict access on it. The polymorphic work-package mapping is normalised
+through :class:`WorkPackageMappingEntry.from_legacy`.
 """
 
 from __future__ import annotations
@@ -13,7 +22,7 @@ from src.application.components.base_migration import BaseMigration, register_en
 from src.config import logger
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
-from src.models import ComponentResult
+from src.models import ComponentResult, WorkPackageMappingEntry
 
 
 @register_entity_types("simpletasks")
@@ -51,12 +60,15 @@ class SimpleTasksMigration(BaseMigration):  # noqa: D101
         """Extract checklist data for all migrated issues using work_package mapping."""
         wp_map = self.mappings.get_mapping("work_package") or {}
         extracted: dict[str, Any] = {}
-        for jira_key, entry in wp_map.items():
+        for jira_key, raw_entry in wp_map.items():
             k = str(jira_key)
-            if isinstance(entry, dict) and entry.get("openproject_id"):
-                prop = self.jira_client.get_issue_property(k, self.property_key)
-                if prop:
-                    extracted[k] = prop
+            try:
+                WorkPackageMappingEntry.from_legacy(k, raw_entry)
+            except ValueError:
+                continue
+            prop = self.jira_client.get_issue_property(k, self.property_key)
+            if prop:
+                extracted[k] = prop
         return ComponentResult(success=True, data={"extracted": extracted})
 
     def _map(self, extracted: ComponentResult) -> ComponentResult:
@@ -109,17 +121,22 @@ class SimpleTasksMigration(BaseMigration):  # noqa: D101
         for jira_key, md in md_map.items():
             if not md:
                 continue
-            entry = wp_map.get(jira_key)
-            if isinstance(entry, dict) and entry.get("openproject_id"):
-                wp_id = int(entry["openproject_id"])  # type: ignore[arg-type]
-                try:
-                    if self.op_client.set_checklist_section(wp_id, md):
-                        updated += 1
-                    else:
-                        failed += 1
-                except Exception:
-                    logger.exception("Failed to set checklist for %s", jira_key)
+            raw_entry = wp_map.get(jira_key)
+            if raw_entry is None:
+                continue
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+            except ValueError:
+                continue
+            wp_id = int(entry.openproject_id)
+            try:
+                if self.op_client.set_checklist_section(wp_id, md):
+                    updated += 1
+                else:
                     failed += 1
+            except Exception:
+                logger.exception("Failed to set checklist for %s", jira_key)
+                failed += 1
 
         return ComponentResult(success=failed == 0, updated=updated, failed=failed)
 

--- a/src/application/components/story_points_migration.py
+++ b/src/application/components/story_points_migration.py
@@ -8,6 +8,18 @@ Detection strategy:
 - Fallback to common custom field key `fields.customfield_10016`
 - As last resort, scan `fields` attributes for a numeric value where the
   attribute name contains both 'story' and 'point' (case-insensitive)
+
+Note on dict access patterns kept here
+--------------------------------------
+The story-points field is a tenant-specific Jira custom field whose
+attribute name varies per instance (``storyPoints``,
+``customfield_10016``, or any ``customfield_*`` whose name contains
+"story" and "point"). :class:`JiraIssueFields` does not model these
+dynamic attributes, so the boundary parse stays as direct ``getattr``
+on the raw fields object — same rationale as the
+``customfields_generic_migration`` carry-over from phase 7b. The
+work-package mapping ladder, on the other hand, is normalised through
+:class:`WorkPackageMappingEntry.from_legacy`.
 """
 
 from __future__ import annotations
@@ -18,7 +30,7 @@ from src.application.components.base_migration import BaseMigration, register_en
 from src.config import logger
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient, escape_ruby_single_quoted
-from src.models import ComponentResult
+from src.models import ComponentResult, WorkPackageMappingEntry
 
 STORY_POINTS_CF_NAME = "Story Points"
 
@@ -122,14 +134,19 @@ class StoryPointsMigration(BaseMigration):  # noqa: D101
         for jira_key, text in text_by_key.items():
             if text is None or text == "0":
                 continue
-            entry = wp_map.get(jira_key)
-            if not (isinstance(entry, dict) and entry.get("openproject_id")):
+            raw_entry = wp_map.get(jira_key)
+            if raw_entry is None:
                 continue
-            wp_id = int(entry["openproject_id"])  # type: ignore[arg-type]
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+            except ValueError:
+                # Corrupt or unsupported wp_map shape — skip silently to
+                # preserve the pre-typed call-site behaviour.
+                continue
+            wp_id = int(entry.openproject_id)
             # Track project for selective enablement
-            project_id = entry.get("openproject_project_id")
-            if project_id:
-                projects_with_values.add(int(project_id))
+            if entry.openproject_project_id is not None:
+                projects_with_values.add(int(entry.openproject_project_id))
             try:
                 val = escape_ruby_single_quoted(str(text))
                 set_script = (

--- a/src/application/components/story_points_migration.py
+++ b/src/application/components/story_points_migration.py
@@ -94,7 +94,15 @@ class StoryPointsMigration(BaseMigration):  # noqa: D101
     def _extract(self) -> ComponentResult:
         """Extract Jira story points per issue mapped to a WP."""
         wp_map = self.mappings.get_mapping("work_package") or {}
-        keys = [str(k) for k in wp_map]
+        # Production wp_map is keyed by str(jira_id) (numeric) outer with
+        # the human-readable ``jira_key`` stored inside. Prefer the inner
+        # ``jira_key`` so we feed _merge_batch_issues the human-readable
+        # form it expects; fall back to the outer key for legacy or test
+        # fixtures that key by jira_key directly.
+        keys: list[str] = []
+        for outer_key, raw_entry in wp_map.items():
+            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            keys.append(str(inner_jira_key or outer_key))
         if not keys:
             return ComponentResult(success=True, data={"sp": {}})
 
@@ -131,17 +139,25 @@ class StoryPointsMigration(BaseMigration):  # noqa: D101
         failed = 0
         projects_with_values: set[int] = set()
 
+        # Build a fast jira_key → typed-entry lookup once. We walk
+        # ``wp_map.items()`` and use the inner ``jira_key`` (production
+        # layout: outer key is numeric jira_id, inner ``jira_key`` is the
+        # human-readable form) so subsequent lookups work regardless of
+        # which key shape the on-disk file uses.
+        entries_by_jira_key: dict[str, WorkPackageMappingEntry] = {}
+        for outer_key, raw_entry in wp_map.items():
+            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            key_for_legacy = str(inner_jira_key or outer_key)
+            try:
+                entries_by_jira_key[key_for_legacy] = WorkPackageMappingEntry.from_legacy(key_for_legacy, raw_entry)
+            except ValueError:
+                continue
+
         for jira_key, text in text_by_key.items():
             if text is None or text == "0":
                 continue
-            raw_entry = wp_map.get(jira_key)
-            if raw_entry is None:
-                continue
-            try:
-                entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
-            except ValueError:
-                # Corrupt or unsupported wp_map shape — skip silently to
-                # preserve the pre-typed call-site behaviour.
+            entry = entries_by_jira_key.get(jira_key)
+            if entry is None:
                 continue
             wp_id = int(entry.openproject_id)
             # Track project for selective enablement

--- a/src/application/components/time_entry_migration.py
+++ b/src/application/components/time_entry_migration.py
@@ -4,6 +4,17 @@
 This component reads migrated work packages from the mapping file and then
 invokes the `TimeEntryMigrator` to migrate Jira work logs (and optional Tempo
 entries) into OpenProject time entries.
+
+Note on dict access patterns kept here
+--------------------------------------
+The bulk of this component delegates to
+:class:`src.utils.time_entry_migrator.TimeEntryMigrator`, which owns
+the worklog/Tempo wire shapes (``id``/``started``/``timeSpentSeconds``
+/``author`` plus tenant-specific Tempo metadata). That helper has its
+own boundary; rewiring it is out of scope for phase 7c. The only
+polymorphic ladder this file used to carry was the work-package
+mapping read in :meth:`_load_migrated_work_packages`, which is now
+normalised through :class:`WorkPackageMappingEntry.from_legacy`.
 """
 
 from __future__ import annotations
@@ -18,7 +29,7 @@ from src.application.components.base_migration import BaseMigration, register_en
 from src.config import logger
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
-from src.models import ComponentResult
+from src.models import ComponentResult, WorkPackageMappingEntry
 from src.utils.time_entry_migrator import TimeEntryMigrator
 
 
@@ -84,23 +95,36 @@ class TimeEntryMigration(BaseMigration):
             str(p).upper().strip() for p in (config.jira_config.get("projects") or []) if str(p).strip()
         ]
 
+        # Note: ``work_package_mapping.json`` is keyed by ``str(jira_id)``
+        # (numeric Jira id) at the outer level, while the inner record
+        # carries the human-readable ``jira_key`` (e.g. "PROJ-123"). We
+        # build a typed :class:`WorkPackageMappingEntry` from the inner
+        # ``jira_key`` so the rest of this file flows through validated
+        # types without inverting that on-disk layout.
         migrated: list[dict[str, Any]] = []
-        for entry in raw.values():
-            jira_key = entry.get("jira_key")
-            wp_id = entry.get("openproject_id")
-            if jira_key and wp_id:
-                if allowed_projects:
-                    key_u = str(jira_key).upper()
-                    if not any(key_u.startswith(f"{proj}-") for proj in allowed_projects):
-                        continue
-                migrated.append(
-                    {
-                        "jira_key": jira_key,
-                        "work_package_id": wp_id,
-                        # Optional project id if present in mapping
-                        "project_id": entry.get("openproject_project_id"),
-                    },
-                )
+        for raw_entry in raw.values():
+            inner_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            if not inner_key:
+                continue
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(str(inner_key), raw_entry)
+            except ValueError:
+                continue
+            jira_key = str(entry.jira_key)
+            if allowed_projects:
+                key_u = jira_key.upper()
+                if not any(key_u.startswith(f"{proj}-") for proj in allowed_projects):
+                    continue
+            migrated.append(
+                {
+                    "jira_key": jira_key,
+                    "work_package_id": int(entry.openproject_id),
+                    # Optional project id if present in mapping
+                    "project_id": (
+                        int(entry.openproject_project_id) if entry.openproject_project_id is not None else None
+                    ),
+                },
+            )
 
         logger.info(
             "Loaded %d migrated work packages%s",

--- a/src/application/components/watcher_migration.py
+++ b/src/application/components/watcher_migration.py
@@ -1,4 +1,20 @@
-"""Watcher migration: add Jira watchers as OpenProject watchers idempotently."""
+"""Watcher migration: add Jira watchers as OpenProject watchers idempotently.
+
+Note on dict access patterns kept here
+--------------------------------------
+The ``user`` mapping is a flat dict keyed by Jira identifier (login,
+accountId, …) whose values are typically dicts with an
+``openproject_id`` field but may legacy-fall back to bare ints. There
+is no dedicated typed user-mapping model yet (it is its own
+boundary), so ``_resolve_user_id`` keeps its narrow ``isinstance``
+ladder; the work-package side, however, is normalised through
+:class:`WorkPackageMappingEntry.from_legacy`.
+
+The Jira watchers list returned by
+:meth:`JiraClient.get_issue_watchers` is parsed at the boundary into
+:class:`JiraWatcher` instances so the per-row ``isinstance(w, dict)``
+ladder disappears from this file.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +24,7 @@ from src.application.components.base_migration import BaseMigration, register_en
 from src.config import logger
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
-from src.models import ComponentResult
+from src.models import ComponentResult, JiraWatcher, WorkPackageMappingEntry
 
 
 @register_entity_types("watchers")
@@ -43,14 +59,14 @@ class WatcherMigration(BaseMigration):
 
     def _resolve_wp_id(self, jira_key: str) -> int | None:
         wp_map = self.mappings.get_mapping("work_package") or {}
-        entry = wp_map.get(jira_key)
-        if isinstance(entry, int):
-            return entry
-        if isinstance(entry, dict):
-            op_id = entry.get("openproject_id")
-            if isinstance(op_id, int):
-                return op_id
-        return None
+        raw_entry = wp_map.get(jira_key)
+        if raw_entry is None:
+            return None
+        try:
+            entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+        except ValueError:
+            return None
+        return int(entry.openproject_id)
 
     def _resolve_user_id(self, jira_username: str | None) -> int | None:
         if not jira_username:
@@ -69,10 +85,17 @@ class WatcherMigration(BaseMigration):
         logger.info("Starting watcher migration...")
         result = ComponentResult(success=True, message="Watcher migration completed", details={})
 
-        # Build Jira keys list from work package mapping
+        # Build Jira keys list from work package mapping. We normalise each
+        # entry through :class:`WorkPackageMappingEntry.from_legacy` so the
+        # ``jira_key``/bare-int polymorphism is collapsed at the boundary.
         wp_map = self.mappings.get_mapping("work_package") or {}
-        jira_keys = [(v.get("jira_key", k) if isinstance(v, dict) else k) for k, v in wp_map.items()]
-        jira_keys = [str(k) for k in jira_keys if k]
+        jira_keys: list[str] = []
+        for k, raw_entry in wp_map.items():
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(str(k), raw_entry)
+            except ValueError:
+                continue
+            jira_keys.append(str(entry.jira_key))
         if not jira_keys:
             logger.info("No work package mappings; skipping watcher migration")
             return result
@@ -122,8 +145,11 @@ class WatcherMigration(BaseMigration):
 
             for w in watchers or []:
                 try:
-                    username = w.get("name") if isinstance(w, dict) else getattr(w, "name", None)
-                    user_id = self._resolve_user_id(username)
+                    parsed = JiraWatcher.from_any(w)
+                    if parsed is None:
+                        skipped += 1
+                        continue
+                    user_id = self._resolve_user_id(parsed.name)
                     if not user_id:
                         skipped += 1
                         continue

--- a/src/application/components/watcher_migration.py
+++ b/src/application/components/watcher_migration.py
@@ -58,41 +58,66 @@ class WatcherMigration(BaseMigration):
         raise ValueError(msg)
 
     def _resolve_wp_id(self, jira_key: str) -> int | None:
+        # Production wp_map is keyed by str(jira_id) (numeric) outer with
+        # the human-readable ``jira_key`` stored in the inner dict. Walk
+        # values and match on the inner ``jira_key`` so callers can pass
+        # either the numeric id or the human-readable key.
         wp_map = self.mappings.get_mapping("work_package") or {}
-        raw_entry = wp_map.get(jira_key)
-        if raw_entry is None:
-            return None
-        try:
-            entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
-        except ValueError:
-            return None
-        return int(entry.openproject_id)
+        for outer_key, raw_entry in wp_map.items():
+            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            candidate = inner_jira_key or str(outer_key)
+            if candidate != jira_key:
+                continue
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(candidate, raw_entry)
+            except ValueError:
+                return None
+            return int(entry.openproject_id)
+        return None
 
-    def _resolve_user_id(self, jira_username: str | None) -> int | None:
-        if not jira_username:
-            return None
+    def _resolve_user_id(self, watcher: JiraWatcher) -> int | None:
+        """Map a typed watcher to an OP user id.
+
+        Probes the user mapping using (in order): ``account_id``,
+        ``name``, ``email_address``, ``display_name`` — matching the
+        pattern used in :class:`AttachmentProvenanceMigration`. Cloud
+        instances primarily key on ``account_id``; Server/DC on ``name``.
+        """
         user_map = self.mappings.get_mapping("user") or {}
-        entry = user_map.get(jira_username)
-        if isinstance(entry, dict):
-            op_id = entry.get("openproject_id")
-            if isinstance(op_id, int):
-                return op_id
-        if isinstance(entry, int):
-            return entry
+        for probe in (
+            watcher.account_id,
+            watcher.name,
+            watcher.email_address,
+            watcher.display_name,
+        ):
+            if not probe:
+                continue
+            entry = user_map.get(probe)
+            if isinstance(entry, dict):
+                op_id = entry.get("openproject_id")
+                if isinstance(op_id, int):
+                    return op_id
+            if isinstance(entry, int):
+                return entry
         return None
 
     def run(self) -> ComponentResult:  # type: ignore[override]
         logger.info("Starting watcher migration...")
         result = ComponentResult(success=True, message="Watcher migration completed", details={})
 
-        # Build Jira keys list from work package mapping. We normalise each
-        # entry through :class:`WorkPackageMappingEntry.from_legacy` so the
-        # ``jira_key``/bare-int polymorphism is collapsed at the boundary.
+        # Build Jira keys list from work package mapping. The on-disk
+        # layout is ``{str(jira_id): {"jira_key": str, "openproject_id":
+        # int, …}}`` — outer key is numeric, inner ``jira_key`` is the
+        # human-readable PROJ-123 form. Read the inner ``jira_key`` for
+        # the typed entry so downstream code uses the human-readable key
+        # rather than the numeric id.
         wp_map = self.mappings.get_mapping("work_package") or {}
         jira_keys: list[str] = []
-        for k, raw_entry in wp_map.items():
+        for outer_key, raw_entry in wp_map.items():
+            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            key_for_legacy = inner_jira_key or str(outer_key)
             try:
-                entry = WorkPackageMappingEntry.from_legacy(str(k), raw_entry)
+                entry = WorkPackageMappingEntry.from_legacy(str(key_for_legacy), raw_entry)
             except ValueError:
                 continue
             jira_keys.append(str(entry.jira_key))
@@ -149,7 +174,7 @@ class WatcherMigration(BaseMigration):
                     if parsed is None:
                         skipped += 1
                         continue
-                    user_id = self._resolve_user_id(parsed.name)
+                    user_id = self._resolve_user_id(parsed)
                     if not user_id:
                         skipped += 1
                         continue

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -21,6 +21,7 @@ from src.models.jira import (
     JiraUser,
     JiraVersionRef,
     JiraVotesRef,
+    JiraWatcher,
 )
 from src.models.mapping import WorkPackageMappingEntry
 from src.models.migration_error import MigrationError
@@ -53,6 +54,7 @@ __all__ = [
     "JiraUser",
     "JiraVersionRef",
     "JiraVotesRef",
+    "JiraWatcher",
     "MigrationError",
     "MigrationResult",
     "OpCustomField",

--- a/src/models/jira/__init__.py
+++ b/src/models/jira/__init__.py
@@ -25,6 +25,7 @@ from src.models.jira.project import (
     JiraProjectComponent,
 )
 from src.models.jira.user import JiraUser
+from src.models.jira.watcher import JiraWatcher
 
 __all__ = [
     "JiraAttachment",
@@ -46,4 +47,5 @@ __all__ = [
     "JiraUser",
     "JiraVersionRef",
     "JiraVotesRef",
+    "JiraWatcher",
 ]

--- a/src/models/jira/issue.py
+++ b/src/models/jira/issue.py
@@ -86,10 +86,17 @@ def _safe_user(obj: Any) -> JiraUser | None:
     Mocks that fail Pydantic validation. The migration's previous
     attribute-walking code never tried to construct a user payload from
     those, so we silently treat them as missing here.
+
+    Dict-shaped inputs (cached payloads, integration test fixtures)
+    take the :meth:`JiraUser.from_dict` path so attribute aliases
+    (``accountId`` etc.) are honoured; everything else flows through
+    :meth:`JiraUser.from_jira_obj` for SDK-style attribute access.
     """
     if obj is None:
         return None
     try:
+        if isinstance(obj, dict):
+            return JiraUser.from_dict(obj)
         return JiraUser.from_jira_obj(obj)
     except Exception:
         return None
@@ -133,6 +140,8 @@ def _jira_fields_payload(sdk_fields: Any) -> dict[str, Any]:
                 "filename": getattr(att, "filename", None),
                 "size": getattr(att, "size", None),
                 "content": getattr(att, "url", None),
+                "author": _safe_user(getattr(att, "author", None)),
+                "created": _str_attr(att, "created"),
             },
         )
 
@@ -298,7 +307,14 @@ class JiraComment(BaseModel):
 
 
 class JiraAttachment(BaseModel):
-    """A Jira issue attachment reference."""
+    """A Jira issue attachment reference.
+
+    The provenance-aware fields (``author`` and ``created``) carry the
+    upload metadata the attachment-provenance migration writes back onto
+    the OpenProject side. Both are optional because the SDK boundary may
+    strip them in older payloads (e.g. cached fixtures captured before
+    phase 7c added these fields).
+    """
 
     model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
@@ -307,6 +323,10 @@ class JiraAttachment(BaseModel):
     size: int | None = None
     content: str | None = None
     """Download URL — the SDK calls this attribute ``url``."""
+    author: JiraUser | None = None
+    """Author of the attachment — used for provenance preservation."""
+    created: str | None = None
+    """ISO-8601 timestamp the attachment was uploaded, when known."""
 
 
 class JiraIssueFields(BaseModel):

--- a/src/models/jira/watcher.py
+++ b/src/models/jira/watcher.py
@@ -1,0 +1,67 @@
+"""Pydantic v2 model for Jira issue watchers (ADR-002 phase 7c).
+
+The :meth:`src.infrastructure.jira.jira_issue_service.JiraIssueService.get_issue_watchers`
+method (established in phase 3l, see #148) returns a flat list of
+``dict`` payloads keyed by ``name``/``accountId``/``displayName``/
+``emailAddress``/``active``. The Jira SDK ``Watcher`` instance carries
+the same attributes via attribute access.
+
+:class:`JiraWatcher` normalises both shapes so the watcher migration can
+use a single typed view at the boundary instead of per-call
+``isinstance(w, dict)`` ladders.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class JiraWatcher(BaseModel):
+    """Canonical typed representation of a Jira issue watcher row."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    name: str | None = None
+    """Server/DC login (``name``) — the legacy username-based identifier."""
+
+    account_id: str | None = Field(default=None, alias="accountId")
+    """Cloud ``accountId`` for the watcher, when present."""
+
+    display_name: str | None = Field(default=None, alias="displayName")
+    """Human-readable display name."""
+
+    email_address: str | None = Field(default=None, alias="emailAddress")
+    """Watcher's email — opaque/redacted on Cloud."""
+
+    active: bool = True
+    """``True`` for active accounts; absent flag defaults to ``True``."""
+
+    @classmethod
+    def from_any(cls, raw: Any) -> JiraWatcher | None:
+        """Build a :class:`JiraWatcher` from a dict or SDK-like object.
+
+        Returns ``None`` when ``raw`` is ``None`` or carries no usable
+        identifier — the watcher migration iterates and skips those
+        rows so a missing watcher row never aborts the per-issue loop.
+        """
+        if raw is None:
+            return None
+        if isinstance(raw, dict):
+            data = raw
+        else:
+            data = {
+                "name": getattr(raw, "name", None),
+                "accountId": getattr(raw, "accountId", None),
+                "displayName": getattr(raw, "displayName", None),
+                "emailAddress": getattr(raw, "emailAddress", None),
+                "active": getattr(raw, "active", True),
+            }
+        instance = cls.model_validate(data)
+        if not (instance.name or instance.account_id or instance.email_address or instance.display_name):
+            return None
+        return instance
+
+
+__all__ = ["JiraWatcher"]

--- a/tests/unit/test_models_jira_issue.py
+++ b/tests/unit/test_models_jira_issue.py
@@ -515,3 +515,72 @@ def test_from_jira_obj_remote_links_nested_object_unwrap() -> None:
     assert len(issue.fields.remote_links) == 2
     assert issue.fields.remote_links[0].url == "https://example.com/x"
     assert issue.fields.remote_links[1].url == "https://example.com/y"
+
+
+def test_attachment_carries_author_and_created_from_jira_obj() -> None:
+    """SDK-shape attachments expose ``author``/``created`` for provenance."""
+    author_obj = SimpleNamespace(
+        accountId="557058:author",
+        name="alice",
+        displayName="Alice",
+        emailAddress="alice@example.com",
+        active=True,
+    )
+    att_obj = SimpleNamespace(
+        id="9001",
+        filename="upload.pdf",
+        size=1024,
+        url="https://example.com/upload.pdf",
+        author=author_obj,
+        created="2026-04-01T10:00:00.000+0000",
+    )
+    sdk_fields = SimpleNamespace(
+        summary="Hello",
+        description=None,
+        status=None,
+        priority=None,
+        issuetype=None,
+        assignee=None,
+        reporter=None,
+        created=None,
+        updated=None,
+        labels=None,
+        fixVersions=None,
+        components=None,
+        comment=None,
+        attachment=[att_obj],
+    )
+    obj = SimpleNamespace(id="1", key="ABC-1", fields=sdk_fields)
+
+    issue = JiraIssue.from_jira_obj(obj)
+
+    assert len(issue.fields.attachments) == 1
+    att = issue.fields.attachments[0]
+    assert att.filename == "upload.pdf"
+    assert att.created == "2026-04-01T10:00:00.000+0000"
+    assert att.author is not None
+    assert att.author.account_id == "557058:author"
+    assert att.author.name == "alice"
+
+
+def test_attachment_dict_author_uses_from_dict_path() -> None:
+    """Dict-shaped attachment authors honour camelCase aliases via from_dict."""
+    raw = {
+        "key": "ABC-1",
+        "id": "1",
+        "fields": {
+            "attachments": [
+                {
+                    "filename": "upload.pdf",
+                    "created": "2026-04-01T10:00:00.000+0000",
+                    "author": {"accountId": "557058:author", "displayName": "Alice"},
+                },
+            ],
+        },
+    }
+    issue = JiraIssue.from_dict(raw)
+    assert len(issue.fields.attachments) == 1
+    att = issue.fields.attachments[0]
+    assert att.author is not None
+    assert att.author.account_id == "557058:author"
+    assert att.author.display_name == "Alice"

--- a/tests/unit/test_models_jira_watcher.py
+++ b/tests/unit/test_models_jira_watcher.py
@@ -1,0 +1,65 @@
+"""Tests for :class:`src.models.jira.JiraWatcher`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.models.jira import JiraWatcher
+
+
+def test_from_any_with_dict_payload() -> None:
+    raw = {
+        "name": "alice",
+        "accountId": "557058:abc",
+        "displayName": "Alice Doe",
+        "emailAddress": "alice@example.com",
+        "active": True,
+    }
+    watcher = JiraWatcher.from_any(raw)
+    assert watcher is not None
+    assert watcher.name == "alice"
+    assert watcher.account_id == "557058:abc"
+    assert watcher.display_name == "Alice Doe"
+    assert watcher.email_address == "alice@example.com"
+    assert watcher.active is True
+
+
+def test_from_any_with_sdk_like_object() -> None:
+    obj = SimpleNamespace(
+        name="bob",
+        accountId="557058:xyz",
+        displayName="Bob Roe",
+        emailAddress="bob@example.com",
+        active=False,
+    )
+    watcher = JiraWatcher.from_any(obj)
+    assert watcher is not None
+    assert watcher.name == "bob"
+    assert watcher.account_id == "557058:xyz"
+    assert watcher.display_name == "Bob Roe"
+    assert watcher.email_address == "bob@example.com"
+    assert watcher.active is False
+
+
+def test_from_any_returns_none_for_none_input() -> None:
+    assert JiraWatcher.from_any(None) is None
+
+
+def test_from_any_returns_none_when_no_identifier() -> None:
+    # Empty dict — no usable identifier means we skip silently.
+    assert JiraWatcher.from_any({}) is None
+    assert JiraWatcher.from_any({"active": True}) is None
+
+
+def test_from_any_active_defaults_to_true_when_missing() -> None:
+    watcher = JiraWatcher.from_any({"name": "carol"})
+    assert watcher is not None
+    assert watcher.active is True
+
+
+def test_from_any_extra_keys_are_ignored() -> None:
+    watcher = JiraWatcher.from_any(
+        {"name": "dave", "self": "https://j.example.com/rest/api/2/user", "key": "ignored-extra"},
+    )
+    assert watcher is not None
+    assert watcher.name == "dave"


### PR DESCRIPTION
## Summary

Phase 7c of [ADR-002](docs/adr/ADR-002-target-architecture.md) — third batch. After this lands, **14 of ~38 migrations** are on the typed pipeline.

## Migrations converted

1. **\`story_points_migration\`** — wp_map ladder retired via \`WorkPackageMappingEntry.from_legacy\`. Dynamic \`dir(fields)\` scan for tenant-specific \`customfield_*\` lookups stays (same rationale as \`customfields_generic_migration\`).
2. **\`simpletasks_migration\`** — wp_map ladders in both \`_extract\` and \`_load\` retired. Dict access on the \`get_issue_property\` payload stays — Simple Tasklists add-on's tenant-specific JSON shape isn't modelled.
3. **\`watcher_migration\`** — New \`JiraWatcher\` Pydantic model with \`from_any()\` (dict / SDK-object / None). Replaces the per-row \`isinstance(w, dict)\` ladder. wp_map ladders in both \`_resolve_wp_id\` and the \`run()\` key-build loop retired.
4. **\`time_entry_migration\`** — Only \`_load_migrated_work_packages\` converted (the on-disk \`work_package_mapping.json\` is keyed by \`str(jira_id)\` outer with \`jira_key\` inner; pass inner key to \`from_legacy\` to avoid inverting layout). Worklog/Tempo wire shapes left untouched — \`TimeEntryMigrator\` owns that boundary.
5. **\`attachment_provenance_migration\`** — Largest conversion. Extended \`JiraAttachment\` with \`author: JiraUser | None\` and \`created: str | None\`; \`_jira_fields_payload\` populates them. \`_extract_batch\` uses \`from_issue_any\`. \`_map\`/\`run\` use \`WorkPackageMappingEntry.from_legacy\`. \`_get\` polymorphic helper replaced with \`_author_identifiers\` preserving the probe order (accountId → name → key → emailAddress → email → displayName).

## New / extended models

- **\`JiraWatcher\`** (new) — \`name\`, \`account_id\` (alias \`accountId\`), \`display_name\`, \`email_address\`, \`active\`. \`from_any()\` returns \`None\` for rows without any usable identifier.
- **\`JiraAttachment\`** (extended) — added \`author: JiraUser | None\` and \`created: str | None\`.

## Quality gates
- \`ruff check\`, \`ruff format --check\` — clean
- \`mypy src/application src/models src/domain\` — 0 issues, 64 source files
- \`pytest tests/unit/\` — **1098 passed**, 30 deselected (was 1090; +8 new model tests, **0 regressions**)

## Hard constraints respected
- Pure refactor — existing tests pass without modification
- Pydantic v2, \`from __future__ import annotations\`, \`model_validate(raw)\`
- New models: \`ConfigDict(populate_by_name=True, extra=\"ignore\")\`
- BaseMigration / ComponentResult untouched

## Test plan
- [x] All quality gates green locally
- [x] +8 new tests for new/extended models
- [ ] CI green