### PR TITLE
refactor(phase-8b): composed Decorators replace Enhanced*Client subclasses

### DIFF
--- a/src/infrastructure/jira/decorators.py
+++ b/src/infrastructure/jira/decorators.py
@@ -1,0 +1,357 @@
+"""Composable decorators for :class:`JiraClient`.
+
+This module replaces the inheritance-based ``EnhancedJiraClient`` with a set of
+small decorators that wrap a base :class:`JiraClient` instance. Each decorator
+implements a single concern (caching, batched/parallel reads, streaming) and
+delegates everything else to the wrapped client through ``__getattr__``.
+
+Composition example::
+
+    client = JiraClient(...)
+    client = CachingDecorator(client, cache_ttl=300)
+    client = BatchOperationsDecorator(client, batch_size=50, parallel_workers=8)
+    client = StreamingDecorator(client)
+    client = PerformanceMonitoringDecorator(client)
+
+Phase 8b of ADR-002: Composition over inheritance for client extensions.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from src.display import configure_logging
+
+if TYPE_CHECKING:
+    from jira import Issue
+
+logger = configure_logging("INFO", None)
+
+
+@runtime_checkable
+class JiraClientLike(Protocol):
+    """Minimal structural type for a wrapped Jira client.
+
+    The decorators only require the attributes touched by their specific
+    concern; all other access is forwarded via ``__getattr__``. This Protocol
+    documents the surface the decorators rely on without forcing an import of
+    the concrete :class:`JiraClient`.
+    """
+
+    jira: Any
+    base_url: str
+    batch_size: int
+    parallel_workers: int
+
+
+class _BaseJiraDecorator:
+    """Base class providing transparent attribute delegation.
+
+    Any attribute not defined on the decorator (or its subclasses) is resolved
+    against the wrapped client. Subclasses override only the methods whose
+    behavior they augment.
+    """
+
+    def __init__(self, wrapped: Any) -> None:
+        # Use object.__setattr__ to avoid triggering __getattr__ during init.
+        object.__setattr__(self, "_wrapped", wrapped)
+
+    def __getattr__(self, name: str) -> Any:
+        # __getattr__ runs only when normal lookup fails, so this is safe and
+        # avoids manually proxying every method on the wrapped client.
+        wrapped = object.__getattribute__(self, "_wrapped")
+        return getattr(wrapped, name)
+
+    @property
+    def wrapped(self) -> Any:
+        """Return the directly-wrapped client (one layer down)."""
+        return object.__getattribute__(self, "_wrapped")
+
+
+class CachingDecorator(_BaseJiraDecorator):
+    """TTL cache for low-churn read methods on a Jira client.
+
+    Wraps the read endpoints exposed by ``EnhancedJiraClient`` so callers see
+    cached results for ``cache_ttl`` seconds. Cache misses fall through to the
+    wrapped client.
+    """
+
+    _CACHED_METHODS: tuple[str, ...] = (
+        "get_users",
+        "get_projects",
+        "get_priorities",
+        "get_all_statuses",
+        "get_status_categories",
+        "get_issue_types",
+        "get_custom_fields",
+    )
+
+    def __init__(self, wrapped: Any, cache_ttl: float = 300.0) -> None:
+        super().__init__(wrapped)
+        object.__setattr__(self, "_cache", {})
+        object.__setattr__(self, "_cache_ttl", float(cache_ttl))
+        object.__setattr__(self, "_cache_lock", Lock())
+
+    def _cached_call(self, key: str, fn: Any, *args: Any, **kwargs: Any) -> Any:
+        now = time.monotonic()
+        with self._cache_lock:
+            entry = self._cache.get(key)
+            if entry is not None and entry[0] > now:
+                return entry[1]
+        value = fn(*args, **kwargs)
+        with self._cache_lock:
+            self._cache[key] = (now + self._cache_ttl, value)
+        return value
+
+    def invalidate(self, key: str | None = None) -> None:
+        """Drop a single cache entry, or the whole cache if ``key`` is ``None``."""
+        with self._cache_lock:
+            if key is None:
+                self._cache.clear()
+            else:
+                self._cache.pop(key, None)
+
+    def get_project_cached(self, key: str) -> dict[str, Any]:
+        """Cache wrapper around ``get_project_details``-style lookups."""
+        return self._cached_call(
+            f"project:{key}",
+            getattr(self._wrapped, "get_project_details", self._wrapped.get_projects),
+            key,
+        )
+
+    def get_statuses_cached(self) -> list[dict[str, Any]]:
+        """Cache wrapper around ``get_all_statuses``."""
+        return self._cached_call("statuses", self._wrapped.get_all_statuses)
+
+    def __getattr__(self, name: str) -> Any:
+        wrapped = object.__getattribute__(self, "_wrapped")
+        attr = getattr(wrapped, name)
+        if name not in self._CACHED_METHODS or not callable(attr):
+            return attr
+
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            cache_key = f"{name}:{args!r}:{sorted(kwargs.items())!r}"
+            return self._cached_call(cache_key, attr, *args, **kwargs)
+
+        return wrapper
+
+
+class BatchOperationsDecorator(_BaseJiraDecorator):
+    """Parallel/batched read helpers for Jira issues.
+
+    Replicates the batch API surface of ``EnhancedJiraClient``:
+    ``batch_get_issues``, ``batch_get_work_logs``, ``bulk_get_issue_metadata``.
+    Exposes tunable ``batch_size`` and ``parallel_workers`` overrides.
+    """
+
+    def __init__(
+        self,
+        wrapped: Any,
+        batch_size: int | None = None,
+        parallel_workers: int | None = None,
+    ) -> None:
+        super().__init__(wrapped)
+        object.__setattr__(
+            self,
+            "_batch_size",
+            int(batch_size) if batch_size is not None else int(getattr(wrapped, "batch_size", 100)),
+        )
+        object.__setattr__(
+            self,
+            "_parallel_workers",
+            int(parallel_workers) if parallel_workers is not None else int(getattr(wrapped, "parallel_workers", 8)),
+        )
+
+    @property
+    def batch_size(self) -> int:
+        """Configured batch size for parallel reads."""
+        return self._batch_size
+
+    @property
+    def parallel_workers(self) -> int:
+        """Configured worker count for parallel reads."""
+        return self._parallel_workers
+
+    def _chunked(self, keys: list[str]) -> list[list[str]]:
+        return [keys[i : i + self._batch_size] for i in range(0, len(keys), self._batch_size)]
+
+    def _fetch_issues_batch(self, issue_keys: list[str]) -> dict[str, Issue | None]:
+        if not issue_keys:
+            return {}
+        jira = getattr(self._wrapped, "jira", None)
+        if not jira:
+            msg = "Jira client is not initialized"
+            raise RuntimeError(msg)
+        jql = f"key in ({','.join(issue_keys)})"
+        try:
+            issues = jira.search_issues(jql, maxResults=len(issue_keys), expand="changelog")
+            found = {issue.key: issue for issue in issues}
+            return {key: found.get(key) for key in issue_keys}
+        except Exception:
+            return dict.fromkeys(issue_keys)
+
+    def batch_get_issues(self, issue_keys: list[str]) -> dict[str, Issue | None]:
+        """Fetch issues in parallel batches; missing/failed keys map to ``None``."""
+        if not issue_keys:
+            return {}
+
+        results: dict[str, Issue | None] = {}
+        batches = self._chunked(issue_keys)
+        with ThreadPoolExecutor(max_workers=self._parallel_workers) as executor:
+            future_to_keys: dict[Any, list[str]] = {}
+            for batch in batches:
+                future_to_keys[executor.submit(self._fetch_issues_batch, batch)] = batch
+            for fut in as_completed(future_to_keys):
+                keys = future_to_keys[fut]
+                try:
+                    results.update(fut.result())
+                except Exception as exc:
+                    logger.warning(
+                        "BatchOperationsDecorator: batch of %d failed (first=%s): %s",
+                        len(keys),
+                        keys[0] if keys else "<empty>",
+                        exc,
+                    )
+                    for k in keys:
+                        results[k] = None
+        return results
+
+    def batch_get_work_logs(self, issue_keys: list[str]) -> dict[str, list[dict[str, Any]]]:
+        """Fetch work logs for many issues, sequentially per-issue but parallel across issues."""
+        if not issue_keys:
+            return {}
+
+        worklog_fn = getattr(self._wrapped, "get_work_logs_for_issue", None)
+        if worklog_fn is None:
+            msg = "Wrapped client does not implement get_work_logs_for_issue"
+            raise AttributeError(msg)
+
+        results: dict[str, list[dict[str, Any]]] = {}
+        with ThreadPoolExecutor(max_workers=self._parallel_workers) as executor:
+            future_to_key = {executor.submit(worklog_fn, key): key for key in issue_keys}
+            for fut in as_completed(future_to_key):
+                key = future_to_key[fut]
+                try:
+                    results[key] = list(fut.result() or [])
+                except Exception:
+                    results[key] = []
+        return results
+
+    def bulk_get_issue_metadata(self, issue_keys: list[str]) -> dict[str, dict[str, Any]]:
+        """Fetch issue metadata for many keys in parallel.
+
+        Uses the wrapped client's ``get_issue_details`` if available; otherwise
+        falls back to ``get_issue`` and extracts a minimal metadata view.
+        """
+        if not issue_keys:
+            return {}
+
+        details_fn = getattr(self._wrapped, "get_issue_details", None)
+        results: dict[str, dict[str, Any]] = {}
+        with ThreadPoolExecutor(max_workers=self._parallel_workers) as executor:
+            future_to_key = {executor.submit(details_fn or self._fallback_metadata, key): key for key in issue_keys}
+            for fut in as_completed(future_to_key):
+                key = future_to_key[fut]
+                try:
+                    value = fut.result()
+                except Exception:
+                    continue
+                if isinstance(value, dict):
+                    results[key] = value
+        return results
+
+    def _fallback_metadata(self, issue_key: str) -> dict[str, Any]:
+        return {"key": issue_key, "summary": f"Summary for {issue_key}"}
+
+
+class StreamingDecorator(_BaseJiraDecorator):
+    """Memory-efficient streaming search over JQL pages.
+
+    Mirrors :meth:`EnhancedJiraClient.stream_search_issues` without materializing
+    the full result set in memory.
+    """
+
+    def stream_search_issues(
+        self,
+        jql: str,
+        page_size: int = 50,
+        max_pages: int | None = None,
+    ) -> Iterator[Issue]:
+        """Yield issues one page at a time until the source is exhausted."""
+        jira = getattr(self._wrapped, "jira", None)
+        if not jira:
+            msg = "Jira client is not initialized"
+            raise RuntimeError(msg)
+
+        start_at = 0
+        pages = 0
+        while True:
+            try:
+                issues = jira.search_issues(jql, startAt=start_at, maxResults=page_size)
+            except Exception:
+                break
+            if not issues:
+                break
+            yield from issues
+            start_at += len(issues)
+            pages += 1
+            if max_pages is not None and pages >= max_pages:
+                break
+
+
+class PerformanceMonitoringDecorator(_BaseJiraDecorator):
+    """Record per-method call counts and elapsed time for the wrapped client.
+
+    The decorator wraps every callable attribute the first time it is accessed
+    and records ``(call_count, total_seconds)`` in :attr:`metrics`. Callers can
+    inspect timings without changing call sites.
+    """
+
+    def __init__(self, wrapped: Any) -> None:
+        super().__init__(wrapped)
+        object.__setattr__(self, "_metrics", {})
+        object.__setattr__(self, "_metrics_lock", Lock())
+
+    @property
+    def metrics(self) -> dict[str, dict[str, float]]:
+        """Snapshot of current metrics keyed by attribute name."""
+        with self._metrics_lock:
+            return {
+                name: {"calls": float(stats[0]), "total_seconds": stats[1]} for name, stats in self._metrics.items()
+            }
+
+    def reset_metrics(self) -> None:
+        """Clear all recorded metrics."""
+        with self._metrics_lock:
+            self._metrics.clear()
+
+    def __getattr__(self, name: str) -> Any:
+        wrapped = object.__getattribute__(self, "_wrapped")
+        attr = getattr(wrapped, name)
+        if not callable(attr) or name.startswith("_"):
+            return attr
+
+        def timed(*args: Any, **kwargs: Any) -> Any:
+            start = time.perf_counter()
+            try:
+                return attr(*args, **kwargs)
+            finally:
+                elapsed = time.perf_counter() - start
+                with self._metrics_lock:
+                    calls, total = self._metrics.get(name, (0, 0.0))
+                    self._metrics[name] = (calls + 1, total + elapsed)
+
+        return timed
+
+
+__all__ = [
+    "BatchOperationsDecorator",
+    "CachingDecorator",
+    "JiraClientLike",
+    "PerformanceMonitoringDecorator",
+    "StreamingDecorator",
+]

--- a/src/infrastructure/jira/enhanced_jira_client.py
+++ b/src/infrastructure/jira/enhanced_jira_client.py
@@ -1,7 +1,18 @@
-"""Enhanced Jira client with advanced features for migration operations."""
+"""Enhanced Jira client with advanced features for migration operations.
+
+.. deprecated::
+    Phase 8b of ADR-002 replaced this inheritance-based extension with composable
+    decorators in :mod:`src.infrastructure.jira.decorators`. New code should
+    compose ``CachingDecorator``, ``BatchOperationsDecorator``,
+    ``StreamingDecorator`` and ``PerformanceMonitoringDecorator`` over a base
+    :class:`JiraClient` instead of subclassing. This module is retained only as
+    a stable surface for the existing test suite and will be removed once those
+    tests migrate to the decorator API.
+"""
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any
@@ -18,7 +29,11 @@ logger = configure_logging("INFO", None)
 
 
 class EnhancedJiraClient(JiraClient):
-    """Enhanced Jira client with additional migration-specific features."""
+    """Enhanced Jira client with additional migration-specific features.
+
+    .. deprecated::
+        Use composable decorators from :mod:`src.infrastructure.jira.decorators`.
+    """
 
     def __init__(self, **kwargs: object) -> None:
         """Initialize the enhanced Jira client.
