### PR TITLE
feat(audit): verify J2O Origin Worklog Key populated on every TE

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -342,6 +342,21 @@ def test_te_worklog_key_missing_field_treated_as_zero() -> None:
     assert any("worklog" in f.lower() for f in failures), failures
 
 
+def test_te_worklog_key_null_value_does_not_crash() -> None:
+    """A ``None`` value (e.g. future Ruby branch emits ``nil``) must not raise.
+
+    Defends against a Ruby schema change where ``te_with_worklog_key``
+    comes back as JSON ``null``. ``int(None)`` would raise ``TypeError``
+    and turn a data-quality signal into a hard tool failure with no
+    actionable message — same contract as PR #178's CF-format rule.
+    """
+    failures, _warnings = _classify(
+        _baseline_metrics(te_total=5, te_with_worklog_key=None),
+    )
+    # None collapses to 0 → 0 < 5 → still fails loud, just doesn't crash.
+    assert any("worklog" in f.lower() for f in failures), failures
+
+
 # --- Pre-existing rules still hold (regression guard) -------------------------
 
 

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -60,6 +60,7 @@ def _baseline_metrics(**overrides: Any) -> dict[str, Any]:
         "wp_attachment_total": 0,
         "wp_watcher_total": 50,
         "te_total": 10,
+        "te_with_worklog_key": 10,
         "te_hours_sum": 12.5,
         "te_distinct_hours_count": 5,
         "te_min_hours": 0.25,
@@ -303,6 +304,42 @@ def test_wp_cf_format_missing_field_treated_as_silent() -> None:
     metrics = _baseline_metrics()
     failures, _warnings = _classify(metrics)
     assert not any("format" in f.lower() for f in failures), failures
+
+
+# --- TimeEntry Origin Worklog Key population --------------------------------
+# Per spec, ``J2O Origin Worklog Key`` MUST be populated on every migrated
+# TimeEntry — it's the dedup key on re-runs. Existence-of-the-CF alone is
+# not enough; missing values let duplicate worklogs slip through silently.
+
+
+def test_te_worklog_key_population_below_te_total_is_failure() -> None:
+    """A populated count below ``te_total`` must fail with a dedup hint."""
+    failures, _warnings = _classify(
+        _baseline_metrics(te_total=10, te_with_worklog_key=7),
+    )
+    assert any("worklog" in f.lower() and ("dedup" in f.lower() or "re-run" in f.lower()) for f in failures), failures
+
+
+def test_te_worklog_key_population_equals_te_total_passes() -> None:
+    """100% population is the healthy state."""
+    failures, _warnings = _classify(
+        _baseline_metrics(te_total=10, te_with_worklog_key=10),
+    )
+    assert not any("worklog" in f.lower() for f in failures), failures
+
+
+def test_te_worklog_key_zero_te_total_is_silent() -> None:
+    """If there are no TimeEntries to begin with, the rule must not fire."""
+    failures, _warnings = _classify(_baseline_metrics(te_total=0, te_with_worklog_key=0))
+    assert not any("worklog" in f.lower() for f in failures), failures
+
+
+def test_te_worklog_key_missing_field_treated_as_zero() -> None:
+    """Missing key fails loud (same contract as type/journal — Ruby/Python skew)."""
+    metrics = _baseline_metrics(te_total=5)
+    del metrics["te_with_worklog_key"]
+    failures, _warnings = _classify(metrics)
+    assert any("worklog" in f.lower() for f in failures), failures
 
 
 # --- Pre-existing rules still hold (regression guard) -------------------------

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -274,7 +274,10 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
         # TE. Below ``te_total`` means dedup on re-run will silently fail
         # for the unmarked entries (each rerun would create duplicates).
         # Missing key in metrics → 0 → fail loud (Ruby/Python skew guard).
-        te_with_wlk = int(metrics.get("te_with_worklog_key", 0))
+        # ``or 0`` so a future Ruby branch that emits ``null`` (rather
+        # than 0) doesn't crash ``_classify`` with ``TypeError`` —
+        # matches the contract pinned by PR #178.
+        te_with_wlk = int(metrics.get("te_with_worklog_key", 0) or 0)
         if te_with_wlk < te_total:
             failures.append(
                 f"TimeEntry 'J2O Origin Worklog Key' population:"

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -136,6 +136,16 @@ def _build_audit_script(jira_project_key: str) -> str:
   }}.to_h
 
   te = TimeEntry.where(entity_type: 'WorkPackage', entity_id: wp_ids)
