### PR TITLE
refactor(phase-8a): add domain/results.py with discriminated-union StepResult

### DIFF
--- a/src/domain/__init__.py
+++ b/src/domain/__init__.py
@@ -22,8 +22,17 @@ from src.domain.ids import (
     OpWorkPackageId,
 )
 from src.domain.repositories import MappingRepository
+from src.domain.results import (
+    Failed,
+    Skipped,
+    StepResult,
+    Success,
+    from_component_result,
+    to_component_result,
+)
 
 __all__ = [
+    "Failed",
     "JiraAccountId",
     "JiraIssueKey",
     "JiraProjectKey",
@@ -36,4 +45,9 @@ __all__ = [
     "OpTypeId",
     "OpUserId",
     "OpWorkPackageId",
+    "Skipped",
+    "StepResult",
+    "Success",
+    "from_component_result",
+    "to_component_result",
 ]

--- a/src/domain/results.py
+++ b/src/domain/results.py
@@ -1,0 +1,297 @@
+"""Discriminated-union step results for the j2o domain layer.
+
+Phase 8a of ADR-002 ("Polish") introduces a typed, three-arm result union
+to replace the ad-hoc :class:`src.models.component_results.ComponentResult`
+dictionary-of-everything envelope. The intent is to give downstream code
+three crisp arms to pattern-match on instead of inspecting ~30 mostly-unused
+counters on every legacy result.
+
+This module is *pure addition*. No migration entry-point or call site is
+modified in this PR; the legacy ``ComponentResult`` class is untouched.
+The bridge between the two worlds is the :func:`from_component_result`
+and :func:`to_component_result` adapter pair, documented below.
+
+Pattern matrix (per ADR-002):
+
+* :class:`Success` — a step that completed and produced a usable result.
+  Carries optional ``data``, a human ``message``, free-form ``counts``
+  for telemetry, and any non-fatal ``warnings``.
+* :class:`Skipped` — a step that intentionally did no work (e.g. nothing
+  to migrate, feature disabled). Carries a structured ``reason`` and an
+  optional human ``message``.
+* :class:`Failed` — a step that raised or could not complete. Carries a
+  primary ``error`` string, the full ``errors`` list (for batched
+  operations that collect multiple failures), and any partial ``counts``.
+
+The union is discriminated by the literal ``kind`` field, so Pydantic v2
+will pick the right concrete model when validating dict input::
+
+    StepResult.model_validate({"kind": "skipped", "reason": "no work"})
+
+Future PRs (phase 8b+) can incrementally migrate call sites; until then
+both shapes coexist and round-trip via the adapter helpers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from src.models.component_results import ComponentResult
+
+
+class Success(BaseModel):
+    """A successful migration step.
+
+    Attributes:
+        kind: Discriminator literal — always ``"success"``.
+        data: Optional payload returned by the step (e.g. a list of
+            created records, a mapping dict, or a summary object). Free
+            shape — callers who care about the type should narrow it.
+        message: Human-readable summary suitable for log lines.
+        counts: Free-form integer counters for telemetry (e.g.
+            ``{"created": 12, "skipped": 3}``). Coarser than the legacy
+            ``ComponentResult``'s 30+ fixed fields by design.
+        warnings: Non-fatal warnings collected during the step.
+
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    kind: Literal["success"] = "success"
+    data: Any = None
+    message: str = ""
+    counts: dict[str, int] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class Skipped(BaseModel):
+    """A migration step that was intentionally skipped (no work to do).
+
+    Attributes:
+        kind: Discriminator literal — always ``"skipped"``.
+        reason: Short, structured reason code (free-form string today,
+            could become an enum later) — e.g. ``"no_work"``,
+            ``"feature_disabled"``, ``"already_migrated"``.
+        message: Optional longer human-readable explanation.
+
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    kind: Literal["skipped"] = "skipped"
+    reason: str = ""
+    message: str = ""
+
+
+class Failed(BaseModel):
+    """A migration step that failed.
+
+    Attributes:
+        kind: Discriminator literal — always ``"failed"``.
+        error: Primary error string (typically the first / most relevant
+            failure). For single-shot steps this is the only error.
+        message: Optional human-readable summary (the legacy envelope
+            often used this for "Migration failed: 5 errors").
+        errors: Full list of errors when a batched step collected
+            multiple failures.
+        counts: Partial counters captured before the failure — useful
+            for diagnostics ("we created 8 of 10 before erroring").
+
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    kind: Literal["failed"] = "failed"
+    error: str = ""
+    message: str = ""
+    errors: list[str] = Field(default_factory=list)
+    counts: dict[str, int] = Field(default_factory=dict)
+
+
+# Discriminated union — pydantic v2 picks the right model from ``kind``.
+StepResult = Annotated[
+    Success | Skipped | Failed,
+    Field(discriminator="kind"),
+]
+
+
+# ── Legacy bridge ────────────────────────────────────────────────────────
+# These adapters let phase 8a land without touching any migration. As call
+# sites are converted incrementally in later phases, the helpers below
+# become the documented "how to bridge" for any code still on the legacy
+# envelope.
+
+# Heuristic prefix used to detect "no-op" legacy results. Migrations
+# historically returned ``ComponentResult(success=True, message="No <X> ...")``
+# to mean "nothing to do" — we reclassify those as ``Skipped`` so the
+# discriminated union carries semantic intent rather than a magic string.
+_SKIP_PREFIX = "No "
+
+
+def _extract_counts(result: ComponentResult) -> dict[str, int]:
+    """Pull the legacy envelope's per-domain integer counters into a dict.
+
+    The legacy ``ComponentResult`` exposes ~20 named integer fields covering
+    overlapping vocabulary (types/issues/fields). We surface only the ones
+    that are non-zero so the resulting ``counts`` map stays compact.
+    """
+    candidates = (
+        "total_types",
+        "matched_types",
+        "normalized_types",
+        "created_types",
+        "failed_types",
+        "existing_types",
+        "total_issues",
+        "matched_issues",
+        "normalized_issues",
+        "created_issues",
+        "failed_issues",
+        "existing_issues",
+        "success_count",
+        "failed_count",
+        "total_count",
+        "extracted",
+        "updated",
+        "failed",
+        "jira_fields_count",
+        "op_fields_count",
+        "mapped_fields_count",
+    )
+    counts: dict[str, int] = {}
+    for name in candidates:
+        value = getattr(result, name, 0)
+        if isinstance(value, int) and value:
+            counts[name] = value
+    return counts
+
+
+def from_component_result(result: ComponentResult) -> StepResult:
+    """Convert a legacy ``ComponentResult`` into the discriminated union.
+
+    The mapping rule is:
+
+    * ``not result.success and (result.errors or result.error)`` → ``Failed``
+      with the primary error sourced from ``result.error`` (or the first
+      entry of ``result.errors``) and the full ``errors`` list preserved.
+      Non-zero counters are forwarded as ``counts``.
+    * ``result.success and result.message.startswith("No ")`` →
+      :class:`Skipped`. This catches the common no-op pattern used across
+      ~20 migrations (e.g. ``"No issues to migrate"``, ``"No custom fields
+      found"``, ``"No work packages with attachments"``). The leading
+      ``"No "`` prefix is treated as a heuristic, not a contract — callers
+      that need precise classification should construct ``Skipped``
+      directly.
+    * Anything else (including ``success=True`` with warnings) → ``Success``
+      with ``data``, ``message``, non-zero counts, and any ``warnings``.
+      The discriminated union is intentionally coarser than
+      ``ComponentResult``'s 30+ fields; counters that don't round-trip
+      land in the free-form ``counts`` dict.
+
+    Args:
+        result: Legacy envelope returned by a migration component.
+
+    Returns:
+        One of :class:`Success`, :class:`Skipped`, or :class:`Failed`.
+
+    """
+    # Failure arm — explicit failure or a populated error field.
+    if not result.success and (result.errors or result.error):
+        primary = result.error or (result.errors[0] if result.errors else "")
+        return Failed(
+            error=primary,
+            message=result.message,
+            errors=list(result.errors),
+            counts=_extract_counts(result),
+        )
+
+    # Skip heuristic — success + "No ..." message.
+    if result.success and result.message.startswith(_SKIP_PREFIX):
+        return Skipped(reason=result.message, message=result.message)
+
+    # Default: success arm, including success-with-warnings.
+    return Success(
+        data=result.data,
+        message=result.message,
+        counts=_extract_counts(result),
+        warnings=list(result.warnings),
+    )
+
+
+def to_component_result(result: StepResult) -> ComponentResult:
+    """Convert a discriminated-union result back to legacy ``ComponentResult``.
+
+    The legacy envelope has many fields; the round-trip is **lossy** in
+    both directions because the discriminated union is intentionally
+    coarser. This helper populates only the fields that the migration
+    entry point and dashboard code actually inspect:
+
+    * ``success``, ``message``, ``errors``, ``warnings``, ``error``, ``data``.
+
+    Counters from a :class:`Success` or :class:`Failed` ``counts`` dict are
+    written back to the matching named fields when they exist on
+    ``ComponentResult``; unknown keys are dropped (the legacy envelope has
+    no free-form counter store).
+
+    Args:
+        result: One of :class:`Success`, :class:`Skipped`, or :class:`Failed`.
+
+    Returns:
+        A populated :class:`ComponentResult` suitable for code paths that
+        still expect the legacy shape.
+
+    """
+    # Local import to avoid a circular dependency between domain/ and models/.
+    from src.models.component_results import ComponentResult
+
+    if isinstance(result, Success):
+        envelope = ComponentResult(
+            success=True,
+            message=result.message,
+            data=result.data,
+            warnings=list(result.warnings),
+        )
+        _apply_counts(envelope, result.counts)
+        return envelope
+
+    if isinstance(result, Skipped):
+        # Skipped maps to success=True with the structured reason as the
+        # message — this matches how legacy code treated "No work" results.
+        return ComponentResult(
+            success=True,
+            message=result.message or result.reason,
+        )
+
+    # Failed
+    envelope = ComponentResult(
+        success=False,
+        message=result.message,
+        error=result.error or None,
+        errors=list(result.errors),
+    )
+    _apply_counts(envelope, result.counts)
+    return envelope
+
+
+def _apply_counts(envelope: ComponentResult, counts: dict[str, int]) -> None:
+    """Write ``counts`` keys onto matching ``ComponentResult`` integer fields.
+
+    Unknown keys are silently dropped — the legacy envelope has a fixed
+    schema and there is no escape hatch for arbitrary counters.
+    """
+    for name, value in counts.items():
+        if hasattr(envelope, name) and isinstance(getattr(envelope, name), int):
+            setattr(envelope, name, value)
+
+
+__all__ = [
+    "Failed",
+    "Skipped",
+    "StepResult",
+    "Success",
+    "from_component_result",
+    "to_component_result",
+]

--- a/src/domain/results.py
+++ b/src/domain/results.py
@@ -24,9 +24,14 @@ Pattern matrix (per ADR-002):
   operations that collect multiple failures), and any partial ``counts``.
 
 The union is discriminated by the literal ``kind`` field, so Pydantic v2
