### PR TITLE
feat(audit): detect orphaned relations and watchers

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -180,6 +180,55 @@ def test_watcher_present_does_not_warn() -> None:
     assert not any("watcher" in w.lower() for w in warnings), warnings
 
 
+# --- Orphan referential integrity (relations / watchers) ---------------------
+# A "project relation" is one where either ``from_id`` OR ``to_id`` is in the
+# project's WP IDs. A relation is *orphaned* when the *other* endpoint
+# references a WP that no longer exists (typically because that WP was
+# deleted in another project without its relations cascading). Watchers are
+# orphaned when ``user_id`` references a deleted user.
+
+
+def test_orphaned_relations_from_is_failure() -> None:
+    """A non-zero ``orphaned_relations_from`` count must fail."""
+    failures, _warnings = _classify(_baseline_metrics(orphaned_relations_from=2))
+    assert any("orphan" in f.lower() and "relation" in f.lower() for f in failures), failures
+
+
+def test_orphaned_relations_to_is_failure() -> None:
+    failures, _warnings = _classify(_baseline_metrics(orphaned_relations_to=1))
+    assert any("orphan" in f.lower() and "relation" in f.lower() for f in failures), failures
+
+
+def test_orphaned_watchers_is_failure() -> None:
+    failures, _warnings = _classify(_baseline_metrics(orphaned_watchers=1))
+    assert any("orphan" in f.lower() and "watcher" in f.lower() for f in failures), failures
+
+
+def test_zero_orphans_passes() -> None:
+    """All orphan counts at zero produce no orphan-related failure."""
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            orphaned_relations_from=0,
+            orphaned_relations_to=0,
+            orphaned_watchers=0,
+        ),
+    )
+    assert not any("orphan" in f.lower() for f in failures), failures
+
+
+def test_missing_orphan_fields_treated_as_zero() -> None:
+    """Missing orphan keys must NOT fire as failures.
+
+    Unlike the type/journal contracts (where missing-key-as-zero is a
+    *failure*), an orphan count of zero is the *healthy* baseline. The
+    rule must therefore be silent when keys are absent — otherwise every
+    legacy audit run would suddenly fail on this branch.
+    """
+    metrics = _baseline_metrics()
+    failures, _warnings = _classify(metrics)
+    assert not any("orphan" in f.lower() for f in failures), failures
+
+
 # --- Pre-existing rules still hold (regression guard) -------------------------
 
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -96,6 +96,10 @@ def _build_audit_script(jira_project_key: str) -> str:
 
   te = TimeEntry.where(entity_type: 'WorkPackage', entity_id: wp_ids)
 