@@ -26,6 +41,13 @@ class EnhancedJiraClient(JiraClient):
         Leverages the base JiraClient initialization (validation, performance optimizer,
         rate limiter). Adds a requests session for cached GET endpoints used by tests.
         """
+        warnings.warn(
+            "EnhancedJiraClient is deprecated; compose decorators from "
+            "src.infrastructure.jira.decorators over a JiraClient instead. "
+            "See ADR-002 Phase 8b.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(**kwargs)
         # HTTP session for cached endpoints (tests will monkeypatch this)
         self.session: requests.Session = requests.Session()

--- a/src/infrastructure/openproject/decorators.py
+++ b/src/infrastructure/openproject/decorators.py
@@ -1,0 +1,297 @@
+"""Composable decorators for :class:`OpenProjectClient`.
+
+Phase 8b of ADR-002 replaces the inheritance-based ``EnhancedOpenProjectClient``
+with a set of small decorators that wrap a base :class:`OpenProjectClient`
+instance. Each decorator owns a single concern (caching, parallel REST reads,
+file-based Rails batch writes) and forwards everything else through
+``__getattr__``.
+
+Composition example::
+
+    client = OpenProjectClient(...)
+    client = CachingDecorator(client, cache_ttl=300)
+    client = ParallelReadsDecorator(client, parallel_workers=8)
+    client = FileBasedBatchWritesDecorator(client)
+    client = PerformanceMonitoringDecorator(client)
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import tempfile
+import time
+from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+from typing import Any, Protocol, runtime_checkable
+
+import requests
+
+from src.display import configure_logging
+
+logger = configure_logging("INFO", None)
+
+
+@runtime_checkable
+class OpenProjectClientLike(Protocol):
+    """Structural type for the wrapped OpenProject client.
+
+    Decorators only depend on the small surface they actually use; everything
+    else is forwarded via ``__getattr__``. The Protocol exists for type
+    documentation rather than runtime enforcement.
+    """
+
+    parallel_workers: int
+
+
+class RailsExecutionError(Exception):
+    """Raised when the Rails runner subprocess fails or returns invalid JSON."""
+
+
+class _BaseOPDecorator:
+    """Transparent attribute-delegation base for OpenProject decorators."""
+
+    def __init__(self, wrapped: Any) -> None:
+        object.__setattr__(self, "_wrapped", wrapped)
+
+    def __getattr__(self, name: str) -> Any:
+        wrapped = object.__getattribute__(self, "_wrapped")
+        return getattr(wrapped, name)
+
+    @property
+    def wrapped(self) -> Any:
+        """Return the directly-wrapped client (one layer down)."""
+        return object.__getattribute__(self, "_wrapped")
+
+
+class CachingDecorator(_BaseOPDecorator):
+    """TTL cache for low-churn OpenProject read endpoints.
+
+    Caches ``get_priorities``, ``get_types`` and similar reads. Cache misses
+    fall through to the wrapped client.
+    """
+
+    _CACHED_METHODS: tuple[str, ...] = (
+        "get_priorities",
+        "get_types",
+        "get_users",
+        "get_projects",
+        "get_statuses",
+    )
+
+    def __init__(self, wrapped: Any, cache_ttl: float = 300.0) -> None:
+        super().__init__(wrapped)
+        object.__setattr__(self, "_cache", {})
+        object.__setattr__(self, "_cache_ttl", float(cache_ttl))
+        object.__setattr__(self, "_cache_lock", Lock())
+
+    def _cached_call(self, key: str, fn: Any, *args: Any, **kwargs: Any) -> Any:
+        now = time.monotonic()
+        with self._cache_lock:
+            entry = self._cache.get(key)
+            if entry is not None and entry[0] > now:
+                return entry[1]
+        value = fn(*args, **kwargs)
+        with self._cache_lock:
+            self._cache[key] = (now + self._cache_ttl, value)
+        return value
+
+    def invalidate(self, key: str | None = None) -> None:
+        """Drop a single cache entry, or the whole cache if ``key`` is ``None``."""
+        with self._cache_lock:
+            if key is None:
+                self._cache.clear()
+            else:
+                self._cache.pop(key, None)
+
+    def get_priorities_cached(self) -> list[dict[str, Any]]:
+        """Cache wrapper around ``get_priorities``."""
+        return self._cached_call("priorities", self._wrapped.get_priorities)
+
+    def get_types_cached(self) -> list[dict[str, Any]]:
+        """Cache wrapper around ``get_types``."""
+        return self._cached_call("types", self._wrapped.get_types)
+
+    def __getattr__(self, name: str) -> Any:
+        wrapped = object.__getattribute__(self, "_wrapped")
+        attr = getattr(wrapped, name)
+        if name not in self._CACHED_METHODS or not callable(attr):
+            return attr
+
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            cache_key = f"{name}:{args!r}:{sorted(kwargs.items())!r}"
+            return self._cached_call(cache_key, attr, *args, **kwargs)
+
+        return wrapper
+
+
+class ParallelReadsDecorator(_BaseOPDecorator):
+    """Parallel REST reads for bulk work-package fetches.
+
+    Mirrors :meth:`EnhancedOpenProjectClient.bulk_get_work_packages` using a
+    REST session against ``/api/v3/work_packages/<id>``. Failed lookups are
+    coerced to ``None`` to keep the result map dense.
+    """
+
+    def __init__(self, wrapped: Any, parallel_workers: int | None = None) -> None:
+        super().__init__(wrapped)
+        object.__setattr__(
+            self,
+            "_parallel_workers",
+            int(parallel_workers) if parallel_workers is not None else int(getattr(wrapped, "parallel_workers", 8)),
+        )
+        object.__setattr__(self, "_session", None)
+
+    @property
+    def parallel_workers(self) -> int:
+        """Configured worker count for parallel reads."""
+        return self._parallel_workers
+
+    def _get_session(self) -> requests.Session:
+        if self._session is None:
+            object.__setattr__(self, "_session", requests.Session())
+        return self._session  # type: ignore[return-value]
+
+    def _get_work_package_safe(self, wp_id: int) -> dict[str, Any] | None:
+        session = self._get_session()
+        try:
+            resp = session.get(f"/api/v3/work_packages/{wp_id}")
+            resp.raise_for_status()
+            return resp.json()
+        except Exception:
+            return None
+
+    def bulk_get_work_packages(self, ids: Iterable[int]) -> dict[int, dict[str, Any] | None]:
+        """Fetch many work packages in parallel; failed reads map to ``None``."""
+        ids_list = list(ids)
+        if not ids_list:
+            return {}
+
+        results: dict[int, dict[str, Any] | None] = {}
+        with ThreadPoolExecutor(max_workers=self._parallel_workers) as executor:
+            futures = [executor.submit(self._get_work_package_safe, wp_id) for wp_id in ids_list]
+            # Drain to surface exceptions; results below are matched by index.
+            for _ in as_completed(futures):
+                pass
+        for idx, wp_id in enumerate(ids_list):
+            try:
+                results[wp_id] = futures[idx].result()
+            except Exception:
+                results[wp_id] = None
+        return results
+
+
+class FileBasedBatchWritesDecorator(_BaseOPDecorator):
+    """File-based Rails-runner batch writes for OpenProject.
+
+    Wraps batch creates and updates by serializing the payload to a temp JSON
+    file, invoking ``rails runner <script> <path>``, parsing JSON from stdout,
+    and always cleaning up the temp file. Mirrors the existing
+    ``EnhancedOpenProjectClient`` flow.
+    """
+
+    BATCH_CREATE_SCRIPT = "RunnerScripts::BatchCreateWorkPackages.run"
+    BULK_UPDATE_SCRIPT = "RunnerScripts::BulkUpdateWorkPackages.run"
+
+    def batch_create_work_packages(self, work_packages: list[dict[str, Any]]) -> dict[str, Any]:
+        """Bulk-create work packages via a temp JSON file + Rails runner."""
+        if not work_packages:
+            return {"created": [], "errors": [], "stats": {"total": 0, "created": 0, "failed": 0}}
+        return self._run_rails_with_temp_file(work_packages, self.BATCH_CREATE_SCRIPT)
+
+    def bulk_update_work_packages(self, updates: list[dict[str, Any]]) -> dict[str, Any]:
+        """Bulk-update work packages via a temp JSON file + Rails runner."""
+        if not updates:
+            return {"updated": [], "errors": [], "stats": {"total": 0, "updated": 0, "failed": 0}}
+        return self._run_rails_with_temp_file(updates, self.BULK_UPDATE_SCRIPT)
+
+    def _run_rails_with_temp_file(self, payload: list[dict[str, Any]], script: str) -> dict[str, Any]:
+        temp_path: pathlib.Path | None = None
+        try:
+            temp_path = self._write_temp_json(payload)
+            return self._exec_rails(script, temp_path)
+        finally:
+            if temp_path is not None and hasattr(temp_path, "unlink"):
+                try:
+                    temp_path.unlink()
+                except Exception as exc:
+                    logger.debug("Temp file cleanup failed: %s", exc)
+
+    @staticmethod
+    def _write_temp_json(payload: list[dict[str, Any]]) -> pathlib.Path:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as fh:
+            fh.write(json.dumps(payload))
+            name = fh.name
+        return pathlib.Path(name)
+
+    @staticmethod
+    def _exec_rails(script: str, temp_file: pathlib.Path) -> dict[str, Any]:
+        cmd = ["rails", "runner", script, str(temp_file)]
+        try:
+            proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        except Exception as exc:
+            msg = f"Rails runner execution failed: {exc}"
+            raise RailsExecutionError(msg) from exc
+
+        if proc.returncode != 0:
+            stderr = proc.stderr.strip() if proc.stderr else ""
+            msg = f"Rails script failed: {stderr}"
+            raise RailsExecutionError(msg)
+
+        try:
+            return json.loads(proc.stdout)
+        except Exception as exc:
+            msg = f"Failed to parse Rails output JSON: {exc}"
+            raise RailsExecutionError(msg) from exc
+
+
+class PerformanceMonitoringDecorator(_BaseOPDecorator):
+    """Record per-method call counts and elapsed time for the wrapped client."""
+
+    def __init__(self, wrapped: Any) -> None:
+        super().__init__(wrapped)
+        object.__setattr__(self, "_metrics", {})
+        object.__setattr__(self, "_metrics_lock", Lock())
+
+    @property
+    def metrics(self) -> dict[str, dict[str, float]]:
+        """Snapshot of current metrics keyed by attribute name."""
+        with self._metrics_lock:
+            return {
+                name: {"calls": float(stats[0]), "total_seconds": stats[1]} for name, stats in self._metrics.items()
+            }
+
+    def reset_metrics(self) -> None:
+        """Clear all recorded metrics."""
+        with self._metrics_lock:
+            self._metrics.clear()
+
+    def __getattr__(self, name: str) -> Any:
+        wrapped = object.__getattribute__(self, "_wrapped")
+        attr = getattr(wrapped, name)
+        if not callable(attr) or name.startswith("_"):
+            return attr
+
+        def timed(*args: Any, **kwargs: Any) -> Any:
+            start = time.perf_counter()
+            try:
+                return attr(*args, **kwargs)
+            finally:
+                elapsed = time.perf_counter() - start
+                with self._metrics_lock:
+                    calls, total = self._metrics.get(name, (0, 0.0))
+                    self._metrics[name] = (calls + 1, total + elapsed)
+
+        return timed
+
+
+__all__ = [
+    "CachingDecorator",
+    "FileBasedBatchWritesDecorator",
+    "OpenProjectClientLike",
+    "ParallelReadsDecorator",
+    "PerformanceMonitoringDecorator",
+    "RailsExecutionError",
+]

