### PR TITLE
feat(audit): validate type/status/priority + journal/relation counts

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -1,0 +1,197 @@
+"""Unit tests for ``tools.audit_migrated_project._classify``.
+
+The classifier turns the Ruby-side metrics hash (returned by the OP
+Rails console) into the human-readable failures + warnings lists. This
+file pins the heuristic rules so future audit-tool changes don't
+silently weaken post-migration validation.
+
+Each test seeds the smallest realistic metrics dict required to trip
+(or not trip) one rule.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.audit_migrated_project import _classify
+
+
+def _baseline_metrics(**overrides: Any) -> dict[str, Any]:
+    """Return a healthy 100-WP baseline; tests override only the field they exercise."""
+    base: dict[str, Any] = {
+        "project_id": 1,
+        "project_identifier": "test",
+        "wp_total": 100,
+        "wp_with_subject": 100,
+        "wp_with_description": 100,
+        "wp_with_assignee": 80,
+        "wp_with_author": 100,
+        "wp_with_due_date": 0,
+        "wp_with_start_date": 0,
+        "wp_with_type": 100,
+        "wp_with_status": 100,
+        "wp_with_priority": 100,
+        "wp_created_in_last_24h": 0,
+        "wp_provenance_cfs": {
+            "J2O Origin Key": {"exists": True, "populated": 100},
+            "J2O Origin ID": {"exists": True, "populated": 100},
+            "J2O Origin System": {"exists": True, "populated": 100},
+            "J2O Origin URL": {"exists": True, "populated": 100},
+            "J2O Project Key": {"exists": True, "populated": 100},
+            "J2O Project ID": {"exists": True, "populated": 100},
+            "J2O First Migration Date": {"exists": True, "populated": 100},
+            "J2O Last Update Date": {"exists": True, "populated": 100},
+        },
+        "user_provenance_cfs": {
+            "J2O Origin System": True,
+            "J2O User ID": True,
+            "J2O User Key": True,
+            "J2O External URL": True,
+        },
+        "te_provenance_cfs": {
+            "J2O Origin Worklog Key": True,
+            "J2O Origin Issue ID": True,
+            "J2O Origin Issue Key": True,
+            "J2O Origin System": True,
+            "J2O First Migration Date": True,
+            "J2O Last Update Date": True,
+        },
+        "wp_journal_total": 100,
+        "wp_attachment_total": 0,
+        "wp_watcher_total": 50,
+        "te_total": 10,
+        "te_hours_sum": 12.5,
+        "te_distinct_hours_count": 5,
+        "te_min_hours": 0.25,
+        "te_max_hours": 4.0,
+        "relation_total": 30,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_baseline_metrics_pass() -> None:
+    """The healthy baseline must produce zero failures and zero warnings."""
+    failures, warnings = _classify(_baseline_metrics())
+    assert failures == []
+    assert warnings == []
+
+
+# --- Bug F: Type/Status/Priority NULL on WPs ----------------------------------
+
+
+def test_wps_missing_type_is_failure() -> None:
+    """A NULL ``type_id`` on any WP is a hard failure (mapping broke silently)."""
+    failures, _warnings = _classify(_baseline_metrics(wp_with_type=99))
+    assert any("type" in f.lower() for f in failures), failures
+
+
+def test_wps_missing_status_is_failure() -> None:
+    failures, _warnings = _classify(_baseline_metrics(wp_with_status=98))
+    assert any("status" in f.lower() for f in failures), failures
+
+
+def test_wps_missing_priority_is_failure() -> None:
+    failures, _warnings = _classify(_baseline_metrics(wp_with_priority=0))
+    assert any("priority" in f.lower() for f in failures), failures
+
+
+def test_missing_type_field_treated_as_zero() -> None:
+    """If the Ruby side hasn't been updated, missing key still produces a failure."""
+    metrics = _baseline_metrics()
+    del metrics["wp_with_type"]
+    failures, _warnings = _classify(metrics)
+    assert any("type" in f.lower() for f in failures), failures
+
+
+# --- Bug I: Journal count below WP count --------------------------------------
+
+
+def test_journal_count_below_wp_count_is_failure() -> None:
+    """Rails auto-creates a journal on every WP creation; <wp_total means broken."""
+    failures, _warnings = _classify(_baseline_metrics(wp_journal_total=50))
+    assert any("journal" in f.lower() for f in failures), failures
+
+
+def test_journal_count_equal_to_wp_count_passes() -> None:
+    failures, _warnings = _classify(_baseline_metrics(wp_journal_total=100))
+    assert not any("journal" in f.lower() for f in failures), failures
+
+
+def test_journal_count_above_wp_count_passes() -> None:
+    """Multiple journals per WP (edits, comments) is normal."""
+    failures, _warnings = _classify(_baseline_metrics(wp_journal_total=500))
+    assert not any("journal" in f.lower() for f in failures), failures
+
+
+def test_missing_journal_field_treated_as_zero() -> None:
+    """A missing ``wp_journal_total`` key must fail-loud (Ruby/Python skew guard).
+
+    Same contract as ``test_missing_type_field_treated_as_zero``: the
+    ``metrics.get(..., 0)`` default is intentional — if the audit hash
+    is missing a key we expect, treat it as zero so the rule fires
+    rather than silently passing.
+    """
+    metrics = _baseline_metrics()
+    del metrics["wp_journal_total"]
+    failures, _warnings = _classify(metrics)
+    assert any("journal" in f.lower() for f in failures), failures
+
+
+# --- Bug D2: Relation count zero heuristic (warning only) ---------------------
+
+
+def test_relation_zero_with_many_wps_warns() -> None:
+    """Big project + zero relations = suspicious but not fatal (small projects can be 0)."""
+    _failures, warnings = _classify(_baseline_metrics(relation_total=0))
+    assert any("relation" in w.lower() for w in warnings), warnings
+
+
+def test_relation_zero_with_few_wps_does_not_warn() -> None:
+    """Below threshold, zero relations is plausible."""
+    _failures, warnings = _classify(
+        _baseline_metrics(
+            wp_total=10,
+            wp_with_subject=10,
+            wp_with_description=10,
+            wp_with_assignee=10,
+            wp_with_author=10,
+            wp_with_type=10,
+            wp_with_status=10,
+            wp_with_priority=10,
+            wp_journal_total=10,
+            relation_total=0,
+            wp_provenance_cfs={k: {"exists": True, "populated": 10} for k in _baseline_metrics()["wp_provenance_cfs"]},
+        ),
+    )
+    assert not any("relation" in w.lower() for w in warnings), warnings
+
+
+# --- Watcher zero heuristic (warning only) ------------------------------------
+
+
+def test_watcher_zero_with_many_wps_warns() -> None:
+    _failures, warnings = _classify(_baseline_metrics(wp_watcher_total=0))
+    assert any("watcher" in w.lower() for w in warnings), warnings
+
+
+def test_watcher_present_does_not_warn() -> None:
+    _failures, warnings = _classify(_baseline_metrics(wp_watcher_total=5))
+    assert not any("watcher" in w.lower() for w in warnings), warnings
+
+
+# --- Pre-existing rules still hold (regression guard) -------------------------
+
+
+def test_error_short_circuit_still_works() -> None:
+    failures, warnings = _classify({"error": "OP project 'NRS' not found"})
+    assert failures == ["Audit aborted: OP project 'NRS' not found"]
+    assert warnings == []
+
+
+def test_zero_wps_short_circuits_before_new_checks() -> None:
+    """If wp_total=0, new heuristic checks must not run (no division, no false positives)."""
+    failures, _warnings = _classify(_baseline_metrics(wp_total=0))
+    # Single failure about no WPs; not a cascade of NULL-field complaints.
+    assert len(failures) == 1
+    assert "no work packages" in failures[0].lower()

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -43,6 +43,11 @@ _REQUIRED_USER_PROVENANCE_CFS: tuple[str, ...] = (
     "J2O External URL",
 )
 
