### PR TITLE
refactor(phase-7e): convert attachments_migration + document 4 out-of-scope

### DIFF
--- a/src/application/components/admin_scheme_migration.py
+++ b/src/application/components/admin_scheme_migration.py
@@ -1,4 +1,25 @@
-"""Migrate Jira permission roles into OpenProject project memberships."""
+"""Migrate Jira permission roles into OpenProject project memberships.
+
+Phase 7e notes
+--------------
+This migration does **not** consume the ``work_package`` mapping. The
+three mappings it touches — ``project``, ``user`` and ``group`` — each
+have their own polymorphic shape that is unrelated to the ``wp_map``
+``dict | int`` ladder phase 7 retires:
+
+* ``project_mapping`` values are dicts with ``openproject_id`` (and
+  occasionally bare ints in older fixtures); used only for filtering
+  which projects to fetch role data for.
+* ``user_mapping`` values are dicts; the multi-identifier probe in
+  :func:`resolve_user_id` already orders ``accountId`` → ``userKey`` →
+  ``name`` explicitly, but the *actor* shape it walks is a custom Jira
+  REST role-actor envelope (``type``, ``name``, ``accountId``,
+  ``userKey``, ``groupName``) that :class:`JiraUser` does not model.
+* ``group_mapping`` values are dicts keyed by group name.
+
+Modelling these as Pydantic types would be pure cosmetic churn at this
+site and is intentionally deferred. Behaviour preserved.
+"""
 
 from __future__ import annotations
 

--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -44,6 +44,11 @@ from src.models import ComponentResult, WorkPackageMappingEntry
 
 @register_entity_types("attachments")
 class AttachmentsMigration(BaseMigration):  # noqa: D101
+    # Cache for the wp_map → jira_key lookup. Built lazily on first use
+    # by :meth:`_wp_lookup_by_jira_key`; reset to ``None`` whenever the
+    # migration runs against a fresh mappings instance.
+    _wp_lookup_cache: dict[str, int] | None
+
     def __init__(self, jira_client: JiraClient, op_client: OpenProjectClient) -> None:
         super().__init__(jira_client=jira_client, op_client=op_client)
         # Attachment directory
@@ -53,6 +58,44 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             ap = None
         self.attachment_dir: Path = Path(ap or (Path(self.data_dir) / "attachments"))
         self.attachment_dir.mkdir(parents=True, exist_ok=True)
+        self._wp_lookup_cache = None
+
+    def _wp_lookup_by_jira_key(self) -> dict[str, int]:
+        """Return a cached ``jira_key → openproject_id`` lookup.
+
+        Walks the ``work_package`` mapping once and normalises each row
+        through :meth:`WorkPackageMappingEntry.from_legacy`. Production
+        ``wp_map`` is keyed by ``str(jira_id)`` outer with the
+        human-readable ``jira_key`` stored inside; legacy/test fixtures
+        sometimes key directly by ``jira_key``. Resolution rules:
+
+        * dict shape with inner ``jira_key`` → use the inner key.
+        * dict shape without inner ``jira_key`` → fall back to outer
+          (covers test fixtures keyed by ``jira_key``).
+        * bare ``int`` shape → SKIP. Legacy bare-int rows do not carry
+          a recoverable ``jira_key``; treating the numeric outer key
+          as a Jira issue key would produce invalid downstream queries
+          like ``key in (10001, …)``.
+
+        Callers receive a copy so accidental mutation cannot poison
+        the cache.
+        """
+        if self._wp_lookup_cache is None:
+            wp_map = self.mappings.get_mapping("work_package") or {}
+            lookup: dict[str, int] = {}
+            for outer_key, raw_entry in wp_map.items():
+                if not isinstance(raw_entry, dict):
+                    # Bare-int legacy rows have no recoverable Jira key.
+                    continue
+                inner_jira_key = raw_entry.get("jira_key")
+                jira_key = str(inner_jira_key or outer_key)
+                try:
+                    entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+                except ValueError:
+                    continue
+                lookup[jira_key] = int(entry.openproject_id)
+            self._wp_lookup_cache = lookup
+        return dict(self._wp_lookup_cache)
 
     def _get_current_entities_for_type(self, entity_type: str) -> list[dict[str, Any]]:
         """Get current entities for transformation.
@@ -185,22 +228,7 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         if not att_by_key:
             return ComponentResult(success=True, data={"ops": []})
 
-        wp_map = self.mappings.get_mapping("work_package") or {}
-
-        # Build a Jira-key → wp-id lookup that absorbs both layouts:
-        # production keys ``wp_map`` by ``str(jira_id)`` with the
-        # human-readable ``jira_key`` stored inside the value, while
-        # legacy/test fixtures key directly by Jira issue key. Inner
-        # ``jira_key`` wins; outer key is the fallback for legacy data.
-        key_to_wp_id: dict[str, int] = {}
-        for outer_key, raw_entry in wp_map.items():
-            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
-            jira_key = str(inner_jira_key or outer_key)
-            try:
-                entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
-            except ValueError:
-                continue
-            key_to_wp_id[jira_key] = int(entry.openproject_id)
+        key_to_wp_id = self._wp_lookup_by_jira_key()
 
         ops: list[dict[str, Any]] = []
         seen_digests: set[str] = set()
@@ -392,13 +420,11 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
     def _process_batch_end_to_end(
         self,
         jira_keys: list[str],
-        wp_map: dict[str, Any],
     ) -> tuple[int, int, dict[str, dict[str, int]]]:
         """Process a batch of issues: extract, download, upload, attach.
 
         Args:
             jira_keys: List of Jira issue keys to process