+  te_ids = te.pluck(:id)
+
+  # Per-TE population of ``J2O Origin Worklog Key``. The spec mandates
+  # this CF on every migrated TimeEntry — it's the dedup key on re-run.
+  # Below ``te_total`` means duplicate worklogs would slip through on
+  # the next migration pass.
+  worklog_key_cf = CustomField.find_by(type: 'TimeEntryCustomField', name: 'J2O Origin Worklog Key')
+  te_with_worklog_key = worklog_key_cf ?
+    CustomValue.where(custom_field_id: worklog_key_cf.id, customized_type: 'TimeEntry').
+      where(customized_id: te_ids).where.not(value: [nil, '']).count : 0
 
   # Relations involving this project on either endpoint. Reused below
   # for the total count and the two orphan-detection queries.
@@ -163,6 +173,7 @@ def _build_audit_script(jira_project_key: str) -> str:
     'wp_attachment_total' => Attachment.where(container_type: 'WorkPackage', container_id: wp_ids).count,
     'wp_watcher_total' => Watcher.where(watchable_type: 'WorkPackage', watchable_id: wp_ids).count,
     'te_total' => te.count,
+    'te_with_worklog_key' => te_with_worklog_key,
     'te_hours_sum' => te.sum(:hours).to_f,
     'te_distinct_hours_count' => te.distinct.count(:hours),
     'te_min_hours' => (te.minimum(:hours) || 0).to_f,
@@ -258,6 +269,17 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
             failures.append(
                 f"All {te_total} TimeEntries have hours = {metrics['te_min_hours']} — units"
                 " are not being preserved (Bug B indicator)"
+            )
+        # ``J2O Origin Worklog Key`` MUST be populated on every migrated
+        # TE. Below ``te_total`` means dedup on re-run will silently fail
+        # for the unmarked entries (each rerun would create duplicates).
+        # Missing key in metrics → 0 → fail loud (Ruby/Python skew guard).
+        te_with_wlk = int(metrics.get("te_with_worklog_key", 0))
+        if te_with_wlk < te_total:
+            failures.append(
+                f"TimeEntry 'J2O Origin Worklog Key' population:"
+                f" {te_with_wlk}/{te_total} — dedup on re-run will silently"
+                " fail for entries missing the key",
             )
 
     # Type / Status / Priority — mapping integrity. Any WP with NULL on

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -136,16 +136,18 @@ def _build_audit_script(jira_project_key: str) -> str:
   }}.to_h
 
   te = TimeEntry.where(entity_type: 'WorkPackage', entity_id: wp_ids)
-  te_ids = te.pluck(:id)
 
   # Per-TE population of ``J2O Origin Worklog Key``. The spec mandates
   # this CF on every migrated TimeEntry — it's the dedup key on re-run.
   # Below ``te_total`` means duplicate worklogs would slip through on
-  # the next migration pass.
+  # the next migration pass. Passing ``te`` (an ``ActiveRecord::Relation``)
+  # straight into ``customized_id:`` generates a subquery instead of
+  # materializing every TE id in Ruby — keeps the query fast on large
+  # projects and avoids any DB parameter/packet limits.
   worklog_key_cf = CustomField.find_by(type: 'TimeEntryCustomField', name: 'J2O Origin Worklog Key')
   te_with_worklog_key = worklog_key_cf ?
     CustomValue.where(custom_field_id: worklog_key_cf.id, customized_type: 'TimeEntry').
-      where(customized_id: te_ids).where.not(value: [nil, '']).count : 0
+      where(customized_id: te.select(:id)).where.not(value: [nil, '']).count : 0
 
   # Relations involving this project on either endpoint. Reused below
   # for the total count and the two orphan-detection queries.


### PR DESCRIPTION
## Summary

The TimeEntry CF `J2O Origin Worklog Key` is the **dedup key on re-runs** — without it on every TE, a follow-up migration silently creates duplicate worklogs because `time_entry_migrator._extract_worklog_keys_from_op_entries` has nothing to match against.

The audit currently only verifies the CF *exists*, never that it's *populated* on each migrated TimeEntry. Closes that gap.

## What's new

- Ruby: `te_with_worklog_key` = count of `CustomValue` rows for this CF on project's TEs (filters out nil/empty values, only counts CF if it exists).
- Python: failure when `te_with_worklog_key < te_total`, citing the dedup consequence.
- Missing-key contract: collapses to 0 → fail loud (matching the type/journal Ruby/Python-skew guard, *not* the orphan/format silent-on-missing contract — because zero population is a real bug, not a baseline state).

## Why not also TE Issue ID / Issue Key / dates?

Per `MIGRATION_SPEC.md` line 47: all 6 TE provenance CFs must **exist** (existence check already in place). Per line 61: only `J2O Origin Worklog Key` must be **populated**. The migration intentionally only populates this one (see `openproject_time_entry_service.py:250`). Audit list and population scope therefore correctly match the spec.

## Test plan

- [x] 4 new unit tests in `tests/unit/test_audit_migrated_project.py` (29/29 passing)
- [x] Local lint + format clean
- [x] Generated Ruby manually inspected; ternary fall-through to \`: 0\` confirmed for the no-CF case
- [ ] CI sweep