### PR TITLE
refactor(phase-7k): convert work_package_migration (the WP monster) to typed pipeline

### DIFF
--- a/src/application/components/work_package_migration.py
+++ b/src/application/components/work_package_migration.py
@@ -370,7 +370,12 @@ class WorkPackageMigration(BaseMigration):
                 jira_key = str(inner_jira_key or outer_key)
                 try:
                     typed_entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
-                except ValidationError, ValueError, TypeError, AttributeError:
+                except (
+                    ValidationError,
+                    ValueError,
+                    TypeError,
+                    AttributeError,
+                ):
                     continue
                 work_package_mapping[jira_key] = int(typed_entry.openproject_id)
 
@@ -564,7 +569,10 @@ class WorkPackageMigration(BaseMigration):
             if isinstance(result, str):
                 try:
                     result = json.loads(result)
-                except json.JSONDecodeError, TypeError:
+                except (
+                    json.JSONDecodeError,
+                    TypeError,
+                ):
                     pass
             if isinstance(result, dict) and result.get("id"):
                 version_id = int(result["id"])
@@ -3417,7 +3425,10 @@ class WorkPackageMigration(BaseMigration):
                 try:
                     seconds = int(seconds_str)
                     return round(seconds / 3600, 2)  # Convert to hours with 2 decimal places
-                except ValueError, TypeError:
+                except (
+                    ValueError,
+                    TypeError,
+                ):
                     return None
 
             from_hours = seconds_to_hours(from_seconds)
@@ -4054,7 +4065,11 @@ class WorkPackageMigration(BaseMigration):
                             "openproject_id": op_id,
                             "openproject_project_id": int(op_project_id),
                         }
-            except TypeError, AttributeError, ValueError:
+            except (
+                TypeError,
+                AttributeError,
+                ValueError,
+            ):
                 continue
 
     def _migrate_work_packages(self) -> dict[str, Any]:

--- a/src/application/components/work_package_migration.py
+++ b/src/application/components/work_package_migration.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any
 
 import requests
+from pydantic import ValidationError
 
 from jira import Issue
 from src import config
@@ -36,7 +37,7 @@ from src.config import logger
 from src.display import ProgressTracker
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
-from src.models import ComponentResult
+from src.models import ComponentResult, WorkPackageMappingEntry
 from src.utils import data_handler
 from src.utils.enhanced_audit_trail_migrator import EnhancedAuditTrailMigrator
 from src.utils.enhanced_timestamp_migrator import EnhancedTimestampMigrator
@@ -353,14 +354,25 @@ class WorkPackageMigration(BaseMigration):
                 if jira_account_id:
                     account_id_mapping[jira_account_id] = user_info
 
-        # For work package mapping, we need to load the existing mapping if available
-        work_package_mapping = {}
+        # For work package mapping, we need to load the existing mapping if available.
+        # The on-disk wp_map is keyed by ``str(jira_id)`` outer with the human-readable
+        # ``jira_key`` stored inside; older fixtures sometimes key directly by
+        # ``jira_key``. Normalise via :class:`WorkPackageMappingEntry.from_legacy` so
+        # we tolerate both shapes and skip bare-int rows (which carry no recoverable
+        # ``jira_key``) — the markdown converter only needs ``jira_key → op_id``.
+        work_package_mapping: dict[str, int] = {}
         if hasattr(self, "work_package_mapping") and self.work_package_mapping:
-            work_package_mapping = {
-                entry.get("jira_key", ""): entry.get("openproject_id", "")
-                for entry in self.work_package_mapping.values()
-                if entry.get("jira_key") and entry.get("openproject_id")
-            }
+            for outer_key, raw_entry in self.work_package_mapping.items():
+                if not isinstance(raw_entry, dict):
+                    # Bare-int legacy rows have no recoverable jira_key.
+                    continue
+                inner_jira_key = raw_entry.get("jira_key")
+                jira_key = str(inner_jira_key or outer_key)
+                try:
+                    typed_entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+                except ValidationError, ValueError, TypeError, AttributeError:
+                    continue
+                work_package_mapping[jira_key] = int(typed_entry.openproject_id)
 
         # Update the markdown converter with new mappings (including attachment mapping)
         self.markdown_converter = MarkdownConverter(
@@ -369,6 +381,71 @@ class WorkPackageMigration(BaseMigration):
             account_id_mapping=account_id_mapping,
             attachment_mapping=self.attachment_mapping,
         )