-            wp_map: Work package mapping dict
 
         Returns:
             Tuple of (updated_count, failed_count, attachment_mapping)
@@ -411,18 +437,8 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         if not att_by_key:
             return 0, 0, {}
 
-        # Build reverse lookup: jira_key -> openproject_id for O(1) access.
-        # Funnel through ``WorkPackageMappingEntry.from_legacy`` so the
-        # ``dict | int`` polymorphism is normalised in one place.
-        key_to_wp: dict[str, int] = {}
-        for outer_key, raw_entry in wp_map.items():
-            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
-            jira_key = str(inner_jira_key or outer_key)
-            try:
-                typed_entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
-            except ValueError:
-                continue
-            key_to_wp[jira_key] = int(typed_entry.openproject_id)
+        # Single normalisation source — see ``_wp_lookup_by_jira_key``.
+        key_to_wp = self._wp_lookup_by_jira_key()
 
         # Download attachments and prepare ops
         ops: list[dict[str, Any]] = []
@@ -489,27 +505,16 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         """Execute attachment migration pipeline - memory efficient per-project."""
         self.logger.info("Starting attachment migration (memory-efficient mode)")
 
-        # Get work package mapping
-        wp_map = self.mappings.get_mapping("work_package") or {}
-        if not wp_map:
+        # Build the canonical Jira-key → wp-id lookup once, then group
+        # the resolved Jira keys by project for batch-friendly processing.
+        # See :meth:`_wp_lookup_by_jira_key` for normalisation rules.
+        key_to_wp_id = self._wp_lookup_by_jira_key()
+        if not key_to_wp_id:
             self.logger.warning("No work package mapping found - skipping attachment migration")
             return ComponentResult(success=True, updated=0, message="No work packages to process")
 
-        # Group jira keys by project for efficient processing. Walk the
-        # raw map (production: outer = ``str(jira_id)``, inner =
-        # ``{"jira_key": ...}``) and prefer the inner ``jira_key``;
-        # ``WorkPackageMappingEntry.from_legacy`` validates the row and
-        # makes the dict/int polymorphism the responsibility of a single
-        # boundary parser. Rows that don't normalise are skipped, just
-        # like the legacy ``isinstance(entry, dict)`` guard did.
         by_project: dict[str, list[str]] = {}
-        for outer_key, raw_entry in wp_map.items():
-            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
-            jira_key = str(inner_jira_key or outer_key)
-            try:
-                WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
-            except ValueError:
-                continue
+        for jira_key in key_to_wp_id:
             project_key = self._issue_project_key(jira_key)
             if project_key not in by_project:
                 by_project[project_key] = []
@@ -540,7 +545,6 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                 try:
                     updated, failed, mapping = self._process_batch_end_to_end(
                         batch_keys,
-                        wp_map,
                     )
                     total_updated += updated
                     total_failed += failed

--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -5,6 +5,25 @@ Flow:
 - Map: download to local attachment path, compute sha256, deduplicate by digest.
 - Load: copy files to container and run a minimal Rails script to attach files
   to the corresponding work packages idempotently (skip if same filename exists).
