### PR TITLE
feat(audit): validate J2O Origin Worklog Key value format

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -306,6 +306,49 @@ def test_wp_cf_format_missing_field_treated_as_silent() -> None:
     assert not any("format" in f.lower() for f in failures), failures
 
 
+# --- TE CF value-format validation ------------------------------------------
+# Parallel to the WP CF format check. The dedup-critical
+# ``J2O Origin Worklog Key`` is built from one of two formulas
+# (``<JIRA_KEY>:<id>`` or ``tempo:<id>``) — a regression that corrupts
+# the value silently breaks dedup on re-run.
+
+
+def test_te_cf_format_violation_is_failure() -> None:
+    """One violation must fail with the CF name and the dedup hint."""
+    failures, _warnings = _classify(
+        _baseline_metrics(te_cf_format_violations={"J2O Origin Worklog Key": 2}),
+    )
+    assert any("format" in f.lower() and "J2O Origin Worklog Key" in f and "dedup" in f.lower() for f in failures), (
+        failures
+    )
+
+
+def test_te_cf_format_zero_violations_passes() -> None:
+    failures, _warnings = _classify(
+        _baseline_metrics(te_cf_format_violations={"J2O Origin Worklog Key": 0}),
+    )
+    assert not any("format" in f.lower() and "TimeEntry" in f for f in failures), failures
+
+
+def test_te_cf_format_missing_field_treated_as_silent() -> None:
+    """Missing key = legacy audit run, must NOT fail (zero is healthy)."""
+    metrics = _baseline_metrics()
+    failures, _warnings = _classify(metrics)
+    assert not any("format" in f.lower() and "TimeEntry" in f for f in failures), failures
+
+
+def test_te_cf_format_null_count_does_not_crash() -> None:
+    """A ``None`` count for a CF must collapse to zero, not raise.
+
+    Same contract as ``test_wp_cf_format_null_count_does_not_crash`` —
+    defends against a Ruby schema change emitting JSON ``null``.
+    """
+    failures, _warnings = _classify(
+        _baseline_metrics(te_cf_format_violations={"J2O Origin Worklog Key": None}),
+    )
+    assert not any("format" in f.lower() and "TimeEntry" in f for f in failures), failures
+
+
 # --- TimeEntry Origin Worklog Key population --------------------------------
 # Per spec, ``J2O Origin Worklog Key`` MUST be populated on every migrated
 # TimeEntry — it's the dedup key on re-runs. Existence-of-the-CF alone is

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -76,6 +76,21 @@ _REQUIRED_TE_PROVENANCE_CFS: tuple[str, ...] = (
     "J2O Last Update Date",
 )
 