+
+    # Default fallback user id used when a journal author cannot be resolved
+    # from the user mapping. See ``_resolve_journal_author_id`` (BUG #32).
+    _BUG32_FALLBACK_USER_ID = 148941
+
+    # Probe order for resolving Jira changelog/comment authors against
+    # ``self.user_mapping``. Mirrors the multi-key fallback documented in
+    # BUG #32 — the user_mapping is augmented with secondary indices on
+    # ``name`` / ``displayName`` / ``emailAddress`` (and others) so any of
+    # these raw Jira fields will resolve to the same OP user when present.
+    _JOURNAL_AUTHOR_PROBE_KEYS: tuple[str, ...] = ("name", "displayName", "emailAddress")
+
+    def _resolve_journal_author_id(
+        self,
+        author_data: dict[str, Any],
+        jira_key: str,
+        kind: str,
+    ) -> int:
+        """Resolve a journal-entry author to an OpenProject user id.
+
+        Walks ``author_data`` against ``self.user_mapping`` using the
+        canonical probe order in :attr:`_JOURNAL_AUTHOR_PROBE_KEYS` and
+        returns the first matching ``openproject_id``. If no probe key
+        resolves, returns :attr:`_BUG32_FALLBACK_USER_ID` and logs a
+        ``[BUG32]`` warning listing every probe field that was present
+        on ``author_data`` so unresolved authors are diagnosable from
+        production logs.
+
+        Args:
+            author_data: Raw Jira author payload from a comment or
+                changelog entry. Tolerates ``None``/empty inputs by
+                resolving to the fallback user.
+            jira_key: Jira issue key, used purely for log context.
+            kind: Free-form label (``"comment"`` / ``"changelog"``)
+                that distinguishes the warning message between callers.
+
+        Returns:
+            The resolved ``openproject_id`` (int) or the BUG #32
+            fallback user id when the author cannot be resolved.
+
+        """
+        if not isinstance(author_data, dict):
+            author_data = {}
+        for key in self._JOURNAL_AUTHOR_PROBE_KEYS:
+            value = author_data.get(key)
+            if not value:
+                continue
+            user_dict = self.user_mapping.get(value)
+            if not user_dict:
+                continue
+            op_id = user_dict.get("openproject_id")
+            if op_id:
+                self.logger.debug(
+                    f"{jira_key}: Found user via {key}: {value} → {op_id}",
+                )
+                return int(op_id)
+
+        # No probe key resolved — fall back to the BUG #32 admin user.
+        attempted_fields = {k: author_data.get(k) for k in self._JOURNAL_AUTHOR_PROBE_KEYS if k in author_data}
+        fallback_id = self._BUG32_FALLBACK_USER_ID
+        self.logger.warning(
+            f"[BUG32] {jira_key}: User not found in mapping for {kind} (tried: {attempted_fields}), "
+            f"using fallback user {fallback_id}",
+        )
+        return fallback_id
 
     def _track_mentioned_users(self, text: str | None, project_id: int) -> None:
         """Extract mentioned user IDs from text and track them for membership assignment.
@@ -2590,35 +2667,13 @@ class WorkPackageMigration(BaseMigration):
                     entry_timestamp = entry.get("timestamp", "")
 
                     if entry_type == "comment":
-                        # Bug #32 fix: Enhanced user attribution - try multiple fields
+                        # Bug #32 fix: Enhanced user attribution - probe multiple author fields.
                         author_data = entry_data.get("author") or {}
-                        comment_author_id = None
-                        author_name = None
-
-                        # Try multiple fields: name, displayName, emailAddress
-                        for key in ["name", "displayName", "emailAddress"]:
-                            if author_data.get(key):
-                                user_dict = self.user_mapping.get(author_data[key])
-                                if user_dict:
-                                    comment_author_id = user_dict.get("openproject_id")
-                                    if comment_author_id:
-                                        author_name = author_data[key]
-                                        self.logger.debug(
-                                            f"{jira_key}: Found user via {key}: {author_name} → {comment_author_id}",
-                                        )
-                                        break
-
-                        if not comment_author_id:
-                            # Use fallback user (148941)
-                            comment_author_id = 148941
-                            attempted_fields = {
-                                k: author_data.get(k)
-                                for k in ["name", "displayName", "emailAddress"]
-                                if k in author_data
-                            }
-                            self.logger.warning(
-                                f"[BUG32] {jira_key}: User not found in mapping for comment (tried: {attempted_fields}), using fallback user {comment_author_id}",
-                            )
+                        comment_author_id = self._resolve_journal_author_id(
+                            author_data,
+                            jira_key,
+                            "comment",
+                        )
                         raw_comment_body = entry_data.get("body", "")
                         # Convert Jira wiki markup to OpenProject markdown
                         if raw_comment_body and hasattr(self, "markdown_converter") and self.markdown_converter:
@@ -2641,35 +2696,13 @@ class WorkPackageMigration(BaseMigration):
                             f"[BUG23] {jira_key}: Added comment operation, total operations: {len(work_package['_rails_operations'])}",
                         )
                     elif entry_type == "changelog":
-                        # Bug #32 fix: Enhanced user attribution - try multiple fields
+                        # Bug #32 fix: Enhanced user attribution - probe multiple author fields.
                         author_data = entry_data.get("author") or {}
-                        changelog_author_id = None
-                        author_name = None
-
-                        # Try multiple fields: name, displayName, emailAddress
-                        for key in ["name", "displayName", "emailAddress"]:
-                            if author_data.get(key):
-                                user_dict = self.user_mapping.get(author_data[key])
-                                if user_dict:
-                                    changelog_author_id = user_dict.get("openproject_id")
-                                    if changelog_author_id:
-                                        author_name = author_data[key]
-                                        self.logger.debug(
-                                            f"{jira_key}: Found user via {key}: {author_name} → {changelog_author_id}",
-                                        )
-                                        break
-
-                        if not changelog_author_id:
-                            # Use fallback user (148941)
-                            changelog_author_id = 148941
-                            attempted_fields = {
-                                k: author_data.get(k)
-                                for k in ["name", "displayName", "emailAddress"]
-                                if k in author_data
-                            }
-                            self.logger.warning(
-                                f"[BUG32] {jira_key}: User not found in mapping for changelog (tried: {attempted_fields}), using fallback user {changelog_author_id}",
-                            )
+                        changelog_author_id = self._resolve_journal_author_id(
+                            author_data,
+                            jira_key,
+                            "changelog",
+                        )
 
                         # Bug #28 fix: Process field changes as structured data
                         # Bug #16 fix: Also capture unmapped field changes as notes (prevent data loss)
@@ -3978,6 +4011,52 @@ class WorkPackageMigration(BaseMigration):
             msg = f"Error rebuilding custom field mapping from OpenProject: {e}"
             raise RuntimeError(msg) from e
 
+    def _record_created_work_packages(
+        self,
+        created_list: list[dict[str, Any]],
+        meta_slice: list[dict[str, Any]],
+        op_project_id: int,
+    ) -> None:
+        """Record bulk-create results into ``self.work_package_mapping``.
+
+        Walks ``created_list`` (the ``created`` array returned by
+        :meth:`OpenProjectClient.bulk_create_records`) and pairs each row
+        with the metadata that produced it via the ``index`` field. The
+        on-disk mapping shape — ``{str(jira_id): {**meta, "openproject_id":
+        op_id, "openproject_project_id": int(op_project_id)}}`` — is the
+        public contract consumed by 20+ downstream migrations and is
+        preserved verbatim from the four call-sites this helper replaces.
+
+        Args:
+            created_list: ``res["created"]`` from the bulk create call.
+                Each item must carry ``index`` (paired meta position) and
+                ``id`` (the new ``work_packages.id``).
+            meta_slice: The ``work_packages_meta`` list (full or batch
+                slice) the indices refer into.
+            op_project_id: The OpenProject project the work packages
+                belong to. Stored on every recorded row.
+
+        """
+        try:
+            _ = self.work_package_mapping  # ensure attribute exists
+        except AttributeError:
+            self.work_package_mapping = {}
+        for item in created_list:
+            try:
+                idx = item.get("index")
+                op_id = item.get("id")
+                if isinstance(idx, int) and 0 <= idx < len(meta_slice):
+                    meta = meta_slice[idx]
+                    jira_id = meta.get("jira_id")
+                    if jira_id is not None:
+                        self.work_package_mapping[str(jira_id)] = {
+                            **meta,
+                            "openproject_id": op_id,
+                            "openproject_project_id": int(op_project_id),
+                        }
+            except TypeError, AttributeError, ValueError:
+                continue
+
     def _migrate_work_packages(self) -> dict[str, Any]:
         """Simplified migration implementation to unblock execution.
 
