### PR TITLE
chore(audit): null-coercion sweep for all numeric metric sites

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -342,6 +342,43 @@ def test_te_worklog_key_missing_field_treated_as_zero() -> None:
     assert any("worklog" in f.lower() for f in failures), failures
 
 
+def test_classify_does_not_crash_when_all_numeric_metrics_are_null() -> None:
+    """Every numeric metric site must coerce ``None`` to 0 instead of raising.
+
+    Defends against a future Ruby schema change emitting JSON ``null``
+    on any metric (a conditional branch that returns ``nil`` instead of
+    0, a partial-result blob, etc.). Without uniform ``or 0`` coercion,
+    Python ``int(None)`` and arithmetic-with-None crash ``_classify``
+    and turn a data-quality signal into a hard tool failure.
+
+    Smoke test: blanks every numeric site simultaneously and verifies
+    ``_classify`` returns normally. The actual outcome (lots of
+    failures, since 0 < wp_total triggers most rules) is the secondary
+    signal — the primary contract under test is "doesn't raise".
+    """
+    metrics = _baseline_metrics(
+        wp_with_author=None,
+        wp_with_subject=None,
+        wp_with_assignee=None,
+        wp_created_in_last_24h=None,
+        wp_with_type=None,
+        wp_with_status=None,
+        wp_with_priority=None,
+        wp_with_description=None,
+        wp_journal_total=None,
+        wp_watcher_total=None,
+        relation_total=None,
+        te_total=None,
+        te_with_worklog_key=None,
+        te_distinct_hours_count=None,
+        orphaned_relations_from=None,
+        orphaned_relations_to=None,
+        orphaned_watchers=None,
+    )
+    failures, _warnings = _classify(metrics)
+    assert isinstance(failures, list)
+
+
 def test_te_worklog_key_null_value_does_not_crash() -> None:
     """A ``None`` value (e.g. future Ruby branch emits ``nil``) must not raise.
 

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -342,6 +342,39 @@ def test_te_worklog_key_missing_field_treated_as_zero() -> None:
     assert any("worklog" in f.lower() for f in failures), failures
 
 
+def test_classify_does_not_crash_when_wp_total_is_null() -> None:
+    """``wp_total`` itself goes through the helper — None must not crash.
+
+    Sibling to the all-other-metrics-null smoke. Setting ``wp_total=None``
+    short-circuits via the ``wp_total == 0`` early-return, so this only
+    exercises the *first* helper call. Without it, a future regression
+    that removes ``_metric_int`` from the wp_total site would slip past
+    the other smoke (which keeps wp_total=100 to exercise downstream).
+    """
+    failures, _warnings = _classify(_baseline_metrics(wp_total=None))
+    assert isinstance(failures, list)
+    assert any("no work packages" in f.lower() for f in failures), failures
+
+
+def test_metric_int_preserves_zero_with_non_zero_default() -> None:
+    """``_metric_int(default=N)`` must return 0 when the value is 0, not N.
+
+    Pins the explicit ``is None`` branch in the helper. A naive
+    ``metrics.get(key, default) or default`` would return ``default``
+    on a legitimate 0 (because ``0 or N == N``), silently masking a
+    "zero is the actual count" signal whenever a caller passes a
+    non-zero default. All current callers use ``default=0``, but the
+    signature advertises non-zero defaults — this test makes sure the
+    body honors that.
+    """
+    from tools.audit_migrated_project import _metric_int
+
+    assert _metric_int({"k": 0}, "k", default=5) == 0
+    assert _metric_int({"k": None}, "k", default=5) == 5
+    assert _metric_int({}, "k", default=5) == 5
+    assert _metric_int({"k": 7}, "k", default=5) == 7
+
+
 def test_classify_does_not_crash_when_all_numeric_metrics_are_null() -> None:
     """Every numeric metric site must coerce ``None`` to 0 instead of raising.
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -216,10 +216,18 @@ def _metric_int(metrics: dict[str, Any], key: str, default: int = 0) -> int:
     ``nil`` / ``null`` (Python sees ``None``). Plain ``int(metrics.get(key, 0))``
     only handles the first — ``int(None)`` raises ``TypeError`` and
     turns a data-quality signal into a hard tool failure with no
-    actionable message. This helper handles both, so every numeric
-    rule below stays robust under Ruby/Python schema skew.
+    actionable message. This helper handles both.
+
+    Note the explicit ``is None`` check rather than the simpler
+    ``metrics.get(key, default) or default``: the latter would collapse
+    a legitimate ``0`` to ``default`` when ``default != 0`` (because
+    ``0 or 5 == 5``). All current callers pass ``default=0`` so the
+    distinction is dormant, but the contract advertised by the
+    signature must hold for any future caller that passes a non-zero
+    default.
     """
-    return int(metrics.get(key, default) or default)
+    value = metrics.get(key)
+    return default if value is None else int(value)
 
 
 def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
@@ -285,9 +293,14 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     te_total = _metric_int(metrics, "te_total")
     if te_total > 0:
         distinct = _metric_int(metrics, "te_distinct_hours_count")
-        if distinct == 1 and metrics.get("te_min_hours") == metrics.get("te_max_hours"):
+        te_min_hours = metrics.get("te_min_hours")
+        te_max_hours = metrics.get("te_max_hours")
+        # Explicit not-None guard: ``None == None`` is True in Python,
+        # which would otherwise let an all-keys-missing metrics dict fire
+        # the rule with a meaningless ``hours = None`` message.
+        if distinct == 1 and te_min_hours is not None and te_min_hours == te_max_hours:
             failures.append(
-                f"All {te_total} TimeEntries have hours = {metrics['te_min_hours']} — units"
+                f"All {te_total} TimeEntries have hours = {te_min_hours} — units"
                 " are not being preserved (Bug B indicator)"
             )
         # ``J2O Origin Worklog Key`` MUST be populated on every migrated

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -207,6 +207,21 @@ end).call
 """
 
 