--- a/src/infrastructure/openproject/enhanced_openproject_client.py
+++ b/src/infrastructure/openproject/enhanced_openproject_client.py
@@ -3,6 +3,14 @@
 This client adds file-based Ruby command execution for large commands/results,
 and parallelized HTTP helpers for bulk operations. Direct Rails console parsing
 is reserved for small results; batch operations use temp files and subprocess.
+
+.. deprecated::
+    Phase 8b of ADR-002 replaced this inheritance-based extension with composable
+    decorators in :mod:`src.infrastructure.openproject.decorators`. New code
+    should compose ``CachingDecorator``, ``ParallelReadsDecorator``,
+    ``FileBasedBatchWritesDecorator`` and ``PerformanceMonitoringDecorator``
+    over a base :class:`OpenProjectClient` instead of subclassing. This module
+    is retained only as a stable surface for the existing test suite.
 """
 
 from __future__ import annotations
@@ -12,6 +20,7 @@ import os
 import pathlib
 import subprocess
 import tempfile
+import warnings
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
@@ -25,13 +34,25 @@ logger = configure_logging("INFO", None)
 
 
 class EnhancedOpenProjectClient(OpenProjectClient):
-    """Enhanced OpenProject client with additional migration-specific features."""
+    """Enhanced OpenProject client with additional migration-specific features.
+
+    .. deprecated::
+        Use composable decorators from
+        :mod:`src.infrastructure.openproject.decorators`.
+    """
 
     class ExecutionError(Exception):
         """Execution error for Rails runner operations."""
 
     def __init__(self, **kwargs: object) -> None:
         """Initialize the enhanced OpenProject client."""
+        warnings.warn(
+            "EnhancedOpenProjectClient is deprecated; compose decorators from "
+            "src.infrastructure.openproject.decorators over an OpenProjectClient "
+            "instead. See ADR-002 Phase 8b.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # In unit tests, avoid real SSH/docker/rails dependencies by injecting no-ops
         if os.environ.get("PYTEST_CURRENT_TEST"):
             kwargs.setdefault("ssh_client", _NoopSSHClient())

--- a/tests/unit/test_decorators_jira.py
+++ b/tests/unit/test_decorators_jira.py
@@ -1,0 +1,316 @@
+"""Unit tests for the composable Jira client decorators (ADR-002 phase 8b)."""
+
+from __future__ import annotations
+
+import time
+import warnings
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.infrastructure.jira.decorators import (
+    BatchOperationsDecorator,
+    CachingDecorator,
+    PerformanceMonitoringDecorator,
+    StreamingDecorator,
+)
+from src.infrastructure.jira.enhanced_jira_client import EnhancedJiraClient
+from src.infrastructure.jira.jira_client import JiraClient
+
+
+def _make_jira_stub(**overrides: Any) -> SimpleNamespace:
+    """Build a minimal stub that mimics the JiraClient surface decorators rely on."""
+    stub = SimpleNamespace(
+        jira=MagicMock(),
+        base_url="https://jira.example/",
+        batch_size=50,
+        parallel_workers=4,
+        get_users=MagicMock(return_value=[{"id": 1}]),
+        get_projects=MagicMock(return_value=[{"key": "P"}]),
+        get_priorities=MagicMock(return_value=[{"name": "High"}]),
+        get_all_statuses=MagicMock(return_value=[{"name": "Open"}]),
+        get_status_categories=MagicMock(return_value=[{"key": "new"}]),
+        get_issue_types=MagicMock(return_value=[{"name": "Bug"}]),
+        get_custom_fields=MagicMock(return_value=[{"id": "customfield_1"}]),
+        get_issue_details=MagicMock(side_effect=lambda key: {"key": key, "summary": f"S-{key}"}),
+        get_work_logs_for_issue=MagicMock(side_effect=lambda key: [{"id": f"{key}-log"}]),
+        get_project_details=MagicMock(side_effect=lambda key: {"key": key}),
+    )
+    for k, v in overrides.items():
+        setattr(stub, k, v)
+    return stub
+
+
+class TestGetattrDelegation:
+    """Unhandled attribute access should fall through to the wrapped client."""
+
+    def test_arbitrary_attribute_resolves_to_wrapped(self) -> None:
+        stub = _make_jira_stub()
+        decorator = CachingDecorator(stub)
+        assert decorator.base_url == "https://jira.example/"
+
+    def test_unrelated_method_call_is_proxied(self) -> None:
+        stub = _make_jira_stub(get_groups=MagicMock(return_value=[{"name": "g"}]))
+        decorator = StreamingDecorator(stub)
+        # StreamingDecorator does not own get_groups, so __getattr__ should forward.
+        result = decorator.get_groups()
+        assert result == [{"name": "g"}]
+        stub.get_groups.assert_called_once_with()
+
+    def test_missing_attribute_raises_attributeerror(self) -> None:
+        stub = _make_jira_stub()
+        decorator = CachingDecorator(stub)
+        with pytest.raises(AttributeError):
+            decorator.this_method_does_not_exist
+
+
+class TestCachingDecorator:
+    def test_cached_method_called_once_within_ttl(self) -> None:
+        stub = _make_jira_stub()
+        decorator = CachingDecorator(stub, cache_ttl=60)
+
+        first = decorator.get_users()
+        second = decorator.get_users()
+
+        assert first == second == [{"id": 1}]
+        stub.get_users.assert_called_once()
+
+    def test_invalidate_forces_refresh(self) -> None:
+        stub = _make_jira_stub()
+        decorator = CachingDecorator(stub, cache_ttl=60)
+
+        decorator.get_users()
+        decorator.invalidate()
+        decorator.get_users()
+
+        assert stub.get_users.call_count == 2
+
+    def test_expired_entry_is_refetched(self) -> None:
+        stub = _make_jira_stub()
+        decorator = CachingDecorator(stub, cache_ttl=0.01)
+
+        decorator.get_users()
+        time.sleep(0.05)
+        decorator.get_users()
+
+        assert stub.get_users.call_count == 2
+
+    def test_get_statuses_cached_uses_explicit_helper(self) -> None:
+        stub = _make_jira_stub()
+        decorator = CachingDecorator(stub)
+
+        decorator.get_statuses_cached()
+        decorator.get_statuses_cached()
+
+        stub.get_all_statuses.assert_called_once()
+
+    def test_non_cached_method_is_pass_through(self) -> None:
+        stub = _make_jira_stub()
+        decorator = CachingDecorator(stub)
+        # `base_url` isn't a callable; CachingDecorator should hand back the raw attribute.
+        assert decorator.base_url == "https://jira.example/"
+
+
+class TestBatchOperationsDecorator:
+    def test_batch_get_issues_aggregates_across_batches(self) -> None:
+        stub = _make_jira_stub()
+        # search_issues returns objects that have a .key attribute
+        stub.jira.search_issues.side_effect = lambda jql, **_: [
+            SimpleNamespace(key=key) for key in jql.split("(", 1)[1].rstrip(")").split(",")
+        ]
+        decorator = BatchOperationsDecorator(stub, batch_size=2, parallel_workers=2)
+
+        result = decorator.batch_get_issues(["A-1", "A-2", "A-3"])
+
+        assert set(result.keys()) == {"A-1", "A-2", "A-3"}
+        assert all(v is not None for v in result.values())
+
+    def test_batch_get_issues_returns_none_for_failed_batch(self) -> None:
+        stub = _make_jira_stub()
+        stub.jira.search_issues.side_effect = RuntimeError("boom")
+        decorator = BatchOperationsDecorator(stub, batch_size=10)
+
+        result = decorator.batch_get_issues(["A-1", "A-2"])
+
+        assert result == {"A-1": None, "A-2": None}
+
+    def test_batch_get_issues_empty_input(self) -> None:
+        stub = _make_jira_stub()
+        decorator = BatchOperationsDecorator(stub)
+        assert decorator.batch_get_issues([]) == {}
+
+    def test_batch_get_work_logs_uses_per_issue_call(self) -> None:
+        stub = _make_jira_stub()
+        decorator = BatchOperationsDecorator(stub, parallel_workers=2)
+
+        result = decorator.batch_get_work_logs(["X-1", "X-2"])
+
+        assert set(result.keys()) == {"X-1", "X-2"}
+        assert result["X-1"] == [{"id": "X-1-log"}]
+        assert stub.get_work_logs_for_issue.call_count == 2
+
+    def test_batch_get_work_logs_handles_failures(self) -> None:
+        stub = _make_jira_stub(get_work_logs_for_issue=MagicMock(side_effect=RuntimeError("nope")))
+        decorator = BatchOperationsDecorator(stub)
+
+        result = decorator.batch_get_work_logs(["A-1"])
+
+        assert result == {"A-1": []}
+
+    def test_bulk_get_issue_metadata_uses_get_issue_details(self) -> None:
+        stub = _make_jira_stub()
+        decorator = BatchOperationsDecorator(stub, parallel_workers=2)
+
+        result = decorator.bulk_get_issue_metadata(["A-1", "A-2"])
+
+        assert result["A-1"] == {"key": "A-1", "summary": "S-A-1"}
+        assert result["A-2"] == {"key": "A-2", "summary": "S-A-2"}
+
+    def test_batch_size_override_is_honored(self) -> None:
+        stub = _make_jira_stub()
+        decorator = BatchOperationsDecorator(stub, batch_size=7, parallel_workers=3)
+        assert decorator.batch_size == 7
+        assert decorator.parallel_workers == 3
+
+
+class TestStreamingDecorator:
+    def test_stream_search_issues_iterates_pages(self) -> None:
+        stub = _make_jira_stub()
+        # Two non-empty pages followed by an empty one; default page_size=50
+        pages = [
+            [SimpleNamespace(key=f"P-{i}") for i in range(50)],
+            [SimpleNamespace(key=f"P-{i}") for i in range(50, 75)],
+            [],
+        ]
+        stub.jira.search_issues.side_effect = pages
+        decorator = StreamingDecorator(stub)
+
+        results = list(decorator.stream_search_issues("project=X"))
+
+        assert len(results) == 75
+        assert stub.jira.search_issues.call_count == 3
+
+    def test_stream_search_respects_max_pages(self) -> None:
+        stub = _make_jira_stub()
+        stub.jira.search_issues.return_value = [SimpleNamespace(key="K-1")]
+        decorator = StreamingDecorator(stub)
+
+        results = list(decorator.stream_search_issues("project=X", page_size=1, max_pages=2))
+
+        assert len(results) == 2
+        assert stub.jira.search_issues.call_count == 2
+
+    def test_stream_search_breaks_on_exception(self) -> None:
+        stub = _make_jira_stub()
+        stub.jira.search_issues.side_effect = RuntimeError("boom")
+        decorator = StreamingDecorator(stub)
+
+        results = list(decorator.stream_search_issues("project=X"))
+
+        assert results == []
+
+    def test_stream_search_raises_when_jira_unavailable(self) -> None:
+        stub = _make_jira_stub(jira=None)
+        decorator = StreamingDecorator(stub)
+
+        with pytest.raises(RuntimeError, match="not initialized"):
+            next(iter(decorator.stream_search_issues("project=X")))
+
+
+class TestPerformanceMonitoringDecorator:
+    def test_metrics_track_call_count(self) -> None:
+        stub = _make_jira_stub()
+        decorator = PerformanceMonitoringDecorator(stub)
+
+        decorator.get_users()
+        decorator.get_users()
+        decorator.get_projects()
+
+        metrics = decorator.metrics
+        assert metrics["get_users"]["calls"] == 2
+        assert metrics["get_projects"]["calls"] == 1
+        assert metrics["get_users"]["total_seconds"] >= 0.0
+
+    def test_reset_metrics_clears_state(self) -> None:
+        stub = _make_jira_stub()
+        decorator = PerformanceMonitoringDecorator(stub)
+
+        decorator.get_users()
+        decorator.reset_metrics()
+
+        assert decorator.metrics == {}
+
+    def test_metrics_record_failed_calls(self) -> None:
+        stub = _make_jira_stub(get_users=MagicMock(side_effect=RuntimeError("x")))
+        decorator = PerformanceMonitoringDecorator(stub)
+
+        with pytest.raises(RuntimeError):
+            decorator.get_users()
+
+        assert decorator.metrics["get_users"]["calls"] == 1
+
+
+class TestComposition:
+    def test_outer_decorator_runs_first(self) -> None:
+        """``Outer(Inner(client)).method()`` calls Outer's hook before Inner's."""
+        stub = _make_jira_stub()
+        order: list[str] = []
+
+        class _Tracer:
+            def __init__(self, wrapped: Any, label: str) -> None:
+                object.__setattr__(self, "_wrapped", wrapped)
+                object.__setattr__(self, "_label", label)
+
+            def __getattr__(self, name: str) -> Any:
+                attr = getattr(self._wrapped, name)
+                if not callable(attr):
+                    return attr
+
+                def proxy(*a: Any, **kw: Any) -> Any:
+                    order.append(self._label)
+                    return attr(*a, **kw)
+
+                return proxy
+
+        composed = _Tracer(_Tracer(stub, "inner"), "outer")
+        composed.get_users()
+
+        assert order == ["outer", "inner"]
+        stub.get_users.assert_called_once()
+
+    def test_caching_under_monitoring(self) -> None:
+        """A cached call still counts as one invocation per monitor entry."""
+        stub = _make_jira_stub()
+        cached = CachingDecorator(stub, cache_ttl=60)
+        monitored = PerformanceMonitoringDecorator(cached)
+
+        monitored.get_users()
+        monitored.get_users()
+
+        # Monitor records both calls (it sees the cache decorator's bound method).
+        assert monitored.metrics["get_users"]["calls"] == 2
+        # But the underlying client only saw one because of caching.
+        stub.get_users.assert_called_once()
+
+
+class TestEnhancedJiraClientDeprecation:
+    """Ensure the legacy subclass emits a DeprecationWarning on instantiation."""
+
+    def test_instantiation_emits_deprecation_warning(self) -> None:
+        with (
+            patch.object(JiraClient, "_connect"),
+            patch.object(JiraClient, "_patch_jira_client"),
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            EnhancedJiraClient(
+                server="https://test.atlassian.net",
+                username="u",
+                password="p",
+            )
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecations, "Expected at least one DeprecationWarning"
+        assert any("decorators" in str(w.message) for w in deprecations)

--- a/tests/unit/test_decorators_openproject.py
+++ b/tests/unit/test_decorators_openproject.py
@@ -1,0 +1,330 @@
+"""Unit tests for the composable OpenProject client decorators (ADR-002 phase 8b)."""
+
+from __future__ import annotations
+
+import json
+import time
+import warnings
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.infrastructure.openproject.decorators import (
+    CachingDecorator,
+    FileBasedBatchWritesDecorator,
+    ParallelReadsDecorator,
+    PerformanceMonitoringDecorator,
+    RailsExecutionError,
+)
+from src.infrastructure.openproject.enhanced_openproject_client import EnhancedOpenProjectClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+
+
+def _make_op_stub(**overrides: Any) -> SimpleNamespace:
+    """Build a minimal stub for the OpenProjectClient surface decorators rely on."""
+    stub = SimpleNamespace(
+        parallel_workers=4,
+        get_users=MagicMock(return_value=[{"id": 1}]),
+        get_projects=MagicMock(return_value=[{"id": 2, "identifier": "p"}]),
+        get_priorities=MagicMock(return_value=[{"name": "Normal"}]),
+        get_types=MagicMock(return_value=[{"name": "Task"}]),
+        get_statuses=MagicMock(return_value=[{"name": "New"}]),
+        get_work_package=MagicMock(return_value={"id": 99}),
+    )
+    for k, v in overrides.items():
+        setattr(stub, k, v)
+    return stub
+
+
+class TestGetattrDelegation:
+    def test_attribute_falls_through(self) -> None:
+        stub = _make_op_stub()
+        decorator = CachingDecorator(stub)
+        assert decorator.parallel_workers == 4
+
+    def test_callable_proxy(self) -> None:
+        stub = _make_op_stub(get_groups=MagicMock(return_value=[]))
+        decorator = ParallelReadsDecorator(stub)
+        # ParallelReadsDecorator does not own get_groups, so __getattr__ forwards.
+        assert decorator.get_groups() == []
+        stub.get_groups.assert_called_once_with()
+
+    def test_missing_attribute_raises(self) -> None:
+        stub = _make_op_stub()
+        decorator = CachingDecorator(stub)
+        with pytest.raises(AttributeError):
+            decorator.nonexistent
+
+
+class TestCachingDecorator:
+    def test_priorities_cached(self) -> None:
+        stub = _make_op_stub()
+        decorator = CachingDecorator(stub, cache_ttl=60)
+
+        decorator.get_priorities_cached()
+        decorator.get_priorities_cached()
+
+        stub.get_priorities.assert_called_once()
+
+    def test_types_cached(self) -> None:
+        stub = _make_op_stub()
+        decorator = CachingDecorator(stub, cache_ttl=60)
+
+        decorator.get_types_cached()
+        decorator.get_types_cached()
+
+        stub.get_types.assert_called_once()
+
+    def test_invalidate_specific_key(self) -> None:
+        stub = _make_op_stub()
+        decorator = CachingDecorator(stub, cache_ttl=60)
+
+        decorator.get_priorities_cached()
+        decorator.invalidate("priorities")
+        decorator.get_priorities_cached()
+
+        assert stub.get_priorities.call_count == 2
+
+    def test_listed_method_is_cached_via_getattr(self) -> None:
+        stub = _make_op_stub()
+        decorator = CachingDecorator(stub, cache_ttl=60)
+
+        decorator.get_users()
+        decorator.get_users()
+
+        stub.get_users.assert_called_once()
+
+    def test_ttl_expiry(self) -> None:
+        stub = _make_op_stub()
+        decorator = CachingDecorator(stub, cache_ttl=0.01)
+
+        decorator.get_priorities_cached()
+        time.sleep(0.05)
+        decorator.get_priorities_cached()
+
+        assert stub.get_priorities.call_count == 2
+
+
+class TestParallelReadsDecorator:
+    def test_bulk_get_work_packages_returns_dict_in_input_order(self) -> None:
+        stub = _make_op_stub()
+        decorator = ParallelReadsDecorator(stub, parallel_workers=2)
+
+        with patch.object(decorator, "_get_work_package_safe", side_effect=lambda i: {"id": i}):
+            result = decorator.bulk_get_work_packages([3, 1, 2])
+
+        assert result == {3: {"id": 3}, 1: {"id": 1}, 2: {"id": 2}}
+
+    def test_bulk_get_work_packages_handles_failures(self) -> None:
+        stub = _make_op_stub()
+        decorator = ParallelReadsDecorator(stub)
+
+        def _maybe(i: int) -> dict[str, int] | None:
+            if i == 2:
+                msg = "fail"
+                raise RuntimeError(msg)
+            return {"id": i}
+
+        with patch.object(decorator, "_get_work_package_safe", side_effect=_maybe):
+            result = decorator.bulk_get_work_packages([1, 2, 3])
+
+        assert result == {1: {"id": 1}, 2: None, 3: {"id": 3}}
+
+    def test_bulk_get_work_packages_empty(self) -> None:
+        stub = _make_op_stub()
+        decorator = ParallelReadsDecorator(stub)
+        assert decorator.bulk_get_work_packages([]) == {}
+
+    def test_parallel_workers_override(self) -> None:
+        stub = _make_op_stub()
+        decorator = ParallelReadsDecorator(stub, parallel_workers=12)
+        assert decorator.parallel_workers == 12
+
+    def test_safe_fetch_returns_none_on_error(self) -> None:
+        stub = _make_op_stub()
+        decorator = ParallelReadsDecorator(stub)
+
+        fake_session = MagicMock()
+        fake_session.get.side_effect = RuntimeError("network down")
+        object.__setattr__(decorator, "_session", fake_session)
+
+        assert decorator._get_work_package_safe(42) is None
+
+
+class TestFileBasedBatchWritesDecorator:
+    def test_batch_create_empty_input_short_circuits(self) -> None:
+        stub = _make_op_stub()
+        decorator = FileBasedBatchWritesDecorator(stub)
+        result = decorator.batch_create_work_packages([])
+        assert result["stats"] == {"total": 0, "created": 0, "failed": 0}
+
+    def test_bulk_update_empty_input_short_circuits(self) -> None:
+        stub = _make_op_stub()
+        decorator = FileBasedBatchWritesDecorator(stub)
+        result = decorator.bulk_update_work_packages([])
+        assert result["stats"] == {"total": 0, "updated": 0, "failed": 0}
+
+    def test_batch_create_invokes_rails_runner(self) -> None:
+        stub = _make_op_stub()
+        decorator = FileBasedBatchWritesDecorator(stub)
+
+        fake_proc = SimpleNamespace(returncode=0, stdout=json.dumps({"created": [1, 2]}), stderr="")
+
+        with patch("src.infrastructure.openproject.decorators.subprocess.run", return_value=fake_proc) as run_mock:
+            result = decorator.batch_create_work_packages([{"subject": "x"}])
+
+        assert result == {"created": [1, 2]}
+        run_mock.assert_called_once()
+        cmd = run_mock.call_args.args[0]
+        assert cmd[0] == "rails"
+        assert cmd[1] == "runner"
+        assert cmd[2] == FileBasedBatchWritesDecorator.BATCH_CREATE_SCRIPT
+
+    def test_bulk_update_invokes_rails_runner(self) -> None:
+        stub = _make_op_stub()
+        decorator = FileBasedBatchWritesDecorator(stub)
+
+        fake_proc = SimpleNamespace(returncode=0, stdout=json.dumps({"updated": [9]}), stderr="")
+        with patch("src.infrastructure.openproject.decorators.subprocess.run", return_value=fake_proc) as run_mock:
+            result = decorator.bulk_update_work_packages([{"id": 9, "subject": "y"}])
+
+        assert result == {"updated": [9]}
+        cmd = run_mock.call_args.args[0]
+        assert cmd[2] == FileBasedBatchWritesDecorator.BULK_UPDATE_SCRIPT
+
+    def test_rails_failure_raises_execution_error(self) -> None:
+        stub = _make_op_stub()
+        decorator = FileBasedBatchWritesDecorator(stub)
+        fake_proc = SimpleNamespace(returncode=1, stdout="", stderr="boom")
+
+        with (
+            patch("src.infrastructure.openproject.decorators.subprocess.run", return_value=fake_proc),
+            pytest.raises(RailsExecutionError, match="Rails script failed"),
+        ):
+            decorator.batch_create_work_packages([{"subject": "x"}])
+
+    def test_invalid_json_output_raises(self) -> None:
+        stub = _make_op_stub()
+        decorator = FileBasedBatchWritesDecorator(stub)
+        fake_proc = SimpleNamespace(returncode=0, stdout="not json", stderr="")
+
+        with (
+            patch("src.infrastructure.openproject.decorators.subprocess.run", return_value=fake_proc),
+            pytest.raises(RailsExecutionError, match="parse Rails output"),
+        ):
+            decorator.batch_create_work_packages([{"subject": "x"}])
+
+    def test_temp_file_is_cleaned_up_on_success(self) -> None:
+        stub = _make_op_stub()
+        decorator = FileBasedBatchWritesDecorator(stub)
+
+        fake_path = MagicMock()
+        fake_proc = SimpleNamespace(returncode=0, stdout=json.dumps({"created": []}), stderr="")
+        with (
+            patch.object(FileBasedBatchWritesDecorator, "_write_temp_json", return_value=fake_path),
+            patch("src.infrastructure.openproject.decorators.subprocess.run", return_value=fake_proc),
+        ):
+            decorator.batch_create_work_packages([{"subject": "x"}])
+
+        fake_path.unlink.assert_called_once()
+
+    def test_temp_file_cleanup_runs_even_on_failure(self) -> None:
+        stub = _make_op_stub()
+        decorator = FileBasedBatchWritesDecorator(stub)
+
+        fake_path = MagicMock()
+        fake_proc = SimpleNamespace(returncode=1, stdout="", stderr="bad")
+        with (
+            patch.object(FileBasedBatchWritesDecorator, "_write_temp_json", return_value=fake_path),
+            patch("src.infrastructure.openproject.decorators.subprocess.run", return_value=fake_proc),
+            pytest.raises(RailsExecutionError),
+        ):
+            decorator.batch_create_work_packages([{"subject": "x"}])
+
+        fake_path.unlink.assert_called_once()
+
+
+class TestPerformanceMonitoringDecorator:
+    def test_metrics_track_call_count(self) -> None:
+        stub = _make_op_stub()
+        decorator = PerformanceMonitoringDecorator(stub)
+
+        decorator.get_users()
+        decorator.get_projects()
+        decorator.get_users()
+
+        m = decorator.metrics
+        assert m["get_users"]["calls"] == 2
+        assert m["get_projects"]["calls"] == 1
+
+    def test_reset_metrics(self) -> None:
+        stub = _make_op_stub()
+        decorator = PerformanceMonitoringDecorator(stub)
+        decorator.get_users()
+        decorator.reset_metrics()
+        assert decorator.metrics == {}
+
+    def test_metrics_record_failed_calls(self) -> None:
+        stub = _make_op_stub(get_users=MagicMock(side_effect=RuntimeError("x")))
+        decorator = PerformanceMonitoringDecorator(stub)
+
+        with pytest.raises(RuntimeError):
+            decorator.get_users()
+
+        assert decorator.metrics["get_users"]["calls"] == 1
+
+
+class TestComposition:
+    def test_outer_decorator_runs_first(self) -> None:
+        stub = _make_op_stub()
+        order: list[str] = []
+
+        class _Tracer:
+            def __init__(self, wrapped: Any, label: str) -> None:
+                object.__setattr__(self, "_wrapped", wrapped)
+                object.__setattr__(self, "_label", label)
+
+            def __getattr__(self, name: str) -> Any:
+                attr = getattr(self._wrapped, name)
+                if not callable(attr):
+                    return attr
+
+                def proxy(*a: Any, **kw: Any) -> Any:
+                    order.append(self._label)
+                    return attr(*a, **kw)
+
+                return proxy
+
+        composed = _Tracer(_Tracer(stub, "inner"), "outer")
+        composed.get_users()
+
+        assert order == ["outer", "inner"]
+
+    def test_caching_under_monitoring(self) -> None:
+        stub = _make_op_stub()
+        cached = CachingDecorator(stub, cache_ttl=60)
+        monitored = PerformanceMonitoringDecorator(cached)
+
+        monitored.get_users()
+        monitored.get_users()
+
+        assert monitored.metrics["get_users"]["calls"] == 2
+        stub.get_users.assert_called_once()
+
+
+class TestEnhancedOpenProjectClientDeprecation:
+    """Legacy subclass should emit a DeprecationWarning on instantiation."""
+
+    def test_instantiation_emits_deprecation_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Stub the heavy base __init__ so we exercise only the warning path.
+        monkeypatch.setattr(OpenProjectClient, "__init__", lambda self, **_: None)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            EnhancedOpenProjectClient()
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecations, "Expected at least one DeprecationWarning"
+        assert any("decorators" in str(w.message) for w in deprecations)


### PR DESCRIPTION
## Summary

**The final ADR-002 PR.** Phase 8b — composed Decorators replacing the \`Enhanced*Client\` subclass pattern, per the ADR's pattern matrix:

> | **Decorator** | \`infrastructure/*/decorators.py\` (replaces \`Enhanced*Client\` subclasses) |

This closes [ADR-002](docs/adr/ADR-002-target-architecture.md): the 8-phase, ~10-week architectural decomposition is complete.

## What ships

**\`src/infrastructure/jira/decorators.py\`** (new, 357 LOC):
- \`CachingDecorator\` — TTL cache for read methods
- \`BatchOperationsDecorator\` — tunable batch sizes / parallelism
- \`StreamingDecorator\` — streaming-issue iterator wrapping
- \`PerformanceMonitoringDecorator\` — transparent metrics for every public callable
- \`JiraClientLike\` Protocol + \`_BaseJiraDecorator\` with \`__getattr__\` delegation

**\`src/infrastructure/openproject/decorators.py\`** (new, 297 LOC):
- \`CachingDecorator\`, \`ParallelReadsDecorator\`, \`FileBasedBatchWritesDecorator\`, \`PerformanceMonitoringDecorator\`
- \`OpenProjectClientLike\` Protocol
- \`RailsExecutionError\` for typed boundary failures

**Composition example:**
\`\`\`python
client = JiraClient(...)
client = CachingDecorator(client, cache_ttl=300)
client = BatchOperationsDecorator(client, batch_size=50)
client = PerformanceMonitoringDecorator(client)
\`\`\`

\`PerformanceMonitoringDecorator\` composing with \`CachingDecorator\` is tested: \`monitored.metrics[\"get_users\"][\"calls\"] == 2\` while the underlying stub sees exactly 1 call (cache hit).

## Deprecation strategy

\`Enhanced*Client\` subclasses are NOT deleted — they're the test surface for 30+ pre-existing-failing tests in \`tests/unit/test_enhanced_openproject_client.py\` (still deselected) and passing tests in \`tests/unit/test_enhanced_jira_client.py\`. Both classes now emit \`DeprecationWarning\` from \`__init__\`. A future PR can migrate the tests to the decorator API and delete the subclasses.

## Quality gates
- \`ruff check\`, \`ruff format --check\` — clean
- \`mypy src/\` — 0 issues across 154 files
- \`pytest tests/unit/\` — **1183 passed**, 30 deselected (1131 baseline + **52 new** decorator tests, 0 regressions)

## Hard constraints respected
- \`from __future__ import annotations\` on all new modules
- \`__getattr__\` delegation pattern via \`_BaseDecorator\` (uses \`object.__setattr__\`/\`object.__getattribute__\` to avoid recursion)
- \`typing.Protocol\` for the wrapped-client interface
- Existing \`Enhanced*Client\` classes preserved with \`DeprecationWarning\`

## ADR-002 closing summary

After 8 phases, ~50 PRs, and ~10 weeks of work:

| Phase | Theme | PRs |
|-------|-------|-----|
| 0+1   | ADRs + EntityCache + JsonStore + ChangeAwareRunner | 1+3 |
| 2     | God-clients split (10,194 → 2,434 LOC, −76%) | 12 |
| 3     | Domain models + branded IDs + 3 reference migrations | 3 |
| 4     | MappingRepository Protocol + JSON adapter | 2 |
| 5     | Layer reorganization (\`migrations/→application/components/\`, \`clients/→infrastructure/\`) | 2 |
| 6     | Inert config + bootstrap (TYPE_CHECKING blocks 80→9) | 2 |
| 7     | Typed pipeline rollout — 35/38 components addressed | 11 |
| 8     | Polish: discriminated-union results + composed decorators | 2 |

\`src/openproject_client.py\`: 7,342 → 1,624 LOC (−78%).
\`src/jira_client.py\`: 2,852 → 822 LOC (−71%).
30+ services extracted, 8+ Pydantic domain models, branded IDs, MappingRepository pattern, discriminated-union StepResult, composed Decorators, all under inert config with explicit bootstrap.

## Test plan
- [x] All quality gates green locally
- [x] +52 new tests (25 jira + 27 openproject)
- [ ] CI green