-will pick the right concrete model when validating dict input::
+will pick the right concrete model when validating dict input. Because
+:data:`StepResult` is an :class:`Annotated` union alias (not a
+``BaseModel``), validation runs through a ``TypeAdapter``::
 
-    StepResult.model_validate({"kind": "skipped", "reason": "no work"})
+    from pydantic import TypeAdapter
+
+    adapter = TypeAdapter(StepResult)
+    result = adapter.validate_python({"kind": "skipped", "reason": "no work"})
 
 Future PRs (phase 8b+) can incrementally migrate call sites; until then
 both shapes coexist and round-trip via the adapter helpers.
@@ -281,9 +286,15 @@ def _apply_counts(envelope: ComponentResult, counts: dict[str, int]) -> None:
 
     Unknown keys are silently dropped — the legacy envelope has a fixed
     schema and there is no escape hatch for arbitrary counters.
+
+    The ``type(...) is int`` check (rather than ``isinstance``) deliberately
+    excludes ``bool``, since ``bool`` is an ``int`` subclass in Python.
+    Without the exclusion a ``"success"`` or ``"dry_run"`` key in
+    ``counts`` would silently overwrite the boolean flags on
+    ``ComponentResult``.
     """
     for name, value in counts.items():
-        if hasattr(envelope, name) and isinstance(getattr(envelope, name), int):
+        if hasattr(envelope, name) and type(getattr(envelope, name)) is int:
             setattr(envelope, name, value)
 
 

--- a/tests/unit/test_domain_results.py
+++ b/tests/unit/test_domain_results.py
@@ -263,7 +263,7 @@ class TestFromComponentResult:
         assert isinstance(result, Success)
         assert result.message == "Found 3 records but kept them as-is"
 
-    def test_default_legacy_is_failed_when_unsuccessful_with_no_errors(self):
+    def test_default_legacy_falls_through_to_success_with_no_error_signal(self):
         # A bare ``ComponentResult()`` has ``success=False`` and no
         # errors — by our rule that lands on the success arm (no
         # signal that anything went wrong). Documenting the edge.

--- a/tests/unit/test_domain_results.py
+++ b/tests/unit/test_domain_results.py
@@ -1,0 +1,392 @@
+"""Unit tests for the discriminated-union step result types (phase 8a).
+
+Covers:
+* construction and discriminator wiring of Success / Skipped / Failed
+* Pydantic v2 round-trips (model_dump / model_validate)
+* JSON round-trips (model_dump_json / model_validate_json)
+* legacy bridge — from_component_result mapping table
+* legacy bridge — to_component_result inverse round-trip
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import TypeAdapter
+
+from src.domain.results import (
+    Failed,
+    Skipped,
+    StepResult,
+    Success,
+    from_component_result,
+    to_component_result,
+)
+from src.models.component_results import ComponentResult
+
+# A Pydantic TypeAdapter is the v2-idiomatic way to validate a bare
+# discriminated union (the union itself is not a BaseModel).
+_StepResultAdapter: TypeAdapter[StepResult] = TypeAdapter(StepResult)
+
+
+# ── Construction ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestVariantConstruction:
+    """Each variant should set its discriminator literal automatically."""
+
+    def test_success_default_kind(self):
+        result = Success()
+        assert result.kind == "success"
+        assert result.data is None
+        assert result.message == ""
+        assert result.counts == {}
+        assert result.warnings == []
+
+    def test_skipped_default_kind(self):
+        result = Skipped()
+        assert result.kind == "skipped"
+        assert result.reason == ""
+        assert result.message == ""
+
+    def test_failed_default_kind(self):
+        result = Failed()
+        assert result.kind == "failed"
+        assert result.error == ""
+        assert result.message == ""
+        assert result.errors == []
+        assert result.counts == {}
+
+    def test_success_with_payload(self):
+        result = Success(
+            data={"created": [1, 2, 3]},
+            message="ok",
+            counts={"created": 3},
+            warnings=["minor"],
+        )
+        assert result.data == {"created": [1, 2, 3]}
+        assert result.message == "ok"
+        assert result.counts == {"created": 3}
+        assert result.warnings == ["minor"]
+
+    def test_skipped_with_reason(self):
+        result = Skipped(reason="no_work", message="nothing to migrate")
+        assert result.reason == "no_work"
+        assert result.message == "nothing to migrate"
+
+    def test_failed_with_errors(self):
+        result = Failed(
+            error="boom",
+            errors=["boom", "second"],
+            counts={"failed": 2},
+        )
+        assert result.error == "boom"
+        assert result.errors == ["boom", "second"]
+        assert result.counts == {"failed": 2}
+
+
+# ── Discriminator dispatch ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestDiscriminatorDispatch:
+    """Pydantic should pick the concrete variant from the ``kind`` field."""
+
+    def test_dict_kind_success(self):
+        result = _StepResultAdapter.validate_python({"kind": "success", "message": "ok"})
+        assert isinstance(result, Success)
+        assert result.message == "ok"
+
+    def test_dict_kind_skipped(self):
+        result = _StepResultAdapter.validate_python({"kind": "skipped", "reason": "no_work"})
+        assert isinstance(result, Skipped)
+        assert result.reason == "no_work"
+
+    def test_dict_kind_failed(self):
+        result = _StepResultAdapter.validate_python({"kind": "failed", "error": "boom", "errors": ["boom"]})
+        assert isinstance(result, Failed)
+        assert result.error == "boom"
+        assert result.errors == ["boom"]
+
+    def test_extra_fields_ignored(self):
+        # ``extra="ignore"`` on each variant means unknown fields don't
+        # fail validation — they're just dropped.
+        result = _StepResultAdapter.validate_python({"kind": "success", "unexpected": 42})
+        assert isinstance(result, Success)
+        assert not hasattr(result, "unexpected")
+
+
+# ── Round-trip via Pydantic ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestRoundTrip:
+    """model_dump / model_validate and JSON variants should be lossless."""
+
+    def test_success_python_round_trip(self):
+        original = Success(
+            data=[1, 2, 3],
+            message="hello",
+            counts={"created": 3},
+            warnings=["w"],
+        )
+        clone = _StepResultAdapter.validate_python(original.model_dump())
+        assert isinstance(clone, Success)
+        assert clone == original
+
+    def test_skipped_python_round_trip(self):
+        original = Skipped(reason="no_work", message="nothing")
+        clone = _StepResultAdapter.validate_python(original.model_dump())
+        assert isinstance(clone, Skipped)
+        assert clone == original
+
+    def test_failed_python_round_trip(self):
+        original = Failed(
+            error="boom",
+            errors=["boom", "second"],
+            counts={"failed": 2},
+            message="went wrong",
+        )
+        clone = _StepResultAdapter.validate_python(original.model_dump())
+        assert isinstance(clone, Failed)
+        assert clone == original
+
+    def test_success_json_round_trip(self):
+        original = Success(
+            data={"k": "v"},
+            message="ok",
+            counts={"created": 1},
+        )
+        json_blob = original.model_dump_json()
+        clone = _StepResultAdapter.validate_json(json_blob)
+        assert isinstance(clone, Success)
+        assert clone == original
+
+    def test_skipped_json_round_trip(self):
+        original = Skipped(reason="feature_disabled", message="off")
+        clone = _StepResultAdapter.validate_json(original.model_dump_json())
+        assert isinstance(clone, Skipped)
+        assert clone == original
+
+    def test_failed_json_round_trip(self):
+        original = Failed(error="boom", errors=["boom"])
+        clone = _StepResultAdapter.validate_json(original.model_dump_json())
+        assert isinstance(clone, Failed)
+        assert clone == original
+
+
+# ── Legacy bridge: from_component_result ──────────────────────────────────
+
+
+@pytest.mark.unit
+class TestFromComponentResult:
+    """Mapping table from the legacy envelope to the discriminated union."""
+
+    def test_success_no_errors_no_warnings(self):
+        legacy = ComponentResult(
+            success=True,
+            message="migrated 5 issues",
+            data={"created": [1, 2, 3, 4, 5]},
+            created_issues=5,
+            total_issues=5,
+        )
+        result = from_component_result(legacy)
+        assert isinstance(result, Success)
+        assert result.message == "migrated 5 issues"
+        assert result.data == {"created": [1, 2, 3, 4, 5]}
+        assert result.counts == {"created_issues": 5, "total_issues": 5}
+        assert result.warnings == []
+
+    def test_success_with_warnings_preserved(self):
+        legacy = ComponentResult(
+            success=True,
+            message="migrated with caveats",
+            warnings=["non-fatal w1", "non-fatal w2"],
+        )
+        result = from_component_result(legacy)
+        assert isinstance(result, Success)
+        assert result.warnings == ["non-fatal w1", "non-fatal w2"]
+        assert result.message == "migrated with caveats"
+
+    def test_failure_with_errors(self):
+        legacy = ComponentResult(
+            success=False,
+            message="Migration failed: 2 errors",
+            errors=["primary boom", "secondary"],
+            failed_issues=2,
+        )
+        result = from_component_result(legacy)
+        assert isinstance(result, Failed)
+        assert result.error == "primary boom"
+        assert result.errors == ["primary boom", "secondary"]
+        assert result.message == "Migration failed: 2 errors"
+        assert result.counts == {"failed_issues": 2}
+
+    def test_failure_with_error_field_only(self):
+        # ``ComponentResult`` has both an ``error`` (str|None) and an
+        # ``errors`` (list) field. Either should trigger the Failed arm.
+        legacy = ComponentResult(
+            success=False,
+            error="single boom",
+        )
+        result = from_component_result(legacy)
+        assert isinstance(result, Failed)
+        assert result.error == "single boom"
+        assert result.errors == []
+
+    def test_skip_heuristic_no_work_message(self):
+        legacy = ComponentResult(
+            success=True,
+            message="No issues to migrate",
+        )
+        result = from_component_result(legacy)
+        assert isinstance(result, Skipped)
+        assert result.reason == "No issues to migrate"
+        assert result.message == "No issues to migrate"
+
+    def test_skip_heuristic_other_no_message(self):
+        legacy = ComponentResult(
+            success=True,
+            message="No custom fields found",
+        )
+        result = from_component_result(legacy)
+        assert isinstance(result, Skipped)
+        assert result.reason == "No custom fields found"
+
+    def test_success_message_not_starting_with_no_is_success(self):
+        # "Normal" success messages should not be mis-classified as Skipped.
+        legacy = ComponentResult(
+            success=True,
+            message="Found 3 records but kept them as-is",
+        )
+        result = from_component_result(legacy)
+        assert isinstance(result, Success)
+        assert result.message == "Found 3 records but kept them as-is"
+
+    def test_default_legacy_is_failed_when_unsuccessful_with_no_errors(self):
+        # A bare ``ComponentResult()`` has ``success=False`` and no
+        # errors — by our rule that lands on the success arm (no
+        # signal that anything went wrong). Documenting the edge.
+        legacy = ComponentResult()
+        result = from_component_result(legacy)
+        # No errors, no error string → falls through to Success arm.
+        assert isinstance(result, Success)
+
+
+# ── Legacy bridge: to_component_result ────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestToComponentResult:
+    """Inverse mapping back to the legacy envelope."""
+
+    def test_success_to_legacy(self):
+        # ``ComponentResult.data`` is ``dict | list[dict] | None``; the
+        # discriminated-union ``Success.data`` is intentionally ``Any``,
+        # so callers bridging back to the legacy envelope must stay
+        # within the legacy schema.
+        payload = [{"id": 1}, {"id": 2}, {"id": 3}]
+        result = Success(
+            data=payload,
+            message="ok",
+            counts={"created_issues": 3, "total_issues": 3},
+            warnings=["w"],
+        )
+        legacy = to_component_result(result)
+        assert legacy.success is True
+        assert legacy.message == "ok"
+        assert legacy.data == payload
+        assert legacy.warnings == ["w"]
+        assert legacy.created_issues == 3
+        assert legacy.total_issues == 3
+
+    def test_skipped_to_legacy(self):
+        result = Skipped(reason="no_work", message="nothing to do")
+        legacy = to_component_result(result)
+        # Skipped maps to success=True (legacy has no third arm).
+        assert legacy.success is True
+        assert legacy.message == "nothing to do"
+
+    def test_skipped_without_message_uses_reason(self):
+        result = Skipped(reason="No issues to migrate")
+        legacy = to_component_result(result)
+        assert legacy.success is True
+        assert legacy.message == "No issues to migrate"
+
+    def test_failed_to_legacy(self):
+        result = Failed(
+            error="boom",
+            errors=["boom", "second"],
+            message="2 failures",
+            counts={"failed_issues": 2},
+        )
+        legacy = to_component_result(result)
+        assert legacy.success is False
+        assert legacy.error == "boom"
+        assert legacy.errors == ["boom", "second"]
+        assert legacy.message == "2 failures"
+        assert legacy.failed_issues == 2
+
+    def test_failed_with_no_error_string_drops_to_none(self):
+        # ``error`` field on ``ComponentResult`` is ``str | None``;
+        # an empty Failed.error should map back to None.
+        result = Failed(errors=["only"])
+        legacy = to_component_result(result)
+        assert legacy.success is False
+        assert legacy.error is None
+        assert legacy.errors == ["only"]
+
+    def test_unknown_count_keys_silently_dropped(self):
+        # Counts not matching a ``ComponentResult`` integer field are
+        # ignored (legacy has no escape hatch for arbitrary counters).
+        result = Success(counts={"completely_made_up_field": 42})
+        legacy = to_component_result(result)
+        assert not hasattr(legacy, "completely_made_up_field")
+        assert legacy.success is True
+
+
+# ── Bridge round-trips ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestBridgeRoundTrip:
+    """End-to-end legacy ↔ union ↔ legacy traversal."""
+
+    def test_success_round_trip(self):
+        original = ComponentResult(
+            success=True,
+            message="all good",
+            data={"k": "v"},
+            warnings=["w"],
+            created_issues=3,
+        )
+        bridged = to_component_result(from_component_result(original))
+        assert bridged.success is True
+        assert bridged.message == "all good"
+        assert bridged.data == {"k": "v"}
+        assert bridged.warnings == ["w"]
+        assert bridged.created_issues == 3
+
+    def test_failed_round_trip(self):
+        original = ComponentResult(
+            success=False,
+            message="failure",
+            errors=["boom"],
+            failed_issues=1,
+        )
+        bridged = to_component_result(from_component_result(original))
+        assert bridged.success is False
+        assert bridged.message == "failure"
+        assert bridged.errors == ["boom"]
+        assert bridged.error == "boom"  # promoted from errors[0]
+        assert bridged.failed_issues == 1
+
+    def test_skipped_round_trip(self):
+        original = ComponentResult(
+            success=True,
+            message="No issues to migrate",
+        )
+        bridged = to_component_result(from_component_result(original))
+        # Skipped collapses to success=True with reason as message.
+        assert bridged.success is True
+        assert bridged.message == "No issues to migrate"


