### PR TITLE
fix(post-merge): repair 3 decorator bugs from PR #170 review

### DIFF
--- a/src/infrastructure/jira/decorators.py
+++ b/src/infrastructure/jira/decorators.py
@@ -125,11 +125,14 @@ class CachingDecorator(_BaseJiraDecorator):
         wrapped client exposes a ``get_project_details(key)`` shim
         (e.g., a fixture), we honour that first.
         """
-        per_key_lookup = getattr(
-            self._wrapped,
-            "get_project_details",
-            None,
-        ) or self._wrapped.get_project_metadata_enhanced
+        per_key_lookup = (
+            getattr(
+                self._wrapped,
+                "get_project_details",
+                None,
+            )
+            or self._wrapped.get_project_metadata_enhanced
+        )
         return self._cached_call(f"project:{key}", per_key_lookup, key)
 
     def get_statuses_cached(self) -> list[dict[str, Any]]:

--- a/src/infrastructure/jira/decorators.py
+++ b/src/infrastructure/jira/decorators.py
@@ -116,12 +116,21 @@ class CachingDecorator(_BaseJiraDecorator):
                 self._cache.pop(key, None)
 
     def get_project_cached(self, key: str) -> dict[str, Any]:
-        """Cache wrapper around ``get_project_details``-style lookups."""
-        return self._cached_call(
-            f"project:{key}",
-            getattr(self._wrapped, "get_project_details", self._wrapped.get_projects),
-            key,
-        )
+        """Cache wrapper around per-key project metadata lookups.
+
+        ``JiraClient.get_projects()`` takes no arguments (it lists every
+        project), so falling back to it with a ``key`` would raise
+        ``TypeError`` (PR #170 review). The real per-key endpoint on the
+        client is :meth:`JiraClient.get_project_metadata_enhanced`; if a
+        wrapped client exposes a ``get_project_details(key)`` shim
+        (e.g., a fixture), we honour that first.
+        """
+        per_key_lookup = getattr(
+            self._wrapped,
+            "get_project_details",
+            None,
+        ) or self._wrapped.get_project_metadata_enhanced
+        return self._cached_call(f"project:{key}", per_key_lookup, key)
 
     def get_statuses_cached(self) -> list[dict[str, Any]]:
         """Cache wrapper around ``get_all_statuses``."""

--- a/src/infrastructure/openproject/decorators.py
+++ b/src/infrastructure/openproject/decorators.py
@@ -155,13 +155,26 @@ class ParallelReadsDecorator(_BaseOPDecorator):
         return self._session  # type: ignore[return-value]
 
     def _get_work_package_safe(self, wp_id: int) -> dict[str, Any] | None:
-        session = self._get_session()
+        r"""Best-effort single work-package lookup via the wrapped Rails client.
+
+        ``OpenProjectClient`` in this codebase is a Rails-runner-over-SSH/docker
+        adapter — it has no HTTP base URL, so the historical
+        ``EnhancedOpenProjectClient`` placeholder using a relative
+        ``requests.Session.get("/api/v3/work_packages/...")`` could never run
+        outside its mock test fixture (PR #170 review). Route through the
+        wrapped client's ``execute_json_query`` instead, which is the documented
+        path for arbitrary single-record reads.
+        """
+        wrapped = self.wrapped
         try:
-            resp = session.get(f"/api/v3/work_packages/{wp_id}")
-            resp.raise_for_status()
-            return resp.json()
+            result = wrapped.execute_json_query(
+                f"WorkPackage.where(id: {int(wp_id)}).as_json.first"
+            )
         except Exception:
             return None
+        if isinstance(result, dict) and result:
+            return result
+        return None
 
     def bulk_get_work_packages(self, ids: Iterable[int]) -> dict[int, dict[str, Any] | None]:
         """Fetch many work packages in parallel; failed reads map to ``None``."""
@@ -187,31 +200,67 @@ class FileBasedBatchWritesDecorator(_BaseOPDecorator):
     """File-based Rails-runner batch writes for OpenProject.
 
     Wraps batch creates and updates by serializing the payload to a temp JSON
-    file, invoking ``rails runner <script> <path>``, parsing JSON from stdout,
-    and always cleaning up the temp file. Mirrors the existing
-    ``EnhancedOpenProjectClient`` flow.
+    file and routing it through the wrapped client's existing remote Rails
+    execution path (typically SSH+docker; ``OpenProjectClient`` runs Rails
+    inside a remote container, not on the local host). The temp file is
+    always cleaned up.
+
+    The wrapped client is expected to expose an ``execute_script_with_data``
+    method that takes ``(script_template, data_payload)`` — the same contract
+    ``OpenProjectClient`` already implements (see
+    :meth:`OpenProjectClient.execute_script_with_data`).
     """
 
     BATCH_CREATE_SCRIPT = "RunnerScripts::BatchCreateWorkPackages.run"
     BULK_UPDATE_SCRIPT = "RunnerScripts::BulkUpdateWorkPackages.run"
 
     def batch_create_work_packages(self, work_packages: list[dict[str, Any]]) -> dict[str, Any]:
-        """Bulk-create work packages via a temp JSON file + Rails runner."""
+        """Bulk-create work packages through the wrapped client's Rails path."""
         if not work_packages:
             return {"created": [], "errors": [], "stats": {"total": 0, "created": 0, "failed": 0}}
-        return self._run_rails_with_temp_file(work_packages, self.BATCH_CREATE_SCRIPT)
+        return self._run_rails_through_wrapped(work_packages, self.BATCH_CREATE_SCRIPT)
 
     def bulk_update_work_packages(self, updates: list[dict[str, Any]]) -> dict[str, Any]:
-        """Bulk-update work packages via a temp JSON file + Rails runner."""
+        """Bulk-update work packages through the wrapped client's Rails path."""
         if not updates:
             return {"updated": [], "errors": [], "stats": {"total": 0, "updated": 0, "failed": 0}}
-        return self._run_rails_with_temp_file(updates, self.BULK_UPDATE_SCRIPT)
+        return self._run_rails_through_wrapped(updates, self.BULK_UPDATE_SCRIPT)
 
-    def _run_rails_with_temp_file(self, payload: list[dict[str, Any]], script: str) -> dict[str, Any]:
+    def _run_rails_through_wrapped(
+        self,
+        payload: list[dict[str, Any]],
+        script: str,
+    ) -> dict[str, Any]:
+        """Delegate execution to the wrapped client's remote Rails path.
+
+        Falls back to a local-subprocess + temp-file invocation if the
+        wrapped client does not expose ``execute_script_with_data`` (e.g.,
+        a fixture that intentionally bypasses the SSH/docker plumbing).
+        The local fallback preserves test compatibility but is documented
+        as inappropriate for production — production deployments should
+        always wrap a real :class:`OpenProjectClient`.
+        """
+        wrapped = self.wrapped
+        execute_with_data = getattr(wrapped, "execute_script_with_data", None)
+        if callable(execute_with_data):
+            try:
+                result = execute_with_data(script, payload)
+            except Exception as exc:
+                msg = f"Rails script failed via wrapped client: {exc}"
+                raise RailsExecutionError(msg) from exc
+            if isinstance(result, dict):
+                return result
+            try:
+                return json.loads(result) if isinstance(result, str) else dict(result)
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                msg = f"Failed to coerce Rails output to dict: {exc}"
+                raise RailsExecutionError(msg) from exc
+
+        # Test-fixture fallback only — no remote execution available.
         temp_path: pathlib.Path | None = None
         try:
             temp_path = self._write_temp_json(payload)
-            return self._exec_rails(script, temp_path)
+            return self._exec_rails_local(script, temp_path)
         finally:
             if temp_path is not None and hasattr(temp_path, "unlink"):
                 try:
@@ -221,13 +270,20 @@ class FileBasedBatchWritesDecorator(_BaseOPDecorator):
 
     @staticmethod
     def _write_temp_json(payload: list[dict[str, Any]]) -> pathlib.Path:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as fh:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8") as fh:
             fh.write(json.dumps(payload))
             name = fh.name
         return pathlib.Path(name)
 
     @staticmethod
-    def _exec_rails(script: str, temp_file: pathlib.Path) -> dict[str, Any]:
+    def _exec_rails_local(script: str, temp_file: pathlib.Path) -> dict[str, Any]:
+        """Local-subprocess Rails invocation — test-fixture fallback only.
+
+        Production ``OpenProjectClient`` runs Rails on a remote SSH+docker
+        host; this path exists so test fixtures that wrap a Mock client
+        without ``execute_script_with_data`` still exercise the temp-file
+        cleanup logic. Real deployments should wrap a full client.
+        """
         cmd = ["rails", "runner", script, str(temp_file)]
         try:
             proc = subprocess.run(cmd, check=False, capture_output=True, text=True)

--- a/src/infrastructure/openproject/decorators.py
+++ b/src/infrastructure/openproject/decorators.py
@@ -27,8 +27,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock
 from typing import Any, Protocol, runtime_checkable
 
-import requests
-
 from src.display import configure_logging
 
 logger = configure_logging("INFO", None)
@@ -128,11 +126,20 @@ class CachingDecorator(_BaseOPDecorator):
 
 
 class ParallelReadsDecorator(_BaseOPDecorator):
-    """Parallel REST reads for bulk work-package fetches.
+    """Parallel single-work-package reads via the wrapped Rails client.
 
-    Mirrors :meth:`EnhancedOpenProjectClient.bulk_get_work_packages` using a
-    REST session against ``/api/v3/work_packages/<id>``. Failed lookups are
-    coerced to ``None`` to keep the result map dense.
+    Mirrors :meth:`EnhancedOpenProjectClient.bulk_get_work_packages` by
+    delegating each lookup to the wrapped client's ``execute_json_query``
+    — the documented Rails-based single-record read path. Failed lookups
+    are coerced to ``None`` to keep the result map dense.
+
+    Concurrency note: ``OpenProjectClient.execute_json_query`` is backed
+    by a single tmux-attached Rails console — concurrent calls would
+    interleave commands and break the JSON-output marker parsing. The
+    decorator therefore serialises ``execute_json_query`` invocations
+    behind a per-instance lock; useful parallelism comes from overlapping
+    network I/O and Rails console latency, not from the parsing path
+    (PR #172 review).
     """
 
     def __init__(self, wrapped: Any, parallel_workers: int | None = None) -> None:
@@ -142,34 +149,33 @@ class ParallelReadsDecorator(_BaseOPDecorator):
             "_parallel_workers",
             int(parallel_workers) if parallel_workers is not None else int(getattr(wrapped, "parallel_workers", 8)),
         )
-        object.__setattr__(self, "_session", None)
+        # Lock around the wrapped Rails console so threaded callers in
+        # ``bulk_get_work_packages`` don't interleave commands.
+        object.__setattr__(self, "_console_lock", Lock())
 
     @property
     def parallel_workers(self) -> int:
         """Configured worker count for parallel reads."""
         return self._parallel_workers
 
-    def _get_session(self) -> requests.Session:
-        if self._session is None:
-            object.__setattr__(self, "_session", requests.Session())
-        return self._session  # type: ignore[return-value]
-
     def _get_work_package_safe(self, wp_id: int) -> dict[str, Any] | None:
-        r"""Best-effort single work-package lookup via the wrapped Rails client.
+        """Best-effort single work-package lookup via the wrapped Rails client.
 
         ``OpenProjectClient`` in this codebase is a Rails-runner-over-SSH/docker
         adapter — it has no HTTP base URL, so the historical
         ``EnhancedOpenProjectClient`` placeholder using a relative
-        ``requests.Session.get("/api/v3/work_packages/...")`` could never run
-        outside its mock test fixture (PR #170 review). Route through the
-        wrapped client's ``execute_json_query`` instead, which is the documented
-        path for arbitrary single-record reads.
+        ``requests.Session.get`` could never run outside its mock test
+        fixture (PR #170 review). Routes through the wrapped client's
+        ``execute_json_query`` under a shared lock so concurrent threads
+        in :meth:`bulk_get_work_packages` don't interleave commands on
+        the underlying tmux console (PR #172 review).
         """
         wrapped = self.wrapped
         try:
-            result = wrapped.execute_json_query(
-                f"WorkPackage.where(id: {int(wp_id)}).as_json.first"
-            )
+            with self._console_lock:
+                result = wrapped.execute_json_query(
+                    f"WorkPackage.where(id: {int(wp_id)}).as_json.first",
+                )
         except Exception:
             return None
         if isinstance(result, dict) and result:
@@ -233,28 +239,32 @@ class FileBasedBatchWritesDecorator(_BaseOPDecorator):
     ) -> dict[str, Any]:
         """Delegate execution to the wrapped client's remote Rails path.
 
+        ``OpenProjectClient.execute_script_with_data`` (via the
+        :class:`OpenProjectRailsRunnerService`) returns an envelope of
+        the shape ``{status, message, data, output}`` rather than the
+        bare ``{created: …}`` payload our callers expect. Unwrap
+        ``data`` on success and raise :class:`RailsExecutionError` on
+        ``status != "success"`` so the decorator's
+        ``batch_create_work_packages`` / ``bulk_update_work_packages``
+        contract matches the legacy ``EnhancedOpenProjectClient``.
+
         Falls back to a local-subprocess + temp-file invocation if the
-        wrapped client does not expose ``execute_script_with_data`` (e.g.,
-        a fixture that intentionally bypasses the SSH/docker plumbing).
-        The local fallback preserves test compatibility but is documented
-        as inappropriate for production — production deployments should
-        always wrap a real :class:`OpenProjectClient`.
+        wrapped client does not expose ``execute_script_with_data``
+        (e.g., a fixture that intentionally bypasses the SSH/docker
+        plumbing). The local fallback preserves test compatibility but
+        is documented as inappropriate for production — production
+        deployments should always wrap a real
+        :class:`OpenProjectClient`.
         """
         wrapped = self.wrapped
         execute_with_data = getattr(wrapped, "execute_script_with_data", None)
         if callable(execute_with_data):
             try:
-                result = execute_with_data(script, payload)
+                envelope = execute_with_data(script, payload)
             except Exception as exc:
                 msg = f"Rails script failed via wrapped client: {exc}"
                 raise RailsExecutionError(msg) from exc
-            if isinstance(result, dict):
-                return result
-            try:
-                return json.loads(result) if isinstance(result, str) else dict(result)
-            except (TypeError, ValueError, json.JSONDecodeError) as exc:
-                msg = f"Failed to coerce Rails output to dict: {exc}"
-                raise RailsExecutionError(msg) from exc
+            return self._unwrap_envelope(envelope)
 
         # Test-fixture fallback only — no remote execution available.
         temp_path: pathlib.Path | None = None
@@ -267,6 +277,35 @@ class FileBasedBatchWritesDecorator(_BaseOPDecorator):
                     temp_path.unlink()
                 except Exception as exc:
                     logger.debug("Temp file cleanup failed: %s", exc)
+
+    @staticmethod
+    def _unwrap_envelope(envelope: Any) -> dict[str, Any]:
+        """Unwrap the ``{status, message, data, output}`` Rails-runner envelope.
+
+        :class:`OpenProjectRailsRunnerService.execute_script_with_data`
+        always returns this envelope (or a string fallback when the
+        runner could not parse JSON). Returns ``data`` as a dict on
+        success; raises :class:`RailsExecutionError` on ``status !=
+        "success"`` or on shape mismatches.
+        """
+        if not isinstance(envelope, dict):
+            msg = f"Expected dict envelope from execute_script_with_data, got {type(envelope).__name__}"
+            raise RailsExecutionError(msg)
+        status = envelope.get("status")
+        if status != "success":
+            message = envelope.get("message") or envelope.get("output") or "<no message>"
+            msg = f"Rails script returned status={status!r}: {message}"
+            raise RailsExecutionError(msg)
+        data = envelope.get("data")
+        if isinstance(data, dict):
+            return data
+        if isinstance(data, list):
+            # Some scripts return a list of per-record results; coerce to
+            # the documented dict-shape contract by aggregating into the
+            # ``created``/``failed`` buckets the decorator promises.
+            return {"created": data, "errors": [], "stats": {"total": len(data), "created": len(data), "failed": 0}}
+        msg = f"Expected dict in envelope['data'], got {type(data).__name__}"
+        raise RailsExecutionError(msg)
 
     @staticmethod
     def _write_temp_json(payload: list[dict[str, Any]]) -> pathlib.Path:

--- a/tests/unit/test_decorators_jira.py
+++ b/tests/unit/test_decorators_jira.py
@@ -112,6 +112,38 @@ class TestCachingDecorator:
         # `base_url` isn't a callable; CachingDecorator should hand back the raw attribute.
         assert decorator.base_url == "https://jira.example/"
 
+    def test_get_project_cached_uses_get_project_metadata_enhanced_fallback(self) -> None:
+        # Real ``JiraClient`` exposes per-key project metadata via
+        # ``get_project_metadata_enhanced``, NOT ``get_projects`` (which takes
+        # no args). The decorator must fall back to the per-key method when no
+        # ``get_project_details`` shim is available.
+        stub = _make_jira_stub(
+            get_project_metadata_enhanced=MagicMock(return_value={"key": "PROJ", "id": "10001"}),
+        )
+        # Strip the optional shim so we exercise the fallback path.
+        if hasattr(stub, "get_project_details"):
+            delattr(stub, "get_project_details")
+        decorator = CachingDecorator(stub)
+
+        first = decorator.get_project_cached("PROJ")
+        second = decorator.get_project_cached("PROJ")
+
+        assert first == second == {"key": "PROJ", "id": "10001"}
+        stub.get_project_metadata_enhanced.assert_called_once_with("PROJ")
+
+    def test_get_project_cached_prefers_get_project_details_shim(self) -> None:
+        stub = _make_jira_stub(
+            get_project_details=MagicMock(return_value={"key": "PROJ", "shim": True}),
+            get_project_metadata_enhanced=MagicMock(),
+        )
+        decorator = CachingDecorator(stub)
+
+        result = decorator.get_project_cached("PROJ")
+
+        assert result == {"key": "PROJ", "shim": True}
+        stub.get_project_details.assert_called_once_with("PROJ")
+        stub.get_project_metadata_enhanced.assert_not_called()
+
 
 class TestBatchOperationsDecorator:
     def test_batch_get_issues_aggregates_across_batches(self) -> None:

--- a/tests/unit/test_decorators_openproject.py
+++ b/tests/unit/test_decorators_openproject.py
@@ -273,8 +273,18 @@ class TestFileBasedBatchWritesDecorator:
     def test_uses_wrapped_execute_script_with_data_when_available(self) -> None:
         # Wrapped client exposes the remote-Rails entrypoint — the decorator
         # must delegate to it instead of falling through to local subprocess.
+        # The real OpenProjectRailsRunnerService.execute_script_with_data
+        # returns a {status, message, data, output} envelope; the decorator
+        # unwraps ``data`` on success.
         stub = _make_op_stub(
-            execute_script_with_data=MagicMock(return_value={"created": [42]}),
+            execute_script_with_data=MagicMock(
+                return_value={
+                    "status": "success",
+                    "message": "ok",
+                    "data": {"created": [42]},
+                    "output": "",
+                },
+            ),
         )
         decorator = FileBasedBatchWritesDecorator(stub)
 
@@ -287,6 +297,44 @@ class TestFileBasedBatchWritesDecorator:
             [{"subject": "x"}],
         )
         run_mock.assert_not_called()
+
+    def test_envelope_with_error_status_raises(self) -> None:
+        # status != "success" must surface as RailsExecutionError, not
+        # silently pass through as the legacy "{created: …}" shape.
+        stub = _make_op_stub(
+            execute_script_with_data=MagicMock(
+                return_value={
+                    "status": "error",
+                    "message": "Type 'invalid' not found",
+                    "data": None,
+                    "output": "",
+                },
+            ),
+        )
+        decorator = FileBasedBatchWritesDecorator(stub)
+
+        with pytest.raises(RailsExecutionError, match="status='error'"):
+            decorator.batch_create_work_packages([{"subject": "x"}])
+
+    def test_envelope_with_list_data_aggregates_to_dict(self) -> None:
+        # Some scripts return a list under data[]; the unwrapper must
+        # coerce to the dict-shape contract callers expect.
+        stub = _make_op_stub(
+            execute_script_with_data=MagicMock(
+                return_value={
+                    "status": "success",
+                    "message": "ok",
+                    "data": [{"id": 1}, {"id": 2}],
+                    "output": "",
+                },
+            ),
+        )
+        decorator = FileBasedBatchWritesDecorator(stub)
+
+        result = decorator.batch_create_work_packages([{"subject": "x"}])
+
+        assert result["created"] == [{"id": 1}, {"id": 2}]
+        assert result["stats"] == {"total": 2, "created": 2, "failed": 0}
 
 
 class TestPerformanceMonitoringDecorator:

--- a/tests/unit/test_decorators_openproject.py
+++ b/tests/unit/test_decorators_openproject.py
@@ -152,6 +152,31 @@ class TestParallelReadsDecorator:
 
         assert decorator._get_work_package_safe(42) is None
 
+    def test_safe_fetch_uses_wrapped_execute_json_query(self) -> None:
+        # ``OpenProjectClient`` is Rails-runner-based (no HTTP base url);
+        # ``_get_work_package_safe`` must route through the wrapped client's
+        # documented Rails query API rather than a relative-URL HTTP GET.
+        stub = _make_op_stub(
+            execute_json_query=MagicMock(return_value={"id": 42, "subject": "x"}),
+        )
+        decorator = ParallelReadsDecorator(stub)
+
+        result = decorator._get_work_package_safe(42)
+
+        assert result == {"id": 42, "subject": "x"}
+        stub.execute_json_query.assert_called_once()
+        # Sanity: the script targets the requested id.
+        script = stub.execute_json_query.call_args.args[0]
+        assert "WorkPackage" in script
+        assert "42" in script
+
+    def test_safe_fetch_returns_none_when_wrapped_query_fails(self) -> None:
+        stub = _make_op_stub(
+            execute_json_query=MagicMock(side_effect=RuntimeError("rails down")),
+        )
+        decorator = ParallelReadsDecorator(stub)
+        assert decorator._get_work_package_safe(42) is None
+
 
 class TestFileBasedBatchWritesDecorator:
     def test_batch_create_empty_input_short_circuits(self) -> None:
@@ -244,6 +269,24 @@ class TestFileBasedBatchWritesDecorator:
             decorator.batch_create_work_packages([{"subject": "x"}])
 
         fake_path.unlink.assert_called_once()
+
+    def test_uses_wrapped_execute_script_with_data_when_available(self) -> None:
+        # Wrapped client exposes the remote-Rails entrypoint — the decorator
+        # must delegate to it instead of falling through to local subprocess.
+        stub = _make_op_stub(
+            execute_script_with_data=MagicMock(return_value={"created": [42]}),
+        )
+        decorator = FileBasedBatchWritesDecorator(stub)
+
+        with patch("src.infrastructure.openproject.decorators.subprocess.run") as run_mock:
+            result = decorator.batch_create_work_packages([{"subject": "x"}])
+
+        assert result == {"created": [42]}
+        stub.execute_script_with_data.assert_called_once_with(
+            FileBasedBatchWritesDecorator.BATCH_CREATE_SCRIPT,
+            [{"subject": "x"}],
+        )
+        run_mock.assert_not_called()
 
 
 class TestPerformanceMonitoringDecorator:


### PR DESCRIPTION
## Summary

Address 3 unresolved Copilot comments from #170 (composed Decorators) — all flagged real bugs in code that only worked under mock-test fixtures.

## Bugs fixed

1. **\`ParallelReadsDecorator._get_work_package_safe\`** used \`requests.Session.get()\` with a relative URL (\`/api/v3/work_packages/...\`). \`OpenProjectClient\` is a Rails-runner-over-SSH/docker adapter and has no HTTP base URL, so this would raise \`MissingSchema\`/\`InvalidURL\` outside tests. Now routes through \`wrapped.execute_json_query()\` — the documented Rails-based single-record read path.

2. **\`FileBasedBatchWritesDecorator._exec_rails\`** ran \`rails runner ...\` via local \`subprocess.run\`. \`OpenProjectClient\` runs Rails inside a remote container — composing this decorator over a real client was guaranteed to fail in production. Now delegates to \`wrapped.execute_script_with_data\` when available (the documented \`OpenProjectClient\` remote-Rails entrypoint), with a clearly-marked local-subprocess fallback for test fixtures.

3. **\`JiraDecorator.get_project_cached\`** fell back to \`JiraClient.get_projects\` when \`get_project_details\` was missing — but \`get_projects()\` takes no arguments, so passing \`key\` would raise \`TypeError\`. Now falls back to \`get_project_metadata_enhanced\` (the actual per-key method).

## New tests

5 new tests pinning the corrected contracts:
- \`test_safe_fetch_uses_wrapped_execute_json_query\`
- \`test_safe_fetch_returns_none_when_wrapped_query_fails\`
- \`test_uses_wrapped_execute_script_with_data_when_available\`
- \`test_get_project_cached_uses_get_project_metadata_enhanced_fallback\`
- \`test_get_project_cached_prefers_get_project_details_shim\`

## Quality gates

- \`ruff check\`, \`ruff format --check\` — clean
- \`pytest tests/unit/\` — **1188 passed** (1183 baseline + 5 new), 30 deselected, 0 regressions

## References

Resolves Copilot comments [r3175458357](https://github.com/netresearch/jira-to-openproject/pull/170#discussion_r3175458357), [r3175458370](https://github.com/netresearch/jira-to-openproject/pull/170#discussion_r3175458370), and [r3175458379](https://github.com/netresearch/jira-to-openproject/pull/170#discussion_r3175458379) from PR #170.