### PR TITLE
fix(post-merge): work_package_content_migration cleanups (#164 review)

### DIFF
--- a/src/application/components/work_package_content_migration.py
+++ b/src/application/components/work_package_content_migration.py
@@ -53,6 +53,8 @@ import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from pydantic import ValidationError
+
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.infrastructure.jira.jira_client import JiraClient
@@ -147,7 +149,7 @@ class WorkPackageContentMigration(BaseMigration):
             return False
 
         try:
-            with self.work_package_mapping_file.open("r") as f:
+            with self.work_package_mapping_file.open("r", encoding="utf-8") as f:
                 self.work_package_mapping = json.load(f)
 
             # Build the canonical jira_key → openproject_id lookup by
@@ -563,7 +565,7 @@ class WorkPackageContentMigration(BaseMigration):
             return None
         try:
             user = JiraUser.from_dict(watcher) if isinstance(watcher, dict) else JiraUser.from_jira_obj(watcher)
-        except Exception:
+        except (ValidationError, TypeError, AttributeError):
             return None
         for probe in (
             user.account_id,
@@ -575,7 +577,7 @@ class WorkPackageContentMigration(BaseMigration):
             if not probe:
                 continue
             user_entry = self.user_mapping.get(probe)
-            if isinstance(user_entry, dict) and user_entry.get("openproject_id"):
+            if isinstance(user_entry, dict) and user_entry.get("openproject_id") is not None:
                 return int(user_entry["openproject_id"])
         return None
 

--- a/src/application/components/work_package_content_migration.py
+++ b/src/application/components/work_package_content_migration.py
@@ -565,7 +565,7 @@ class WorkPackageContentMigration(BaseMigration):
             return None
         try:
             user = JiraUser.from_dict(watcher) if isinstance(watcher, dict) else JiraUser.from_jira_obj(watcher)
-        except (ValidationError, TypeError, AttributeError):
+        except ValidationError, TypeError, AttributeError:
             return None
         for probe in (
             user.account_id,
@@ -584,7 +584,7 @@ class WorkPackageContentMigration(BaseMigration):
                 continue
             try:
                 return int(raw_id)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 continue
         return None
 

--- a/src/application/components/work_package_content_migration.py
+++ b/src/application/components/work_package_content_migration.py
@@ -577,8 +577,15 @@ class WorkPackageContentMigration(BaseMigration):
             if not probe:
                 continue
             user_entry = self.user_mapping.get(probe)
-            if isinstance(user_entry, dict) and user_entry.get("openproject_id") is not None:
-                return int(user_entry["openproject_id"])
+            if not isinstance(user_entry, dict):
+                continue
+            raw_id = user_entry.get("openproject_id")
+            if raw_id is None:
+                continue
+            try:
+                return int(raw_id)
+            except (TypeError, ValueError):
+                continue
         return None
 
     def _collect_content_for_issue(


### PR DESCRIPTION
## Summary

Address 3 unresolved Gemini comments from #164 (auto-merged before resolution).

- Explicit \`encoding=\"utf-8\"\` on the work-package-mapping JSON \`open(\"r\")\` (deterministic + non-ASCII safe).
- Narrowed bare \`except Exception\` on \`JiraUser\` parsing to \`(ValidationError, TypeError, AttributeError)\` — matches the pattern from PR #167 lessons; avoids masking unrelated programmer errors.
- \`user_entry.get(\"openproject_id\") is not None\` instead of bare truthy — explicit \`None\` check is safer for IDs.

## Quality gates
- \`ruff check\` clean
- \`pytest tests/unit/\` — 1183 passed, 30 deselected, 0 regressions

## References

Resolves Copilot comments [r3174880667](https://github.com/netresearch/jira-to-openproject/pull/164#discussion_r3174880667), [r3174880679](https://github.com/netresearch/jira-to-openproject/pull/164#discussion_r3174880679), [r3174880687](https://github.com/netresearch/jira-to-openproject/pull/164#discussion_r3174880687).