@@ -4168,25 +4247,11 @@ class WorkPackageMigration(BaseMigration):
                                 # Always process the created list to build mapping
                                 created_list = res.get("created", [])
                                 if isinstance(created_list, list) and created_list:
-                                    try:
-                                        _ = self.work_package_mapping  # ensure attribute exists
-                                    except Exception:
-                                        self.work_package_mapping = {}
-                                    for item in created_list:
-                                        try:
-                                            idx = item.get("index")
-                                            op_id = item.get("id")
-                                            if isinstance(idx, int) and 0 <= idx < len(work_packages_meta):
-                                                meta = work_packages_meta[idx]
-                                                jira_id = meta.get("jira_id")
-                                                if jira_id is not None:
-                                                    self.work_package_mapping[str(jira_id)] = {
-                                                        **meta,
-                                                        "openproject_id": op_id,
-                                                        "openproject_project_id": int(op_project_id),
-                                                    }
-                                        except Exception:
-                                            continue
+                                    self._record_created_work_packages(
+                                        created_list,
+                                        work_packages_meta,
+                                        int(op_project_id),
+                                    )
                                 # Compute created count
                                 c = res.get("created_count") or res.get("total_created")
                                 if c is None:
@@ -4249,25 +4314,11 @@ class WorkPackageMigration(BaseMigration):
                                             if isinstance(sub_res, dict):
                                                 created_list = sub_res.get("created", [])
                                                 if isinstance(created_list, list) and created_list:
-                                                    try:
-                                                        _ = self.work_package_mapping
-                                                    except Exception:
-                                                        self.work_package_mapping = {}
-                                                    for item in created_list:
-                                                        try:
-                                                            idx = item.get("index")
-                                                            op_id = item.get("id")
-                                                            if isinstance(idx, int) and 0 <= idx < len(meta_slice):
-                                                                meta = meta_slice[idx]
-                                                                jira_id = meta.get("jira_id")
-                                                                if jira_id is not None:
-                                                                    self.work_package_mapping[str(jira_id)] = {
-                                                                        **meta,
-                                                                        "openproject_id": op_id,
-                                                                        "openproject_project_id": int(op_project_id),
-                                                                    }
-                                                        except Exception:
-                                                            continue
+                                                    self._record_created_work_packages(
+                                                        created_list,
+                                                        meta_slice,
+                                                        int(op_project_id),
+                                                    )
                                                 c = sub_res.get("created_count") or (
                                                     len(created_list) if isinstance(created_list, list) else 0
                                                 )
@@ -4350,25 +4401,11 @@ class WorkPackageMigration(BaseMigration):
                             # Always process the created list to build mapping
                             created_list = res.get("created", [])
                             if isinstance(created_list, list) and created_list:
-                                try:
-                                    _ = self.work_package_mapping
-                                except Exception:
-                                    self.work_package_mapping = {}
-                                for item in created_list:
-                                    try:
-                                        idx = item.get("index")
-                                        op_id = item.get("id")
-                                        if isinstance(idx, int) and 0 <= idx < len(work_packages_meta):
-                                            meta = work_packages_meta[idx]
-                                            jira_id = meta.get("jira_id")
-                                            if jira_id is not None:
-                                                self.work_package_mapping[str(jira_id)] = {
-                                                    **meta,
-                                                    "openproject_id": op_id,
-                                                    "openproject_project_id": int(op_project_id),
-                                                }
-                                    except Exception:
-                                        continue
+                                self._record_created_work_packages(
+                                    created_list,
+                                    work_packages_meta,
+                                    int(op_project_id),
+                                )
                             # Compute created count
                             c = res.get("created_count") or res.get("total_created")
                             if c is None:
@@ -4419,25 +4456,11 @@ class WorkPackageMigration(BaseMigration):
                                         if isinstance(sub_res, dict):
                                             created_list = sub_res.get("created", [])
                                             if isinstance(created_list, list) and created_list:
-                                                try:
-                                                    _ = self.work_package_mapping
-                                                except Exception:
-                                                    self.work_package_mapping = {}
-                                                for item in created_list:
-                                                    try:
-                                                        idx = item.get("index")
-                                                        op_id = item.get("id")
-                                                        if isinstance(idx, int) and 0 <= idx < len(meta_slice):
-                                                            meta = meta_slice[idx]
-                                                            jira_id = meta.get("jira_id")
-                                                            if jira_id is not None:
-                                                                self.work_package_mapping[str(jira_id)] = {
-                                                                    **meta,
-                                                                    "openproject_id": op_id,
-                                                                    "openproject_project_id": int(op_project_id),
-                                                                }
-                                                    except Exception:
-                                                        continue
+                                                self._record_created_work_packages(
+                                                    created_list,
+                                                    meta_slice,
+                                                    int(op_project_id),
+                                                )
                                             c = sub_res.get("created_count") or (
                                                 len(created_list) if isinstance(created_list, list) else 0
                                             )


