### PR TITLE
feat(audit): validate WP provenance CF value formats

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -277,6 +277,22 @@ def test_wp_cf_format_multiple_violations_each_reported() -> None:
     assert any("J2O Origin URL" in f for f in failed_cfs)
 
 
+def test_wp_cf_format_null_count_does_not_crash() -> None:
+    """A ``None`` count for a CF must collapse to zero, not raise.
+
+    Defends against a Ruby schema change or partial-result blob where
+    the violation count comes back as JSON ``null``. ``int(None)`` would
+    crash ``_classify`` with ``TypeError`` and turn a data-quality
+    signal into a hard tool failure with no actionable message.
+    """
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            wp_cf_format_violations={"J2O Origin Key": None, "J2O Origin ID": 0},
+        ),
+    )
+    assert not any("format" in f.lower() for f in failures), failures
+
+
 def test_wp_cf_format_missing_field_treated_as_silent() -> None:
     """A missing ``wp_cf_format_violations`` key must NOT fail.
 

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -229,6 +229,66 @@ def test_missing_orphan_fields_treated_as_zero() -> None:
     assert not any("orphan" in f.lower() for f in failures), failures
 
 
+# --- WP CF value-format validation -------------------------------------------
+# Provenance CFs are populated by the migrator with specific shapes
+# (e.g. ``J2O Origin Key`` is always a Jira issue key like ``NRS-123``).
+# Existence + populated-count alone does not catch a regression that
+# silently corrupts the value (wrong format, truncation, missing
+# prefix). The Ruby side counts per-CF format violations; the
+# classifier fails on any non-zero violation count.
+
+
+def test_wp_cf_format_violation_is_failure() -> None:
+    """One violation in any tracked WP CF must fail with the CF name."""
+    failures, _warnings = _classify(
+        _baseline_metrics(wp_cf_format_violations={"J2O Origin Key": 3}),
+    )
+    assert any("format" in f.lower() and "J2O Origin Key" in f for f in failures), failures
+
+
+def test_wp_cf_format_zero_violations_passes() -> None:
+    """An all-zero violations dict must produce no failures."""
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            wp_cf_format_violations={
+                "J2O Origin Key": 0,
+                "J2O Origin ID": 0,
+                "J2O Origin URL": 0,
+            },
+        ),
+    )
+    assert not any("format" in f.lower() for f in failures), failures
+
+
+def test_wp_cf_format_multiple_violations_each_reported() -> None:
+    """Each violating CF gets its own line so operators can pinpoint the bad field."""
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            wp_cf_format_violations={
+                "J2O Origin Key": 2,
+                "J2O Origin URL": 1,
+                "J2O Project Key": 0,
+            },
+        ),
+    )
+    failed_cfs = [f for f in failures if "format" in f.lower()]
+    assert len(failed_cfs) == 2, failed_cfs
+    assert any("J2O Origin Key" in f for f in failed_cfs)
+    assert any("J2O Origin URL" in f for f in failed_cfs)
+
+
+def test_wp_cf_format_missing_field_treated_as_silent() -> None:
+    """A missing ``wp_cf_format_violations`` key must NOT fail.
+
+    Same contract as the orphan rule: a missing key means a legacy
+    audit run from before this branch. Zero is the healthy baseline;
+    silently skipping the check on absent metric is correct.
+    """
+    metrics = _baseline_metrics()
+    failures, _warnings = _classify(metrics)
+    assert not any("format" in f.lower() for f in failures), failures
+
+
 # --- Pre-existing rules still hold (regression guard) -------------------------
 
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -118,9 +118,12 @@ def _build_audit_script(jira_project_key: str) -> str:
   {{ {cf_format_pairs} }}.each do |cf_name, regex|
     cf = CustomField.find_by(type: 'WorkPackageCustomField', name: cf_name)
     next unless cf
+    # ``pluck.count {{ block }}`` streams the comparison instead of
+    # building an intermediate ``reject``-array — same semantics, no
+    # per-value allocation overhead on large projects.
     bad = CustomValue.where(custom_field_id: cf.id, customized_type: 'WorkPackage').
       where(customized_id: wp_ids).where.not(value: [nil, '']).
-      pluck(:value).reject {{ |v| v =~ regex }}.count
+      pluck(:value).count {{ |v| v !~ regex }}
     wp_cf_format_violations[cf_name] = bad
   end
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -300,9 +300,12 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     # WP CF format validation. The Ruby side counts populated values
     # that don't match the expected regex per CF. Missing key = legacy
     # audit run before this branch — silently skip (zero is healthy).
+    # ``int(count or 0)`` so a future Ruby schema that emits ``null``
+    # (or a partial-result blob with a missing CF) doesn't crash
+    # ``_classify`` with ``TypeError``; a ``None`` collapses to zero.
     wp_cf_violations = metrics.get("wp_cf_format_violations", {}) or {}
     for cf_name, count in wp_cf_violations.items():
-        if int(count) > 0:
+        if int(count or 0) > 0:
             failures.append(
                 f"{count} populated values of WP CF '{cf_name}' do not match the expected format",
             )

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -36,6 +36,25 @@ _REQUIRED_WP_PROVENANCE_CFS: tuple[str, ...] = (
     "J2O Last Update Date",
 )
 
+# Ruby regex literals for each WP provenance CF — the migrator
+# populates these with crisp formats and a regression that corrupts
+# the value (truncation, missing prefix, wrong type) is invisible to
+# the populated-count check. Patterns are kept conservative so a
+# legitimate edge case cannot silently fail; if a CF name is absent
+# from this map, the audit only checks population, not format.
+_WP_CF_FORMAT_REGEXES: tuple[tuple[str, str], ...] = (
+    ("J2O Origin Key", r"\A[A-Z][A-Z0-9_]+-\d+\z"),
+    ("J2O Origin ID", r"\A\d+\z"),
+    ("J2O Origin System", r"\AJira\z"),
+    # Forward slashes escaped so the Ruby ``/.../`` regex literal
+    # doesn't terminate at the protocol's ``://``.
+    ("J2O Origin URL", r"\Ahttps?:\/\/[^\s]+\/browse\/[A-Z][A-Z0-9_]+-\d+\z"),
+    ("J2O Project Key", r"\A[A-Z][A-Z0-9_]*\z"),
+    ("J2O Project ID", r"\A\d+\z"),
+    ("J2O First Migration Date", r"\A\d{4}-\d{2}-\d{2}\z"),
+    ("J2O Last Update Date", r"\A\d{4}-\d{2}-\d{2}\z"),
+)
+
 _REQUIRED_USER_PROVENANCE_CFS: tuple[str, ...] = (
     "J2O Origin System",
     "J2O User ID",
@@ -69,6 +88,10 @@ def _build_audit_script(jira_project_key: str) -> str:
     expected_wp_cfs = list(_REQUIRED_WP_PROVENANCE_CFS)
     expected_user_cfs = list(_REQUIRED_USER_PROVENANCE_CFS)
     expected_te_cfs = list(_REQUIRED_TE_PROVENANCE_CFS)
+    # Build the Ruby hash literal mapping CF name -> Regexp literal.
+    # Keep the regex sources verbatim — they're the same on both sides
+    # (Ruby and Python both accept ``\A``, ``\z``, character classes).
+    cf_format_pairs = ", ".join(f"{name!r} => /{pattern}/" for name, pattern in _WP_CF_FORMAT_REGEXES)
     return f"""
 (lambda do
   proj_key = {jira_project_key!r}.downcase
@@ -84,6 +107,21 @@ def _build_audit_script(jira_project_key: str) -> str:
     populated = cf ? CustomValue.where(custom_field_id: cf.id, customized_type: 'WorkPackage').
       where(customized_id: wp_ids).where.not(value: [nil, '']).count : 0
     wp_provenance[cf_name] = {{ 'exists' => !cf.nil?, 'populated' => populated }}
+  end
+
+  # Per-CF format-violation count. For each WP provenance CF that has
+  # a regex spec, count populated values that don't match. Pluck-then-
+  # filter (rather than DB-side regex) keeps the query DB-portable
+  # across Postgres/MySQL/SQLite and lets us reuse the same regex
+  # source on both sides.
+  wp_cf_format_violations = {{}}
+  {{ {cf_format_pairs} }}.each do |cf_name, regex|
+    cf = CustomField.find_by(type: 'WorkPackageCustomField', name: cf_name)
+    next unless cf
+    bad = CustomValue.where(custom_field_id: cf.id, customized_type: 'WorkPackage').
+      where(customized_id: wp_ids).where.not(value: [nil, '']).
+      pluck(:value).reject {{ |v| v =~ regex }}.count
+    wp_cf_format_violations[cf_name] = bad
   end
 
   user_provenance = {expected_user_cfs!r}.map {{ |n|
@@ -115,6 +153,7 @@ def _build_audit_script(jira_project_key: str) -> str:
     'wp_with_priority' => wps.where.not(priority_id: nil).count,
     'wp_created_in_last_24h' => wps.where("created_at > ?", Time.now - 86400).count,
     'wp_provenance_cfs' => wp_provenance,
+    'wp_cf_format_violations' => wp_cf_format_violations,
     'user_provenance_cfs' => user_provenance,
     'te_provenance_cfs' => te_provenance,
     'wp_journal_total' => Journal.where(journable_type: 'WorkPackage', journable_id: wp_ids).count,
@@ -256,6 +295,16 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
         if int(metrics.get("wp_watcher_total", 0)) == 0:
             warnings.append(
                 f"No watchers found across {wp_total} WPs — watcher migration may have silently skipped",
+            )
+
+    # WP CF format validation. The Ruby side counts populated values
+    # that don't match the expected regex per CF. Missing key = legacy
+    # audit run before this branch — silently skip (zero is healthy).
+    wp_cf_violations = metrics.get("wp_cf_format_violations", {}) or {}
+    for cf_name, count in wp_cf_violations.items():
+        if int(count) > 0:
+            failures.append(
+                f"{count} populated values of WP CF '{cf_name}' do not match the expected format",
             )
 
     # Orphan referential integrity. Unlike the type/journal contracts


### PR DESCRIPTION
## Summary

Builds on #176 / #177 to close the **CF value validation gap**: the audit currently checks `J2O *` provenance CFs are *populated*, but never that the values match the expected shape. A regression that silently corrupts CF values (truncation, missing prefix, wrong type) slips through unnoticed.

## What's new

Per-CF format-violation count, computed Ruby-side via `pluck(:value).count { |v| v !~ regex }` (streams the comparison, no per-value allocation; DB-portable):

| CF | Regex |
|---|---|
| `J2O Origin Key` | `\A[A-Z][A-Z0-9_]+-\d+\z` |
| `J2O Origin ID` | `\A\d+\z` |
| `J2O Origin System` | `\AJira\z` |
| `J2O Origin URL` | `/browse/<key>` URL (forward slashes escaped so the Ruby `/.../` literal doesn't terminate at `://`) |
| `J2O Project Key` | `\A[A-Z][A-Z0-9_]*\z` |
| `J2O Project ID` | `\A\d+\z` |
| `J2O First Migration Date` | `\A\d{4}-\d{2}-\d{2}\z` |
| `J2O Last Update Date` | `\A\d{4}-\d{2}-\d{2}\z` |

The classifier fails on any non-zero violation count and cites the CF name. ``int(count or 0)`` collapses a future ``null`` to zero so a partial-result blob doesn't crash with ``TypeError``.

## Out of scope (follow-up candidates)

User and TimeEntry CFs have looser value formats (account IDs, free-form names, URLs with arbitrary query params). Validating those needs more careful regex design — deliberately not bundled here.

## Test plan

- [x] 5 unit tests in `tests/unit/test_audit_migrated_project.py` (25/25 passing) — including the null-count regression guard
- [x] Local lint + format clean
- [x] Generated Ruby manually inspected; URL pattern's escaped `/` confirmed (else Ruby `/.../` literal would terminate prematurely on `://`)
- [x] CI sweep (all checks ✅ on each push)