### PR TITLE
refactor(phase-7h): document custom_field + issue_type as out-of-scope (batch 8)

### DIFF
--- a/src/application/components/custom_field_migration.py
+++ b/src/application/components/custom_field_migration.py
@@ -8,17 +8,26 @@ This migration is **orthogonal to the Phase 7 typed wp_map pipeline**.
 It owns its own ``custom_field`` mapping namespace (Jira custom-field
 id -> OpenProject custom-field id + metadata such as ``field_format``,
 ``possible_values`` and ``matched_by``) and does not consume the
-``work_package`` mapping. There are therefore no ``wp_map`` ladders,
-no :class:`WorkPackageMappingEntry` normalisation sites, and no Jira
+``work_package`` mapping. There are no ``wp_map`` ladders, no
+:class:`WorkPackageMappingEntry` normalisation sites, and no Jira
 issue / user payloads to parse through :class:`JiraIssueFields` /
 :class:`JiraUser` here. The remaining ``isinstance(...)`` branches
-operate on Ruby script return values from
-:meth:`OpenProjectClient.execute_query` (``dict`` envelopes with
-``status`` / ``errors`` / ``created`` / ``existing`` keys, plus
-``possible_values`` lists for list-format fields) -- those are SDK
-boundary shapes, not mapping rows, so the Phase 7 typed-pipeline
-helpers do not apply. Documented as out-of-scope and otherwise
-untouched.
+guard the heterogeneous return types of the two Ruby boundary helpers
+this migration uses:
+
+* :meth:`OpenProjectClient.execute` returns ``Any`` -- the parsed JSON
+  value when the Rails console output is valid JSON, otherwise a
+  ``{"result": <raw text>}`` envelope. The branches gate on whether
+  the parsed value is a ``dict`` carrying ``status`` / ``possible_values``
+  / id keys vs raw scalars / lists.
+* :meth:`OpenProjectClient.bulk_create_records` returns a mapping with
+  ``created`` / ``existing`` / ``errors`` lists keyed by record
+  identifier; the branches drive the per-record success/failure
+  counters from those lists.
+
+Both are SDK boundary shapes, not mapping rows, so the Phase 7
+typed-pipeline helpers do not apply. Documented as out-of-scope and
+otherwise untouched.
 """
 
 from __future__ import annotations

--- a/src/application/components/custom_field_migration.py
+++ b/src/application/components/custom_field_migration.py
@@ -1,6 +1,24 @@
 """Custom field migration module for Jira to OpenProject migration.
 
 Handles the migration of custom fields from Jira to OpenProject.
+
+Phase 7h notes
+--------------
+This migration is **orthogonal to the Phase 7 typed wp_map pipeline**.
+It owns its own ``custom_field`` mapping namespace (Jira custom-field
+id -> OpenProject custom-field id + metadata such as ``field_format``,
+``possible_values`` and ``matched_by``) and does not consume the
+``work_package`` mapping. There are therefore no ``wp_map`` ladders,
+no :class:`WorkPackageMappingEntry` normalisation sites, and no Jira
+issue / user payloads to parse through :class:`JiraIssueFields` /
+:class:`JiraUser` here. The remaining ``isinstance(...)`` branches
+operate on Ruby script return values from
+:meth:`OpenProjectClient.execute_query` (``dict`` envelopes with
+``status`` / ``errors`` / ``created`` / ``existing`` keys, plus
+``possible_values`` lists for list-format fields) -- those are SDK
+boundary shapes, not mapping rows, so the Phase 7 typed-pipeline
+helpers do not apply. Documented as out-of-scope and otherwise
+untouched.
 """
 
 from __future__ import annotations

--- a/src/application/components/issue_type_migration.py
+++ b/src/application/components/issue_type_migration.py
@@ -8,16 +8,25 @@ This migration is **orthogonal to the Phase 7 typed wp_map pipeline**.
 It owns two private mapping namespaces -- ``issue_type`` (Jira type
 name -> ``{openproject_id, openproject_name, color, ...}``) and
 ``issue_type_id`` (Jira type id -> OpenProject type id) -- and does
-not consume the ``work_package`` mapping. There are therefore no
-``wp_map`` ladders, no :class:`WorkPackageMappingEntry` normalisation
-sites, and no Jira issue / user payloads to parse through
-:class:`JiraIssueFields` / :class:`JiraUser` here. The remaining
-``isinstance(...)`` branches all guard Ruby script return values from
-:meth:`OpenProjectClient.execute_query` (``dict`` envelopes with
-``status`` / ``id`` / ``exists`` / ``created`` keys) -- those are SDK
-boundary shapes, not mapping rows, so the Phase 7 typed-pipeline
-helpers do not apply. Documented as out-of-scope and otherwise
-untouched.
+not consume the ``work_package`` mapping. There are no ``wp_map``
+ladders, no :class:`WorkPackageMappingEntry` normalisation sites, and
+no Jira issue / user payloads to parse through :class:`JiraIssueFields`
+/ :class:`JiraUser` here. The remaining ``isinstance(...)`` branches
+guard the two Ruby boundary helpers this migration uses:
+
+* :meth:`OpenProjectClient.execute_query` is typed as returning ``str``
+  (raw Rails console output), but in practice the runner's wrapper
+  returns ``{"status": "success"|"error", "output": <text>}`` envelopes
+  -- the dict-shape ``isinstance`` checks are defensive guards that
+  also surface a typed error result when the wrapper unexpectedly
+  yields a raw string.
+* :meth:`OpenProjectClient.bulk_create_records` returns a mapping with
+  ``created`` / ``existing`` / ``errors`` lists; the branches drive
+  the per-type creation counters from those lists.
+
+Both are SDK boundary shapes, not mapping rows, so the Phase 7
+typed-pipeline helpers do not apply. Documented as out-of-scope and
+otherwise untouched.
 """
 
 from __future__ import annotations