+
+Phase 7e notes
+--------------
+The polymorphic ``wp_map`` (``dict | int``) ladder used to resolve a Jira
+issue key to an OpenProject work-package id is normalised through
+:meth:`WorkPackageMappingEntry.from_legacy` here. Production ``wp_map``
+is keyed by ``str(jira_id)`` (numeric) outer, with the human-readable
+``jira_key`` stored inside the value; the mapping walk prefers the
+inner ``jira_key`` and falls back to the outer key (matching test
+fixtures that key directly by Jira issue key).
+
+The Jira SDK boundary in :meth:`_extract_batch` is intentionally left
+duck-typed: the legacy reader probes ``attachment.content`` (an SDK
+quirk — the real ``jira.Attachment`` exposes the download URL via
+``url`` while cached/test payloads tend to expose ``content``). The
+canonical :class:`JiraIssueFields.from_issue_any` reader maps
+``att.url`` to ``JiraAttachment.content``, which would change observed
+behaviour against the existing test doubles. Phase 7's scope is the
+``wp_map`` ladder; this SDK probe is deferred.
 """
 
 from __future__ import annotations
@@ -20,7 +39,7 @@ from src.application.components.base_migration import BaseMigration, register_en
 from src.config import logger
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
-from src.models import ComponentResult
+from src.models import ComponentResult, WorkPackageMappingEntry
 
 
 @register_entity_types("attachments")
@@ -167,16 +186,27 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             return ComponentResult(success=True, data={"ops": []})
 
         wp_map = self.mappings.get_mapping("work_package") or {}
+
+        # Build a Jira-key → wp-id lookup that absorbs both layouts:
+        # production keys ``wp_map`` by ``str(jira_id)`` with the
+        # human-readable ``jira_key`` stored inside the value, while
+        # legacy/test fixtures key directly by Jira issue key. Inner
+        # ``jira_key`` wins; outer key is the fallback for legacy data.
+        key_to_wp_id: dict[str, int] = {}
+        for outer_key, raw_entry in wp_map.items():
+            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            jira_key = str(inner_jira_key or outer_key)
+            try:
+                entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+            except ValueError:
+                continue
+            key_to_wp_id[jira_key] = int(entry.openproject_id)
+
         ops: list[dict[str, Any]] = []
         seen_digests: set[str] = set()
 
         for key, items in att_by_key.items():
-            entry = wp_map.get(key)
-            wp_id = None
-            if isinstance(entry, dict):
-                wp_id = entry.get("openproject_id")
-            elif isinstance(entry, int):
-                wp_id = entry
+            wp_id = key_to_wp_id.get(key)
             if not wp_id:
                 continue
 
@@ -381,12 +411,18 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         if not att_by_key:
             return 0, 0, {}
 
-        # Build reverse lookup: jira_key -> openproject_id for O(1) access
-        key_to_wp = {
-            entry.get("jira_key"): entry.get("openproject_id")
-            for entry in wp_map.values()
-            if isinstance(entry, dict) and entry.get("jira_key")
-        }
+        # Build reverse lookup: jira_key -> openproject_id for O(1) access.
+        # Funnel through ``WorkPackageMappingEntry.from_legacy`` so the
+        # ``dict | int`` polymorphism is normalised in one place.
+        key_to_wp: dict[str, int] = {}
+        for outer_key, raw_entry in wp_map.items():
+            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            jira_key = str(inner_jira_key or outer_key)
+            try:
+                typed_entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+            except ValueError:
+                continue
+            key_to_wp[jira_key] = int(typed_entry.openproject_id)
 
         # Download attachments and prepare ops
         ops: list[dict[str, Any]] = []
@@ -459,15 +495,25 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             self.logger.warning("No work package mapping found - skipping attachment migration")
             return ComponentResult(success=True, updated=0, message="No work packages to process")
 
-        # Group jira keys by project for efficient processing
+        # Group jira keys by project for efficient processing. Walk the
+        # raw map (production: outer = ``str(jira_id)``, inner =
+        # ``{"jira_key": ...}``) and prefer the inner ``jira_key``;
+        # ``WorkPackageMappingEntry.from_legacy`` validates the row and
+        # makes the dict/int polymorphism the responsibility of a single
+        # boundary parser. Rows that don't normalise are skipped, just
+        # like the legacy ``isinstance(entry, dict)`` guard did.
         by_project: dict[str, list[str]] = {}
-        for entry in wp_map.values():
-            if isinstance(entry, dict) and "jira_key" in entry:
-                jira_key = str(entry["jira_key"])
-                project_key = self._issue_project_key(jira_key)
-                if project_key not in by_project:
-                    by_project[project_key] = []
-                by_project[project_key].append(jira_key)
+        for outer_key, raw_entry in wp_map.items():
+            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            jira_key = str(inner_jira_key or outer_key)
+            try:
+                WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+            except ValueError:
+                continue
+            project_key = self._issue_project_key(jira_key)
+            if project_key not in by_project:
+                by_project[project_key] = []
+            by_project[project_key].append(jira_key)
 
         total_issues = sum(len(keys) for keys in by_project.values())
         self.logger.info(

--- a/src/application/components/group_migration.py
+++ b/src/application/components/group_migration.py
@@ -1,3 +1,29 @@
+"""Synchronise Jira groups and project role memberships into OpenProject.
+
+Phase 7e notes
+--------------
+This migration does **not** consume the ``work_package`` mapping. The
+mappings it touches — ``group``, ``user``, ``project`` — each carry
+their own polymorphic shape that is orthogonal to the ``wp_map``
+``dict | int`` ladder phase 7 retires:
+
+* ``user_mapping`` is read in :meth:`_synchronize_memberships` to build
+  a flat ``user_lookup`` dict. The probe order (``key``/``jira_key``/
+  ``jira_name``) is not a per-user multi-identifier walk against a
+  single :class:`JiraUser` instance; it pre-indexes by *all* known
+  identifiers so the membership step can resolve actor names that come
+  from arbitrary upstream shapes (Jira group members, project
+  role-actor envelopes). Switching to a typed walk would not simplify
+  this and would change the lookup semantics around case-insensitive
+  fallbacks.
+* ``group_mapping`` and ``project_mapping`` values are dicts; their
+  shape is local to this migration and is not modelled in
+  :mod:`src.models`.
+
+Phase 7's scope is the ``wp_map`` ladder; this migration is left as-is.
+Behaviour preserved.
+"""
+
 from __future__ import annotations
 
 from collections import defaultdict

--- a/src/application/components/reporting_migration.py
+++ b/src/application/components/reporting_migration.py
@@ -1,4 +1,17 @@
-"""Migrate Jira filters and dashboards into OpenProject queries and wiki summaries."""
+"""Migrate Jira filters and dashboards into OpenProject queries and wiki summaries.
+
+Phase 7e notes
+--------------
+This migration does **not** consume the ``work_package`` mapping. The
+``project`` mapping is read only to resolve a fallback wiki project for
+dashboard imports — the values flow through a local
+:func:`_lookup_project_id` helper that already handles the dict-shape
+defensively. The Jira inputs (filters, dashboards, share permissions,
+gadgets) arrive as uniform REST dicts; there is no polymorphic ladder
+of the kind phase 7 retires. Modelling them as Pydantic types would be
+cosmetic at this site and is intentionally deferred. Behaviour
+preserved.
+"""
 
 from __future__ import annotations
 

--- a/src/application/components/tempo_account_migration.py
+++ b/src/application/components/tempo_account_migration.py
@@ -1,5 +1,15 @@
 """Tempo account migration module for Jira to OpenProject migration.
 Handles the migration of Tempo Timesheet accounts from Jira to OpenProject.