+  # Relations involving this project on either endpoint. Reused below
+  # for the total count and the two orphan-detection queries.
+  project_relations = Relation.where('from_id IN (?) OR to_id IN (?)', wp_ids, wp_ids)
+
   {{
     'project_id' => proj.id,
     'project_identifier' => proj.identifier,
@@ -125,7 +129,16 @@ def _build_audit_script(jira_project_key: str) -> str:
     # (the common intra-project case) is counted exactly once instead
     # of twice. The downstream zero-threshold heuristic still works:
     # zero stays zero, but non-zero numbers reflect reality.
-    'relation_total' => Relation.where('from_id IN (?) OR to_id IN (?)', wp_ids, wp_ids).count,
+    'relation_total' => project_relations.count,
+    # Orphan detection. A *project relation* with ``from_id NOT IN
+    # work_packages`` can only mean ``to_id IN wp_ids`` AND the from-end
+    # is a deleted WP elsewhere — i.e. the "from" endpoint is dangling.
+    # Symmetric for the to-end. Watcher orphans fire when a watching
+    # user has been deleted without cascade.
+    'orphaned_relations_from' => project_relations.where('from_id NOT IN (SELECT id FROM work_packages)').count,
+    'orphaned_relations_to' => project_relations.where('to_id NOT IN (SELECT id FROM work_packages)').count,
+    'orphaned_watchers' => Watcher.where(watchable_type: 'WorkPackage', watchable_id: wp_ids).
+      where('user_id NOT IN (SELECT id FROM users)').count,
   }}
 end).call
 """
@@ -236,6 +249,27 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
             warnings.append(
                 f"No watchers found across {wp_total} WPs — watcher migration may have silently skipped",
             )
+
+    # Orphan referential integrity. Unlike the type/journal contracts
+    # (where missing-key-as-zero is *also* a failure to flag a stale
+    # Ruby script), a missing orphan key must stay silent — zero is the
+    # healthy baseline and legacy audit runs without these keys would
+    # otherwise wrongly fail. Only fire when we get a positive count.
+    orphan_rel_from = int(metrics.get("orphaned_relations_from", 0))
+    orphan_rel_to = int(metrics.get("orphaned_relations_to", 0))
+    orphan_rel_total = orphan_rel_from + orphan_rel_to
+    if orphan_rel_total > 0:
+        failures.append(
+            f"{orphan_rel_total} orphaned relations"
+            f" (from-side dangling: {orphan_rel_from},"
+            f" to-side dangling: {orphan_rel_to})"
+            " — relations reference deleted WPs",
+        )
+    orphan_watchers = int(metrics.get("orphaned_watchers", 0))
+    if orphan_watchers > 0:
+        failures.append(
+            f"{orphan_watchers} orphaned watchers — user_id references a deleted user",
+        )
 
     # Description coverage (warning only)
     desc_pct = (metrics.get("wp_with_description", 0) / wp_total) * 100

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -130,15 +130,23 @@ def _build_audit_script(jira_project_key: str) -> str:
     # of twice. The downstream zero-threshold heuristic still works:
     # zero stays zero, but non-zero numbers reflect reality.
     'relation_total' => project_relations.count,
-    # Orphan detection. A *project relation* with ``from_id NOT IN
-    # work_packages`` can only mean ``to_id IN wp_ids`` AND the from-end
+    # Orphan detection. A *project relation* with ``from_id`` not in
+    # ``work_packages`` can only mean ``to_id IN wp_ids`` AND the from-end
     # is a deleted WP elsewhere — i.e. the "from" endpoint is dangling.
     # Symmetric for the to-end. Watcher orphans fire when a watching
     # user has been deleted without cascade.
-    'orphaned_relations_from' => project_relations.where('from_id NOT IN (SELECT id FROM work_packages)').count,
-    'orphaned_relations_to' => project_relations.where('to_id NOT IN (SELECT id FROM work_packages)').count,
+    #
+    # ``NOT EXISTS`` instead of ``NOT IN (SELECT ...)`` so a NULL in the
+    # subquery cannot collapse the entire predicate to ``UNKNOWN`` (the
+    # three-valued-logic trap). PKs are ``NOT NULL`` today so behavior
+    # is identical, but ``NOT EXISTS`` stays correct if that ever
+    # changes and is typically faster.
+    'orphaned_relations_from' => project_relations.
+      where('NOT EXISTS (SELECT 1 FROM work_packages wp WHERE wp.id = relations.from_id)').count,
+    'orphaned_relations_to' => project_relations.
+      where('NOT EXISTS (SELECT 1 FROM work_packages wp WHERE wp.id = relations.to_id)').count,
     'orphaned_watchers' => Watcher.where(watchable_type: 'WorkPackage', watchable_id: wp_ids).
-      where('user_id NOT IN (SELECT id FROM users)').count,
+      where('NOT EXISTS (SELECT 1 FROM users u WHERE u.id = watchers.user_id)').count,
   }}
 end).call
 """


### PR DESCRIPTION
## Summary

Builds on #176 to catch a silent class of post-migration data corruption: relations or watchers whose other endpoint references a row that no longer exists. These don't cause loud failures (Rails models still load), but they break reports, exports, and link-follow operations.

## What's new

**3 Ruby metrics** added via the reused ``project_relations`` AR scope:
- `orphaned_relations_from` — relations entering project WPs from a now-deleted WP elsewhere
- `orphaned_relations_to` — relations leaving project WPs to a now-deleted WP elsewhere
- `orphaned_watchers` — watchers on project WPs whose ``user_id`` references a deleted user

**Failure rules** in `_classify`:
- Any of the three > 0 → loud failure with from/to breakdown.

**Missing-key contract**: unlike type/journal (where missing-as-zero is a fail-loud signal for stale Ruby), missing orphan keys stay silent — zero is healthy and legacy audit runs would otherwise wrongly fail. Pinned by `test_missing_orphan_fields_treated_as_zero`.

## Test plan

- [x] 5 new unit tests in `tests/unit/test_audit_migrated_project.py` (20/20 passing)
- [x] Local lint + format clean
- [ ] CI sweep