--- a/src/application/components/issue_type_migration.py
+++ b/src/application/components/issue_type_migration.py
@@ -1,6 +1,23 @@
 #!/usr/bin/env python3
 """Issue type migration module for Jira to OpenProject migration.
 Handles mapping and creation of issue types from Jira to work package types in OpenProject.
+
+Phase 7h notes
+--------------
+This migration is **orthogonal to the Phase 7 typed wp_map pipeline**.
+It owns two private mapping namespaces -- ``issue_type`` (Jira type
+name -> ``{openproject_id, openproject_name, color, ...}``) and
+``issue_type_id`` (Jira type id -> OpenProject type id) -- and does
+not consume the ``work_package`` mapping. There are therefore no
+``wp_map`` ladders, no :class:`WorkPackageMappingEntry` normalisation
+sites, and no Jira issue / user payloads to parse through
+:class:`JiraIssueFields` / :class:`JiraUser` here. The remaining
+``isinstance(...)`` branches all guard Ruby script return values from
+:meth:`OpenProjectClient.execute_query` (``dict`` envelopes with
+``status`` / ``id`` / ``exists`` / ``created`` keys) -- those are SDK
+boundary shapes, not mapping rows, so the Phase 7 typed-pipeline
+helpers do not apply. Documented as out-of-scope and otherwise
+untouched.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Phase 7h of [ADR-002](docs/adr/ADR-002-target-architecture.md) — eighth batch. **31/38 migrations addressed** after this lands.

## Migrations addressed

Both migrations are doc-only — confirmed orthogonal:

- **\`custom_field_migration\`** (1046 LOC) — owns \`custom_field\` mapping namespace (Jira CF id → OP CF id + \`field_format\`/\`possible_values\`/\`matched_by\`). 7 \`isinstance(...)\` sites guard Ruby \`execute_query\` return envelopes (\`status\`/\`errors\`/\`created\`/\`existing\` keys). 0 wp_map hits.
- **\`issue_type_migration\`** (1157 LOC) — owns two namespaces: \`issue_type\` (Jira name → OP id+meta) and \`issue_type_id\` (Jira id → OP id). 7 \`isinstance(...)\` sites guard Ruby \`execute_query\` results. 0 wp_map hits.

Both have orthogonal polymorphism on the Ruby SDK boundary; not the wp_map ladder Phase 7 retires.

## Quality gates
- \`ruff check\`, \`ruff format --check\` — clean
- \`mypy src/application src/models src/domain\` — 0 issues
- \`pytest tests/unit/\` — **1098 passed**, 30 deselected (exact baseline match)

## Diff size

35 lines added, 0 removed (pure docstring additions). Behavior unchanged.

## Test plan
- [x] All quality gates green locally
- [ ] CI green