+def _metric_int(metrics: dict[str, Any], key: str, default: int = 0) -> int:
+    """Read a numeric metric, coercing missing key OR JSON ``null`` to default.
+
+    The audit's Ruby script returns a JSON dict whose values become the
+    Python ``metrics`` dict here. A future Ruby schema can fail this
+    contract two ways: omit a key (Python sees missing) or emit
+    ``nil`` / ``null`` (Python sees ``None``). Plain ``int(metrics.get(key, 0))``
+    only handles the first — ``int(None)`` raises ``TypeError`` and
+    turns a data-quality signal into a hard tool failure with no
+    actionable message. This helper handles both, so every numeric
+    rule below stays robust under Ruby/Python schema skew.
+    """
+    return int(metrics.get(key, default) or default)
+
+
 def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     """Return (failures, warnings) per the migration spec."""
     failures: list[str] = []
@@ -221,31 +236,34 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
         failures.append(f"Audit aborted: {error_msg}")
         return failures, warnings
 
-    wp_total = int(metrics.get("wp_total", 0))
+    wp_total = _metric_int(metrics, "wp_total")
     if wp_total == 0:
         failures.append("No work packages found for project (migration likely never ran for it)")
         return failures, warnings
 
     # All WPs must have author + subject
-    if metrics.get("wp_with_author", 0) < wp_total:
-        failures.append(f"WPs missing author_id: {wp_total - metrics['wp_with_author']}/{wp_total}")
-    if metrics.get("wp_with_subject", 0) < wp_total:
-        failures.append(f"WPs missing subject: {wp_total - metrics['wp_with_subject']}/{wp_total}")
+    wp_with_author = _metric_int(metrics, "wp_with_author")
+    if wp_with_author < wp_total:
+        failures.append(f"WPs missing author_id: {wp_total - wp_with_author}/{wp_total}")
+    wp_with_subject = _metric_int(metrics, "wp_with_subject")
+    if wp_with_subject < wp_total:
+        failures.append(f"WPs missing subject: {wp_total - wp_with_subject}/{wp_total}")
 
     # Assignee — coverage signal (was the bug at <1% before fix)
-    assignee_pct = (metrics.get("wp_with_assignee", 0) / wp_total) * 100
+    wp_with_assignee = _metric_int(metrics, "wp_with_assignee")
+    assignee_pct = (wp_with_assignee / wp_total) * 100
     if assignee_pct < 5:
         failures.append(
-            f"Suspiciously low assignee coverage: {metrics['wp_with_assignee']}/{wp_total} = {assignee_pct:.1f}%"
-            " (Bug A indicator)"
+            f"Suspiciously low assignee coverage: {wp_with_assignee}/{wp_total} = {assignee_pct:.1f}% (Bug A indicator)"
         )
 
     # created_at preservation — if >50% of WPs were created in the last 24h,
     # update_columns isn't sticking (Bug E indicator)
-    created_recent_pct = (metrics.get("wp_created_in_last_24h", 0) / wp_total) * 100
+    wp_created_recent = _metric_int(metrics, "wp_created_in_last_24h")
+    created_recent_pct = (wp_created_recent / wp_total) * 100
     if created_recent_pct > 50:
         failures.append(
-            f"{metrics['wp_created_in_last_24h']}/{wp_total} ({created_recent_pct:.0f}%) WPs have"
+            f"{wp_created_recent}/{wp_total} ({created_recent_pct:.0f}%) WPs have"
             " created_at within last 24h — original Jira timestamps not preserved (Bug E indicator)"
         )
 
@@ -264,9 +282,9 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
         failures.append(f"TimeEntry provenance CFs missing: {missing_te_cfs} (Bug D indicator)")
 
     # Time entry hours — Bug B indicator
-    te_total = metrics.get("te_total", 0)
+    te_total = _metric_int(metrics, "te_total")
     if te_total > 0:
-        distinct = metrics.get("te_distinct_hours_count", 0)
+        distinct = _metric_int(metrics, "te_distinct_hours_count")
         if distinct == 1 and metrics.get("te_min_hours") == metrics.get("te_max_hours"):
             failures.append(
                 f"All {te_total} TimeEntries have hours = {metrics['te_min_hours']} — units"
@@ -276,10 +294,7 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
         # TE. Below ``te_total`` means dedup on re-run will silently fail
         # for the unmarked entries (each rerun would create duplicates).
         # Missing key in metrics → 0 → fail loud (Ruby/Python skew guard).
-        # ``or 0`` so a future Ruby branch that emits ``null`` (rather
-        # than 0) doesn't crash ``_classify`` with ``TypeError`` —
-        # matches the contract pinned by PR #178.
-        te_with_wlk = int(metrics.get("te_with_worklog_key", 0) or 0)
+        te_with_wlk = _metric_int(metrics, "te_with_worklog_key")
         if te_with_wlk < te_total:
             failures.append(
                 f"TimeEntry 'J2O Origin Worklog Key' population:"
@@ -296,7 +311,7 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
         ("status", "wp_with_status"),
         ("priority", "wp_with_priority"),
     ):
-        populated = int(metrics.get(key, 0))
+        populated = _metric_int(metrics, key)
         if populated < wp_total:
             failures.append(
                 f"WPs missing {label}_id: {wp_total - populated}/{wp_total}"
@@ -306,7 +321,7 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     # Journal count — Rails auto-emits a Journal on WP create/update.
     # If wp_journal_total < wp_total, journaling is broken (or WPs were
     # bulk-inserted in a way that bypassed the Journal hooks).
-    journal_total = int(metrics.get("wp_journal_total", 0))
+    journal_total = _metric_int(metrics, "wp_journal_total")
     if journal_total < wp_total:
         failures.append(
             f"Journal count {journal_total} < wp_total {wp_total} — every WP"
@@ -317,12 +332,12 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     # project legitimately may have neither, but on a project of
     # ``_HEURISTIC_SIZE_THRESHOLD`` WPs or more, zero is suspicious.
     if wp_total >= _HEURISTIC_SIZE_THRESHOLD:
-        if int(metrics.get("relation_total", 0)) == 0:
+        if _metric_int(metrics, "relation_total") == 0:
             warnings.append(
                 f"No relations found across {wp_total} WPs — relation"
                 " migration may have silently skipped (Bug D2 indicator)",
             )
-        if int(metrics.get("wp_watcher_total", 0)) == 0:
+        if _metric_int(metrics, "wp_watcher_total") == 0:
             warnings.append(
                 f"No watchers found across {wp_total} WPs — watcher migration may have silently skipped",
             )
@@ -345,8 +360,8 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     # Ruby script), a missing orphan key must stay silent — zero is the
     # healthy baseline and legacy audit runs without these keys would
     # otherwise wrongly fail. Only fire when we get a positive count.
-    orphan_rel_from = int(metrics.get("orphaned_relations_from", 0))
-    orphan_rel_to = int(metrics.get("orphaned_relations_to", 0))
+    orphan_rel_from = _metric_int(metrics, "orphaned_relations_from")
+    orphan_rel_to = _metric_int(metrics, "orphaned_relations_to")
     orphan_rel_total = orphan_rel_from + orphan_rel_to
     if orphan_rel_total > 0:
         failures.append(
@@ -355,14 +370,14 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
             f" to-side dangling: {orphan_rel_to})"
             " — relations reference deleted WPs",
         )
-    orphan_watchers = int(metrics.get("orphaned_watchers", 0))
+    orphan_watchers = _metric_int(metrics, "orphaned_watchers")
     if orphan_watchers > 0:
         failures.append(
             f"{orphan_watchers} orphaned watchers — user_id references a deleted user",
         )
 
     # Description coverage (warning only)
-    desc_pct = (metrics.get("wp_with_description", 0) / wp_total) * 100
+    desc_pct = (_metric_int(metrics, "wp_with_description") / wp_total) * 100
     if desc_pct < 50:
         warnings.append(f"Only {desc_pct:.0f}% of WPs have a description")
 


### PR DESCRIPTION
## Summary

Per the silent-failure review of #179: the existing `int(metrics.get(key, 0))` and `metrics.get(key, 0) / wp_total` sites in `_classify` carry the same latent `TypeError` vulnerability that #178 / #179 hardening fixed for the new rules. If a future Ruby schema change ever emits JSON `null` for one of those metrics, plain `int(None)` raises and `None / wp_total` raises — turning a data-quality signal into a hard tool failure with no actionable message.

## What's new

- New helper `_metric_int(metrics, key, default=0)` that coerces both **missing key** AND **`None` value** to the default.
- 14 numeric metric sites converted (the dict-typed metrics like provenance maps and CF violations already use `or {}` correctly).
- Tidies the read-then-format-error pattern: the helper-bound local now feeds both the comparison AND the failure message, avoiding the redundant `metrics['key']` re-access (which would `KeyError` on a missing key — silently impossible in healthy runs but a test footgun).

## Test plan

- [x] New `test_classify_does_not_crash_when_all_numeric_metrics_are_null` smoke test — blanks every numeric site simultaneously and asserts `_classify` returns normally. Pins the contract so any future site that forgets the helper fails CI.
- [x] All 31 existing tests still pass
- [x] Local lint + format clean
- [ ] CI sweep