+
+Phase 7e notes
+--------------
+This migration is plugin-specific (Tempo Timesheets) and does **not**
+consume the ``work_package`` mapping. It walks the Tempo REST shape
+(``id``, ``key``, ``name``, ``leadDisplayName``, ``customerName``,
+``viewUrl``, …) which is not modelled in :mod:`src.models`. The
+``account_mapping`` it persists is local to this migration (Tempo
+account id → OP company id). There is no polymorphic ladder of the
+kind phase 7 retires. Behaviour preserved.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Phase 7e of [ADR-002](docs/adr/ADR-002-target-architecture.md) — fifth batch. After this lands, 24/38 migrations have been addressed (5 converted in this batch + 19 prior).

## Migrations addressed

**Converted (wp_map ladder retired):**
- **\`attachments_migration\`** — Builds a \`jira_key → wp_id\` lookup via \`WorkPackageMappingEntry.from_legacy\` that absorbs both production layout (\`str(jira_id)\` outer with inner \`jira_key\`) and legacy/test fixtures (key directly by \`jira_key\`). Replaces the \`isinstance(entry, dict)/isinstance(entry, int)\` ladder. Same fix pattern as \`time_entry_migration\`, \`attachment_provenance_migration\`, \`watcher_migration\`, \`story_points_migration\` — production lookups go from silently failing on numeric outer keys to working.

**Left as-is, documented:**
- **\`admin_scheme_migration\`** — touches project/user/group mappings with orthogonal polymorphism; \`JiraUser\` doesn't model the role-actor envelope shape (\`type\`, \`name\`, \`accountId\`, \`userKey\`, \`groupName\`).
- **\`group_migration\`** — pre-indexes \`user_lookup\` with multi-identifier walk for arbitrary upstream shapes; converting to a typed walk would lose the case-insensitive fallback semantics needed for membership resolution.
- **\`reporting_migration\`** — Jira filters/dashboards arrive as uniform REST dicts; no polymorphic ladder.
- **\`tempo_account_migration\`** — Tempo plugin-specific REST shape not modelled in \`src.models\`; no wp_map ladder.

## Quality gates
- \`ruff check\`, \`ruff format --check\` — clean
- \`mypy src/application src/models src/domain\` — 0 issues, 64 source files
- \`pytest tests/unit/\` — **1098 passed**, 30 deselected (exact baseline match; 0 regressions)

## Hard constraints respected
- Pure refactor — existing tests pass without modification
- BaseMigration / ComponentResult untouched
- Each out-of-scope migration has a clear docstring rationale

## Test plan
- [x] All quality gates green locally
- [x] All existing tests pass without modification
- [ ] CI green