### PR TITLE
fix(post-merge): restore TYPE_CHECKING for type-only OpenProjectClient imports (#157 cleanup)

### DIFF
--- a/src/infrastructure/openproject/openproject_work_package_service.py
+++ b/src/infrastructure/openproject/openproject_work_package_service.py
@@ -50,10 +50,12 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Iterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from src.infrastructure.exceptions import QueryExecutionError
-from src.infrastructure.openproject.openproject_client import OpenProjectClient
+
+if TYPE_CHECKING:
+    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class OpenProjectWorkPackageService:

--- a/src/utils/custom_field_project_enablement.py
+++ b/src/utils/custom_field_project_enablement.py
@@ -15,7 +15,10 @@ Usage:
 
 from __future__ import annotations
 
-from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.infrastructure.openproject.openproject_client import OpenProjectClient
 
 
 class CustomFieldProjectTracker:


### PR DESCRIPTION
## Summary

Address two unresolved Copilot comments from #157 (Phase 6b TYPE_CHECKING cleanup) that were auto-merged before being properly resolved.

## Files changed

- \`src/utils/custom_field_project_enablement.py:18\` — \`OpenProjectClient\` is only used in a single annotation (\`op_client: OpenProjectClient\`); restored to \`TYPE_CHECKING\`.
- \`src/infrastructure/openproject/openproject_work_package_service.py:56\` — \`OpenProjectClient\` only used in the \`__init__\` annotation; restored to \`TYPE_CHECKING\`.

## Why

Phase 6b's TYPE_CHECKING cleanup over-aggressively promoted these to runtime imports. That pulls in the full \`openproject_client\` module (and its transitive imports like \`rails_console_client\`) just to satisfy the type checker. Restoring \`TYPE_CHECKING\` keeps the modules import-light and avoids unnecessary side-effect propagation.

The \"true circular import\" between \`OpenProjectClient\` and \`OpenProjectWorkPackageService\` (composition relationship — client instantiates the service) is the canonical TYPE_CHECKING use case that should never have been removed.

## Quality gates
- \`ruff check\` + \`mypy\` — clean
- \`pytest tests/unit/\` — 1183 passed, 30 deselected (no regression)

## Reference

Resolves Copilot comments [#3173786779](https://github.com/netresearch/jira-to-openproject/pull/157#discussion_r3173786779) and [#3173786819](https://github.com/netresearch/jira-to-openproject/pull/157#discussion_r3173786819) from PR #157.