### PR TITLE
fix(post-merge): config bootstrap test isolation + 4 small concerns (#156 review)

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -35,7 +35,9 @@ if TYPE_CHECKING:
 
 # Import error recovery specific config
 # Re-export bootstrap so callers can do ``from src.config import bootstrap``.
-from ._bootstrap import bootstrap, is_bootstrapped, reset_bootstrap_state
+from ._bootstrap import bootstrap
+from ._bootstrap import is_bootstrapped as is_bootstrapped
+from ._bootstrap import reset_bootstrap_state as reset_bootstrap_state
 from .error_recovery_config import ErrorRecoveryConfig, load_error_recovery_config
 
 # Create a singleton instance of ConfigLoader
@@ -66,9 +68,11 @@ var_dirs: dict[DirType, Path] = {
     "temp": var_dir / "temp",
 }
 
-# Logging level used by ``bootstrap()`` to configure handlers. Read here
-# so the constant is available to callers that want to introspect it
-# without bootstrapping.
+# Import-time snapshot of the configured logging level. Exposed so
+# callers can introspect the default without bootstrapping; the actual
+# handler configuration in ``bootstrap()`` reads
+# ``migration_config["log_level"]`` directly so CLI/runtime overrides
+# applied between import and bootstrap are honored.
 LOG_LEVEL: LogLevel = migration_config.get("log_level", "DEBUG")  # type: ignore[assignment]
 
 
@@ -135,7 +139,13 @@ logging.Logger.notice = _notice  # type: ignore[attr-defined,assignment]
 logger: ExtendedLogger = cast("ExtendedLogger", logging.getLogger("migration"))
 
 
-# Export logger for use by other modules
+# ``__all__`` defines the public surface for ``from src.config import *``.
+# ``is_bootstrapped`` and ``reset_bootstrap_state`` are documented as
+# test-only helpers in :mod:`src.config._bootstrap`; we deliberately
+# keep them re-exported on the module (so tests can do
+# ``from src.config import reset_bootstrap_state``) but exclude them
+# from ``__all__`` to discourage production callers from depending on
+# test-only APIs.
 __all__ = [
     "FALLBACK_MAIL_DOMAIN",
     "LOG_LEVEL",
@@ -148,14 +158,12 @@ __all__ = [
     "get_mappings",
     "get_path",
     "get_value",
-    "is_bootstrapped",
     "jira_config",
     "load_error_recovery_config",
     "logger",
     "mappings",
     "migration_config",
     "openproject_config",
-    "reset_bootstrap_state",
     "reset_mappings",
     "update_from_cli_args",
     "validate_config",

--- a/src/config/_bootstrap.py
+++ b/src/config/_bootstrap.py
@@ -84,7 +84,7 @@ def _attach_per_run_log_handler(logger: ExtendedLogger) -> None:
         file_formatter = logging.Formatter(
             "%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s",
         )
-        file_handler = logging.FileHandler(per_run_log_file)
+        file_handler = logging.FileHandler(per_run_log_file, encoding="utf-8")
         file_handler.setFormatter(file_formatter)
         file_handler.setLevel(getattr(logging, str(log_level).upper(), logging.INFO))
         logging.getLogger().addHandler(file_handler)

--- a/src/config/_bootstrap.py
+++ b/src/config/_bootstrap.py
@@ -67,6 +67,24 @@ def _configure_logging_with_file_handler() -> ExtendedLogger:
     return configure_logging(log_level, latest_log_file)
 
 
+def _resolve_log_level(level: object) -> int:
+    """Resolve a log-level name (including the custom ``NOTICE``/``SUCCESS``) to its numeric value.
+
+    ``getattr(logging, name, INFO)`` does not know about levels registered
+    via :func:`logging.addLevelName` (such as our 21=``NOTICE`` and
+    25=``SUCCESS``) and silently falls back to ``INFO`` for them. That
+    would make the per-run log file less verbose than the console/aggregate
+    handler whenever a custom level is selected. We mirror the
+    name→number mapping used by :func:`src.display.configure_logging`.
+    """
+    name = str(level).upper()
+    if name == "NOTICE":
+        return 21
+    if name == "SUCCESS":
+        return 25
+    return getattr(logging, name, logging.INFO)
+
+
 def _attach_per_run_log_handler(logger: ExtendedLogger) -> None:
     """Attach a per-run timestamped log handler to the root logger.
 
@@ -86,7 +104,7 @@ def _attach_per_run_log_handler(logger: ExtendedLogger) -> None:
         )
         file_handler = logging.FileHandler(per_run_log_file, encoding="utf-8")
         file_handler.setFormatter(file_formatter)
-        file_handler.setLevel(getattr(logging, str(log_level).upper(), logging.INFO))
+        file_handler.setLevel(_resolve_log_level(log_level))
         logging.getLogger().addHandler(file_handler)
         logger.info("Per-run log file: %s", per_run_log_file)
     except OSError:

--- a/src/display.py
+++ b/src/display.py
@@ -158,7 +158,7 @@ def configure_logging(
         file_format = logging.Formatter(
             "%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s",
         )
-        file_handler = logging.FileHandler(log_file)
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
         file_handler.setFormatter(file_format)
         file_handler.setLevel(numeric_level)
         handlers.append(file_handler)

--- a/tests/unit/test_config_bootstrap.py
+++ b/tests/unit/test_config_bootstrap.py
@@ -60,7 +60,7 @@ def _reset_logging_guard() -> None:
     """
     display._LOGGING_CONFIGURED = False
     display._LOGGER = None
-    display._LOG_LEVEL_NUM = None  # type: ignore[attr-defined]
+    display._LOG_LEVEL_NUM = None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_config_bootstrap.py
+++ b/tests/unit/test_config_bootstrap.py
@@ -17,30 +17,83 @@ failure).
 
 from __future__ import annotations
 
+import importlib
 import logging
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
-from src import config
+from src import config, display
 from src.config import _bootstrap
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
+def _close_all_file_handlers() -> None:
+    """Detach and close every FileHandler on root and the ``migration`` logger.
+
+    Required between tests: each ``bootstrap()`` call attaches a handler
+    that targets a tmp_path FileHandler. Without active cleanup later
+    tests can inherit handlers pointing at previous tests' tmp paths,
+    making the suite order-dependent / flaky and accumulating per-run
+    handlers.
+    """
+    for logger in (logging.getLogger(), logging.getLogger("migration")):
+        for handler in list(logger.handlers):
+            if isinstance(handler, logging.FileHandler):
+                logger.removeHandler(handler)
+                try:
+                    handler.close()
+                except Exception:
+                    pass
+
+
+def _reset_logging_guard() -> None:
+    """Clear ``src.display``'s 'already configured' cache so reconfig works.
+
+    ``configure_logging`` short-circuits when ``_LOGGING_CONFIGURED`` is
+    set, so a test that mutated logging state needs to clear the guard
+    before the next ``bootstrap()`` reconfigures cleanly.
+    """
+    display._LOGGING_CONFIGURED = False
+    display._LOGGER = None
+    display._LOG_LEVEL_NUM = None  # type: ignore[attr-defined]
+
+
 @pytest.fixture(autouse=True)
 def _reset_bootstrap_state() -> Iterator[None]:
-    """Each test starts with a clean bootstrap flag.
+    """Each test starts and ends with a clean bootstrap + logging state.
 
     The flag is module-level state on ``src.config._bootstrap``, so
     without this fixture tests would leak state into each other and the
-    idempotency assertions would silently no-op.
+    idempotency assertions would silently no-op. The companion logging
+    cleanup ensures FileHandlers attached to tmp_path don't outlive the
+    test that created them.
     """
     _bootstrap.reset_bootstrap_state()
+    _close_all_file_handlers()
+    _reset_logging_guard()
     yield
     _bootstrap.reset_bootstrap_state()
+    _close_all_file_handlers()
+    _reset_logging_guard()
+
+
+def _redirect_all_var_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, Path]:
+    """Redirect every ``var_dirs`` key under ``tmp_path``.
+
+    Necessary because ``bootstrap()`` walks the full ``var_dirs`` dict
+    and ``mkdir(exist_ok=True)`` each entry — a partial redirection
+    leaks the un-redirected keys (``backups``, ``run``, ``snapshots``…)
+    into the real repo ``var/`` tree, polluting the working copy and
+    failing in read-only test environments.
+    """
+    redirected: dict[str, Path] = {name: tmp_path / name for name in config.var_dirs}
+    monkeypatch.setattr(config, "var_dirs", redirected)
+    return redirected
 
 
 def _file_handlers_on(logger_name: str) -> list[logging.FileHandler]:
@@ -76,14 +129,7 @@ def test_module_import_is_inert() -> None:
     """
     # Strip any handlers a previous test (or production startup) may
     # have left behind so we observe the true post-import state.
-    for handler in list(logging.getLogger().handlers):
-        if isinstance(handler, logging.FileHandler):
-            logging.getLogger().removeHandler(handler)
-            handler.close()
-    for handler in list(logging.getLogger("migration").handlers):
-        if isinstance(handler, logging.FileHandler):
-            logging.getLogger("migration").removeHandler(handler)
-            handler.close()
+    _close_all_file_handlers()
 
     # ``src.config`` has already been imported by the test runner; the
     # import itself didn't add file handlers. The attribute access is a
@@ -92,24 +138,44 @@ def test_module_import_is_inert() -> None:
     assert _file_handlers_on("migration") == []
 
 
+def test_fresh_module_reload_attaches_no_file_handlers() -> None:
+    """A *truly* fresh import of ``src.config`` is import-side-effect free.
+
+    The plain ``test_module_import_is_inert`` test runs against a
+    cached ``src.config`` module, so a regression that attaches handlers
+    only at import time can slip through if the test simply removes
+    handlers before asserting. This test re-imports ``src.config`` from
+    scratch via ``importlib.reload`` (after detaching all FileHandlers
+    and resetting the logging guard) and asserts the *reload itself*
+    adds no FileHandler.
+    """
+    _close_all_file_handlers()
+    _reset_logging_guard()
+    handlers_before = _file_handlers_on("migration")
+
+    importlib.reload(sys.modules["src.config"])
+
+    handlers_after = _file_handlers_on("migration")
+    assert handlers_after == handlers_before, (
+        "src.config reload must not attach any FileHandler; got new handlers: "
+        f"{set(handlers_after) - set(handlers_before)}"
+    )
+
+
 def test_bootstrap_attaches_file_handler(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """After ``bootstrap()``, the migration logger has a working FileHandler."""
-    # Redirect var/ paths so the test does not pollute the real tree.
-    log_dir = tmp_path / "logs"
-    redirected = {**config.var_dirs, "logs": log_dir, "data": tmp_path / "data"}
-    monkeypatch.setattr(config, "var_dirs", redirected)
+    redirected = _redirect_all_var_dirs(monkeypatch, tmp_path)
 
     config.bootstrap()
 
-    assert log_dir.exists(), "bootstrap() should create the logs directory"
+    assert redirected["logs"].exists(), "bootstrap() should create the logs directory"
     handlers = _file_handlers_on("migration")
     assert handlers, "bootstrap() should attach at least one FileHandler"
 
 
 def test_bootstrap_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Calling ``bootstrap()`` twice must not double-attach handlers."""
-    redirected = {**config.var_dirs, "logs": tmp_path / "logs", "data": tmp_path / "data"}
-    monkeypatch.setattr(config, "var_dirs", redirected)
+    _redirect_all_var_dirs(monkeypatch, tmp_path)
 
     config.bootstrap()
     handlers_after_first = list(logging.getLogger().handlers)
@@ -128,18 +194,17 @@ def test_bootstrap_skips_mkdir_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``bootstrap(mkdir=False)`` must not create directories."""
-    log_dir = tmp_path / "logs_should_not_exist"
-    data_dir = tmp_path / "data_should_not_exist"
-    redirected = {**config.var_dirs, "logs": log_dir, "data": data_dir}
-    monkeypatch.setattr(config, "var_dirs", redirected)
+    redirected = _redirect_all_var_dirs(monkeypatch, tmp_path)
 
     # Skip the file-handler step too: without the directory, attaching a
     # FileHandler would itself raise — we are testing the mkdir flag in
     # isolation.
     config.bootstrap(mkdir=False, configure_log=False, prune_logs=False)
 
-    assert not log_dir.exists()
-    assert not data_dir.exists()
+    # Every redirected dir must remain absent — the helper redirected
+    # *all* of var_dirs, so this assertion proves no key escaped.
+    for path in redirected.values():
+        assert not path.exists(), f"bootstrap(mkdir=False) created {path}"
     assert config.is_bootstrapped()
 
 
@@ -148,14 +213,10 @@ def test_bootstrap_skips_logging_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``bootstrap(configure_log=False)`` must not attach a FileHandler."""
-    redirected = {**config.var_dirs, "logs": tmp_path / "logs", "data": tmp_path / "data"}
-    monkeypatch.setattr(config, "var_dirs", redirected)
+    _redirect_all_var_dirs(monkeypatch, tmp_path)
 
     # Strip any pre-existing handlers so the assertion is meaningful.
-    for handler in list(logging.getLogger().handlers):
-        if isinstance(handler, logging.FileHandler):
-            logging.getLogger().removeHandler(handler)
-            handler.close()
+    _close_all_file_handlers()
 
     config.bootstrap(mkdir=True, configure_log=False, prune_logs=False)
 
@@ -183,8 +244,7 @@ def test_reset_bootstrap_state_allows_rerun(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``reset_bootstrap_state()`` re-arms ``bootstrap()`` for the next call."""
-    redirected = {**config.var_dirs, "logs": tmp_path / "logs", "data": tmp_path / "data"}
-    monkeypatch.setattr(config, "var_dirs", redirected)
+    _redirect_all_var_dirs(monkeypatch, tmp_path)
 
     config.bootstrap()
     assert config.is_bootstrapped()
@@ -193,5 +253,10 @@ def test_reset_bootstrap_state_allows_rerun(
     assert not config.is_bootstrapped()
 
     # Second bootstrap actually runs again because the flag was reset.
+    # Reset logging state too — the first bootstrap attached its
+    # handler to the now-doomed tmp_path, and configure_logging will
+    # short-circuit otherwise.
+    _close_all_file_handlers()
+    _reset_logging_guard()
     config.bootstrap()
     assert config.is_bootstrapped()


### PR DESCRIPTION
## Summary

Address 10 unresolved Copilot/Gemini comments from #156 (Phase 6a inert config + bootstrap) that auto-merged before they were resolved.

## Test isolation (5 partial-redirection sites collapsed into helpers)

- **\`_redirect_all_var_dirs()\` helper** redirects EVERY \`var_dirs\` key under \`tmp_path\`. Replaces 5 partial redirections that only covered \`logs\`/\`data\` and let \`bootstrap()\` \`mkdir\` the rest of \`var/\` (\`backups\`, \`run\`, \`snapshots\`, …) into the real repo tree, polluting the working copy and failing in read-only environments.
- **Autouse fixture** also runs \`_close_all_file_handlers()\` and \`_reset_logging_guard()\` on setup AND teardown. Without these, each \`bootstrap()\` attaches a tmp_path-targeted \`FileHandler\` that outlives the test that created it; later tests inherit handlers pointing at deleted paths, making the suite order-dependent / flaky and accumulating per-run handlers.
- **New \`test_fresh_module_reload_attaches_no_file_handlers\` test** uses \`importlib.reload\` to validate import-time inertness against an actually-fresh module. The existing \`test_module_import_is_inert\` ran against a cached \`src.config\`; a regression that attaches handlers only at import time could slip through if the test merely removed handlers before asserting.

## 4 small concerns

- **\`src/config/__init__.py:71\` LOG_LEVEL** comment now accurately describes it as an import-time snapshot — \`bootstrap()\` reads \`migration_config['log_level']\` directly so CLI/runtime overrides applied between import and bootstrap are honored.
- **\`src/config/__init__.py\`** removed \`reset_bootstrap_state\` and \`is_bootstrapped\` from \`__all__\` to discourage production callers from depending on test-only APIs. Names are still re-exported on the module (\`as\` alias to keep ruff happy) so tests can still \`from src.config import reset_bootstrap_state\`.
- **\`src/config/_bootstrap.py:87\` FileHandler** now opens with \`encoding='utf-8'\` for deterministic non-ASCII handling across operating systems.

## Quality gates

- \`ruff check\` clean
- \`pytest tests/unit/\` — **1184 passed** (+1 new fresh-reload test), 30 deselected, 0 regressions

## References

Resolves Copilot comments [r3173679028](https://github.com/netresearch/jira-to-openproject/pull/156#discussion_r3173679028), [r3173679075](https://github.com/netresearch/jira-to-openproject/pull/156#discussion_r3173679075), [r3173679086](https://github.com/netresearch/jira-to-openproject/pull/156#discussion_r3173679086), [r3173679098](https://github.com/netresearch/jira-to-openproject/pull/156#discussion_r3173679098), [r3173679111](https://github.com/netresearch/jira-to-openproject/pull/156#discussion_r3173679111), [r3173679127](https://github.com/netresearch/jira-to-openproject/pull/156#discussion_r3173679127), [r3173679141](https://github.com/netresearch/jira-to-openproject/pull/156#discussion_r3173679141), [r3173679164](https://github.com/netresearch/jira-to-openproject/pull/156#discussion_r3173679164), [r3173679180](https://github.com/netresearch/jira-to-openproject/pull/156#discussion_r3173679180), and Gemini [r3173682785](https://github.com/netresearch/jira-to-openproject/pull/156#discussion_r3173682785).