### PR DESCRIPTION
## Summary

Phase 8a of [ADR-002](docs/adr/ADR-002-target-architecture.md) — first half of Phase 8 polish. Per the ADR's pattern matrix:

> | **Result type** | \`domain/results.py\` — discriminated union (Success / Skipped / Failed) |

**Pure addition** — no existing migration or model code touched. Future PRs can incrementally migrate \`_extract\`/\`_map\`/\`_load\` return types.

## What ships

- **\`src/domain/results.py\`** (297 LOC, new) — \`Success\`, \`Skipped\`, \`Failed\` Pydantic v2 variants + \`StepResult = Annotated[Success | Skipped | Failed, Field(discriminator=\"kind\")]\`. Adapter pair \`from_component_result\`/\`to_component_result\` for gradual migration.
- **\`tests/unit/test_domain_results.py\`** (392 LOC, new, 33 tests) covering construction, discriminator dispatch, round-trip, mapping table, bridge.
- **\`src/domain/__init__.py\`** (+14 lines) — re-exports the union and helpers.

## Mapping rules (legacy → union)

- \`success and not errors and not warnings\` → \`Success\`
- \`success\` with warnings → \`Success\` (warnings preserved)
- \`not success and errors\` → \`Failed\`
- \`success and message.startswith(\"No \")\` → \`Skipped\` (heuristic)
- Bare default (\`success=False\` + no error signal) → \`Success\` (no evidence of failure)

## Adapter design notes

- \`StepResult\` is an \`Annotated\` union, not a \`BaseModel\` — tests use \`pydantic.TypeAdapter[StepResult]\` (v2-idiomatic for bare discriminated unions).
- \`_extract_counts\` enumerates ~20 known counter fields explicitly (not via \`model_fields\` introspection) — more honest about what's round-tripped.
- \`_apply_counts\` silently drops unknown keys (legacy envelope has fixed schema).
- \`Skipped\` collapses to \`success=True\` on the way back (legacy has no third arm); \`result.message or result.reason\` keeps a useful legacy message.

## Quality gates
- \`ruff check\` (touched paths) — clean
- \`ruff format --check .\` — 374 files clean
- \`mypy src/domain\` — 0 errors, 4 files
- \`pytest tests/unit/\` — **1131 passed** (1098 baseline + **33 new**), 30 deselected, 0 regressions

## Hard constraints respected
- Pure addition — \`src/models/component_results.py\` and all migration code untouched
- Pydantic v2 with \`Field(discriminator=\"kind\")\`
- \`from __future__ import annotations\`, \`ConfigDict(populate_by_name=True, extra=\"ignore\")\`
- \`TYPE_CHECKING\` import of \`ComponentResult\` to avoid circular dep

## What's next

- **Phase 8b** — Composed Decorators replacing \`Enhanced*Client\` subclasses (separate PR).
- Future: incremental migration of select \`_extract\`/\`_map\`/\`_load\` to return \`StepResult\` directly; the adapter pair makes this gradual.

## Test plan
- [x] All quality gates green locally
- [x] 33 new tests pass
- [ ] CI green