### PR DESCRIPTION
## Summary

Phase 7k of [ADR-002](docs/adr/ADR-002-target-architecture.md) — **the final Phase 7 migration**. Converts the WP monster (4688 LOC, hotspot #1 in the codebase). After this lands, **35/38 components** addressed; the remaining 3 are framework files (\`base_migration.py\`, \`__init__.py\`, entity-type registry).

## What changed

\`work_package_migration.py\`: **+163 / −140** (net +23 LOC for helper docstrings + class-level constants). \`self.work_package_mapping\` references dropped from **17 → 8** (4 of those 8 consolidated inside the new helper).

## wp_map ladders retired

- **1 reader site** (\`_update_markdown_converter_mappings\`) — converted to \`WorkPackageMappingEntry.from_legacy()\` with explicit bare-int skip (matching PR #162's correctness fix).
- **4 writer sites** collapsed into 4 single-line calls to a new \`_record_created_work_packages(...)\` helper. **The on-disk dict shape is preserved verbatim** — the public contract for 20+ downstream consumers is untouched.

## User-probe sites converted

- **2 sites** in \`_build_rails_ops_for_issue\` (comment author + changelog author BUG #32 fallback paths) replaced by \`_resolve_journal_author_id(author_data, jira_key, kind)\`.

## Helper methods extracted

1. **\`_record_created_work_packages(created_list, meta_slice, op_project_id)\`** — 4 nearly-identical writer blocks (~21 LOC each) collapsed to a single owner of the wp_map write contract. Replaces broad \`except Exception\` with documented \`(TypeError, AttributeError, ValueError)\` tuple.
2. **\`_resolve_journal_author_id(author_data, jira_key, kind)\`** — centralizes the BUG #32 fallback constant (148941), defines the canonical probe order in one place, parameterizes the warning-message variation.

## Sites intentionally left as-is (documented)

1. **\`_extract_issue_meta\`** — collects fields not exposed by \`JiraIssueFields\` (duedate, parent_key, raw component lists, watcher counts). Routing through \`from_issue_any\` would silently drop these. Out of scope.
2. **\`_prepare_work_package\` / \`prepare_work_package\`** — high-blast-radius SDK-attribute logic with very specific shape expectations exercised by \`test_work_package_structure_validation.py\` and \`test_wp_data_prewrite_sanitization.py\`. Conversion deferred to a follow-up with dedicated test coverage.
3. **Probe order kept at existing 3-key (\`name → displayName → emailAddress\`) instead of canonical 5-key (\`account_id → name → key → email_address → display_name\`)**. Widening would be **behavior-additive** (new fallback paths for users currently falling back to BUG #32 admin id 148941) — even if a "good" change, that's a behavior change, not a pure refactor. Clear follow-up.
4. **Status / issue-type mapping ladders inside \`_prepare_work_package\`** — three-stage probe priority order is risky to touch without dedicated test coverage. Left untouched.

## Quality gates

- \`ruff check\`, \`ruff format --check\` — clean
- \`mypy src/application src/models src/domain\` — 0 issues, 64 source files
- \`pytest\` (WP-specific): 30 → 30 passing, no test edits
- \`pytest tests/unit/\` — **1098 passed**, 30 deselected (exact baseline match; **0 regressions**)

## Phase 7 complete

This closes Phase 7. Across 11 batches:
- **35 of 38** migration components have been addressed (the remaining 3 are framework files, not components)
- **\~30 wp_map dict/int ladders retired**
- **~15 multi-identifier user probes** converted to canonical order at consumer sites
- **8 new Pydantic models** introduced (JiraPriority, JiraResolutionRef, JiraSecurityLevelRef, JiraVotesRef, JiraRemoteLinkRef, JiraProjectComponent, JiraComponentLead, JiraWatcher)
- **JiraIssueFields** extended with affects_versions, remote_links, attachments author/created
- **WorkPackageMappingEntry** drives the typed wp_map flow + a forward-only normalization script for legacy var/data/

## Test plan
- [x] All quality gates green locally
- [x] Existing tests pass without modification
- [ ] CI green