+# Regex specs for TimeEntry provenance CF *values*. Per the migrator
+# (``src/utils/time_entry_transformer.py``), the dedup-critical
+# ``J2O Origin Worklog Key`` is built from one of two unconditional
+# formulas:
+#
+#   - ``f"{issue_key}:{worklog_id}"``  for Jira worklogs
+#   - ``f"tempo:{tempo_id}"``          for Tempo worklogs
+#
+# A regression that corrupts either form breaks dedup on re-run
+# silently — the existing populated-count check (PR #179) cannot
+# detect a populated-but-malformed value.
+_TE_CF_FORMAT_REGEXES: tuple[tuple[str, str], ...] = (
+    ("J2O Origin Worklog Key", r"\A([A-Z][A-Z0-9_]+-\d+:\d+|tempo:\d+)\z"),
+)
+
 
 def _build_audit_script(jira_project_key: str) -> str:
     """Build the Ruby audit expression for a Jira project.
@@ -92,6 +107,7 @@ def _build_audit_script(jira_project_key: str) -> str:
     # Keep the regex sources verbatim — they're the same on both sides
     # (Ruby and Python both accept ``\A``, ``\z``, character classes).
     cf_format_pairs = ", ".join(f"{name!r} => /{pattern}/" for name, pattern in _WP_CF_FORMAT_REGEXES)
+    te_cf_format_pairs = ", ".join(f"{name!r} => /{pattern}/" for name, pattern in _TE_CF_FORMAT_REGEXES)
     return f"""
 (lambda do
   proj_key = {jira_project_key!r}.downcase
@@ -149,6 +165,22 @@ def _build_audit_script(jira_project_key: str) -> str:
     CustomValue.where(custom_field_id: worklog_key_cf.id, customized_type: 'TimeEntry').
       where(customized_id: te.select(:id)).where.not(value: [nil, '']).count : 0
 
+  # Per-CF format-violation count for TE provenance CFs. Same shape as
+  # the WP version above (pluck → ``count {{ block }}`` streams the
+  # comparison without an intermediate array). The dedup-critical
+  # ``J2O Origin Worklog Key`` is the only TE CF the migrator
+  # populates per-row; corrupting its format silently breaks
+  # idempotent re-runs.
+  te_cf_format_violations = {{}}
+  {{ {te_cf_format_pairs} }}.each do |cf_name, regex|
+    cf = CustomField.find_by(type: 'TimeEntryCustomField', name: cf_name)
+    next unless cf
+    bad = CustomValue.where(custom_field_id: cf.id, customized_type: 'TimeEntry').
+      where(customized_id: te.select(:id)).where.not(value: [nil, '']).
+      pluck(:value).count {{ |v| v !~ regex }}
+    te_cf_format_violations[cf_name] = bad
+  end
+
   # Relations involving this project on either endpoint. Reused below
   # for the total count and the two orphan-detection queries.
   project_relations = Relation.where('from_id IN (?) OR to_id IN (?)', wp_ids, wp_ids)
@@ -169,6 +201,7 @@ def _build_audit_script(jira_project_key: str) -> str:
     'wp_created_in_last_24h' => wps.where("created_at > ?", Time.now - 86400).count,
     'wp_provenance_cfs' => wp_provenance,
     'wp_cf_format_violations' => wp_cf_format_violations,
+    'te_cf_format_violations' => te_cf_format_violations,
     'user_provenance_cfs' => user_provenance,
     'te_provenance_cfs' => te_provenance,
     'wp_journal_total' => Journal.where(journable_type: 'WorkPackage', journable_id: wp_ids).count,
@@ -366,6 +399,17 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
         if int(count or 0) > 0:
             failures.append(
                 f"{count} populated values of WP CF '{cf_name}' do not match the expected format",
+            )
+
+    # TE CF format validation (parallel to WP). Same missing-key
+    # contract: silent on absent metric (legacy audit run); fails
+    # loud only when a populated value doesn't match its regex.
+    te_cf_violations = metrics.get("te_cf_format_violations", {}) or {}
+    for cf_name, count in te_cf_violations.items():
+        if int(count or 0) > 0:
+            failures.append(
+                f"{count} populated values of TimeEntry CF '{cf_name}' do not match the expected format"
+                " — dedup on re-run depends on this format",
             )
 
     # Orphan referential integrity. Unlike the type/journal contracts

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -87,6 +87,14 @@ _REQUIRED_TE_PROVENANCE_CFS: tuple[str, ...] = (
 # A regression that corrupts either form breaks dedup on re-run
 # silently — the existing populated-count check (PR #179) cannot
 # detect a populated-but-malformed value.
+#
+# Note on the ``tempo:\d+`` arm: Tempo Cloud worklog IDs are documented
+# integers and ``time_entry_transformer.py`` reads them as such. If a
+# future Tempo API version (or a custom extractor) emits non-numeric
+# IDs (UUIDs, strings), this audit would flag every Tempo row as a
+# format violation — fail-loud, not silent, but a hint to the future
+# maintainer that the ``\d+`` Tempo arm needs updating alongside the
+# transformer.
 _TE_CF_FORMAT_REGEXES: tuple[tuple[str, str], ...] = (
     ("J2O Origin Worklog Key", r"\A([A-Z][A-Z0-9_]+-\d+:\d+|tempo:\d+)\z"),
 )


### PR DESCRIPTION
## Summary

Closes the TE-side mirror of #178: PR #179 verified the dedup-critical `J2O Origin Worklog Key` is *populated* on every TE, but never that the value is *formatted correctly*. A regression that corrupts the value (truncation, missing prefix, wrong type) silently breaks dedup on re-run because `time_entry_migrator._extract_worklog_keys_from_op_entries` can no longer reconstruct match keys.

## What's new

`_TE_CF_FORMAT_REGEXES` with the conservative pattern matching both formulas the migrator uses:

| Format | Source | Example |
|---|---|---|
| `<JIRA_KEY>:<digits>` | Jira worklog (`time_entry_transformer.py:126`) | `NRS-123:10001` |
| `tempo:<digits>` | Tempo worklog (`time_entry_transformer.py:226-234`) | `tempo:888` |

Pattern: `\A([A-Z][A-Z0-9_]+-\d+:\d+|tempo:\d+)\z` (Ruby/Python identical, no escaped `/` needed).

A parallel Ruby `te_cf_format_violations` block uses the same `pluck.count { |v| v !~ regex }` streaming approach as the WP block (no per-value allocation, DB-portable). Classifier fails on any non-zero violation count and cites the dedup consequence.

## Missing-key contract

Same as the WP CF format rule: silent on absent metric (legacy audit run = healthy zero baseline), fail loud only when a positive non-matching count comes back.

## Test plan

- [x] 4 new unit tests in `tests/unit/test_audit_migrated_project.py` (37/37 passing)
- [x] Local lint + format clean
- [x] Generated Ruby manually inspected; both formats accept the regex unchanged
- [ ] CI sweep