+# A project of this size or larger should typically have at least
+# one relation and one watcher across its WPs; below this we don't
+# warn (small/inactive projects legitimately have zero).
+_HEURISTIC_SIZE_THRESHOLD = 50
+
 _REQUIRED_TE_PROVENANCE_CFS: tuple[str, ...] = (
     "J2O Origin Worklog Key",
     "J2O Origin Issue ID",
@@ -101,6 +106,9 @@ def _build_audit_script(jira_project_key: str) -> str:
     'wp_with_author' => wps.where.not(author_id: nil).count,
     'wp_with_due_date' => wps.where.not(due_date: nil).count,
     'wp_with_start_date' => wps.where.not(start_date: nil).count,
+    'wp_with_type' => wps.where.not(type_id: nil).count,
+    'wp_with_status' => wps.where.not(status_id: nil).count,
+    'wp_with_priority' => wps.where.not(priority_id: nil).count,
     'wp_created_in_last_24h' => wps.where("created_at > ?", Time.now - 86400).count,
     'wp_provenance_cfs' => wp_provenance,
     'user_provenance_cfs' => user_provenance,
@@ -113,7 +121,11 @@ def _build_audit_script(jira_project_key: str) -> str:
     'te_distinct_hours_count' => te.distinct.count(:hours),
     'te_min_hours' => (te.minimum(:hours) || 0).to_f,
     'te_max_hours' => (te.maximum(:hours) || 0).to_f,
-    'relation_total' => Relation.where(from_id: wp_ids).count + Relation.where(to_id: wp_ids).count,
+    # Single OR-query so a relation with both ends inside ``wp_ids``
+    # (the common intra-project case) is counted exactly once instead
+    # of twice. The downstream zero-threshold heuristic still works:
+    # zero stays zero, but non-zero numbers reflect reality.
+    'relation_total' => Relation.where('from_id IN (?) OR to_id IN (?)', wp_ids, wp_ids).count,
   }}
 end).call
 """
@@ -183,6 +195,46 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
             failures.append(
                 f"All {te_total} TimeEntries have hours = {metrics['te_min_hours']} — units"
                 " are not being preserved (Bug B indicator)"
+            )
+
+    # Type / Status / Priority — mapping integrity. Any WP with NULL on
+    # one of these is a silent mapping failure (the Jira→OP map for the
+    # corresponding domain didn't resolve and the WP got persisted
+    # anyway).
+    for label, key in (
+        ("type", "wp_with_type"),
+        ("status", "wp_with_status"),
+        ("priority", "wp_with_priority"),
+    ):
+        populated = int(metrics.get(key, 0))
+        if populated < wp_total:
+            failures.append(
+                f"WPs missing {label}_id: {wp_total - populated}/{wp_total}"
+                f" — {label} mapping likely failed for those issues",
+            )
+
+    # Journal count — Rails auto-emits a Journal on WP create/update.
+    # If wp_journal_total < wp_total, journaling is broken (or WPs were
+    # bulk-inserted in a way that bypassed the Journal hooks).
+    journal_total = int(metrics.get("wp_journal_total", 0))
+    if journal_total < wp_total:
+        failures.append(
+            f"Journal count {journal_total} < wp_total {wp_total} — every WP"
+            " creation should emit at least one Journal record",
+        )
+
+    # Relations / Watchers — size-gated heuristic warnings. A small
+    # project legitimately may have neither, but on a project of
+    # ``_HEURISTIC_SIZE_THRESHOLD`` WPs or more, zero is suspicious.
+    if wp_total >= _HEURISTIC_SIZE_THRESHOLD:
+        if int(metrics.get("relation_total", 0)) == 0:
+            warnings.append(
+                f"No relations found across {wp_total} WPs — relation"
+                " migration may have silently skipped (Bug D2 indicator)",
+            )
+        if int(metrics.get("wp_watcher_total", 0)) == 0:
+            warnings.append(
+                f"No watchers found across {wp_total} WPs — watcher migration may have silently skipped",
             )
 
     # Description coverage (warning only)


### PR DESCRIPTION
## Summary

Strengthens `tools/audit_migrated_project.py` (the post-migration audit tool added in #175). The tool already collected `wp_journal_total`, `wp_attachment_total`, `wp_watcher_total` and `relation_total` but never validated them — they were just passed through into the JSON output.

## What's new

**New failure rules** (any → exit 1):
- WPs with NULL `type_id` / `status_id` / `priority_id` — silent mapping failure (the Jira→OP map for the corresponding domain didn't resolve but the WP was persisted anyway).
- `wp_journal_total < wp_total` — Rails auto-emits a Journal on every WP create, so below `wp_total` means journaling is broken or WPs were bulk-inserted bypassing the Journal hooks.

**New warning rules** (size-gated, threshold = 50 WPs):
- Zero relations across the project — Bug D2 indicator (the relation migration may have silently skipped on a project that should have links).
- Zero watchers across the project.

**Bugfix** in the Ruby script:
- `Relation.where(from_id: wp_ids).count + Relation.where(to_id: wp_ids).count` double-counted intra-project relations. Replaced with one OR-query that counts each relation exactly once.

## Test plan

- [x] New `tests/unit/test_audit_migrated_project.py` — 15 tests pinning each rule (baseline-passes, each-failure, each-warning, size-gated short-circuit, error-key short-circuit).
- [x] Includes \"missing-Ruby-key treated as zero → fail loud\" contract tests for both the type and journal rules so a future Ruby/Python skew fails loud instead of quietly slipping through.
- [x] Local lint (\`ruff check\` + \`ruff format --check\`) clean on touched files.
- [x] Full unit suite (\`pytest tests/unit -n auto\`) — 1320 passed, 0 failures.
- [ ] Re-run the live audit on a migrated project (NRS or TEST) post-merge — the new rules will exercise on real metrics.

## Related

- Builds on #175 (post-migration data-quality bug fixes + spec + audit tool).
- Closes the \"D2 verification\" follow-up: a future migration with no relations on a >50-WP project will now warn loudly.