### PR TITLE
feat(audit): validate User provenance CF value formats

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -349,6 +349,56 @@ def test_te_cf_format_null_count_does_not_crash() -> None:
     assert not any("format" in f.lower() and "TimeEntry" in f for f in failures), failures
 
 
+# --- User CF value-format validation -----------------------------------------
+# Parallel to WP/TE CF format checks. Scoped to the two User CFs whose
+# value formats are deterministic — ``J2O Origin System`` (always
+# ``Jira[ + variant]``) and ``J2O External URL``
+# (``ViewProfile.jspa`` link). User ID/Key are deliberately skipped
+# because their values are user-input-derived (display names, mixed-case
+# keys, non-ASCII), and any conservative pattern would false-positive.
+
+
+def test_user_cf_format_violation_is_failure() -> None:
+    failures, _warnings = _classify(
+        _baseline_metrics(user_cf_format_violations={"J2O Origin System": 3}),
+    )
+    assert any("format" in f.lower() and "User CF" in f and "J2O Origin System" in f for f in failures), failures
+
+
+def test_user_cf_format_zero_violations_passes() -> None:
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            user_cf_format_violations={"J2O Origin System": 0, "J2O External URL": 0},
+        ),
+    )
+    assert not any("format" in f.lower() and "User CF" in f for f in failures), failures
+
+
+def test_user_cf_format_multiple_violations_each_reported() -> None:
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            user_cf_format_violations={"J2O Origin System": 1, "J2O External URL": 2},
+        ),
+    )
+    failed_user_cfs = [f for f in failures if "User CF" in f and "format" in f.lower()]
+    assert len(failed_user_cfs) == 2, failed_user_cfs
+
+
+def test_user_cf_format_missing_field_treated_as_silent() -> None:
+    """Legacy audit-run contract: missing key is healthy (zero), not a failure."""
+    metrics = _baseline_metrics()
+    failures, _warnings = _classify(metrics)
+    assert not any("format" in f.lower() and "User CF" in f for f in failures), failures
+
+
+def test_user_cf_format_null_count_does_not_crash() -> None:
+    """``None`` count collapses to zero, not raise — Ruby schema-skew guard."""
+    failures, _warnings = _classify(
+        _baseline_metrics(user_cf_format_violations={"J2O Origin System": None}),
+    )
+    assert not any("format" in f.lower() and "User CF" in f for f in failures), failures
+
+
 # --- TimeEntry Origin Worklog Key population --------------------------------
 # Per spec, ``J2O Origin Worklog Key`` MUST be populated on every migrated
 # TimeEntry — it's the dedup key on re-runs. Existence-of-the-CF alone is

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -399,6 +399,51 @@ def test_user_cf_format_null_count_does_not_crash() -> None:
     assert not any("format" in f.lower() and "User CF" in f for f in failures), failures
 
 
+def test_user_origin_system_regex_rejects_typo_corruption() -> None:
+    """The ``Origin System`` regex must not pass typo-style corruption.
+
+    Pins the mandatory whitespace separator: ``"Jiraz"``,
+    ``"Jirabad"``, ``"Jira_corrupted"`` (no whitespace after ``Jira``)
+    must all be rejected. Without the whitespace anchor, the regex
+    would silently accept arbitrary suffixes attached to ``"Jira"``.
+    """
+    import re
+
+    from tools.audit_migrated_project import _USER_CF_FORMAT_REGEXES
+
+    pattern = dict(_USER_CF_FORMAT_REGEXES)["J2O Origin System"]
+    rx = re.compile(pattern)
+    for bad in ("Jiraz", "Jirabad", "Jira_corrupted", "JiraX"):
+        assert rx.match(bad) is None, f"regex accepted corrupted value {bad!r}"
+
+
+def test_user_origin_system_regex_accepts_operator_override_punctuation() -> None:
+    """The ``Origin System`` regex must accept operator-typed deployment labels.
+
+    ``user_migration._get_origin_system_label`` falls back to
+    ``config.jira_config["deployment"]`` — a free-form string that may
+    legitimately contain parens, slashes, and hyphens (e.g.
+    ``"Jira (Server)"``, ``"Jira Data-Center"``, ``"Jira Cloud/v9"``).
+    A regex that's too tight here would false-positive on real values.
+    """
+    import re
+
+    from tools.audit_migrated_project import _USER_CF_FORMAT_REGEXES
+
+    pattern = dict(_USER_CF_FORMAT_REGEXES)["J2O Origin System"]
+    rx = re.compile(pattern)
+    for good in (
+        "Jira",
+        "Jira Cloud",
+        "Jira Server v9.1",
+        "Jira (Server)",
+        "Jira Data-Center",
+        "Jira Cloud/v9",
+        "Jira Data Center 9.1.2",
+    ):
+        assert rx.match(good) is not None, f"regex rejected legit value {good!r}"
+
+
 # --- TimeEntry Origin Worklog Key population --------------------------------
 # Per spec, ``J2O Origin Worklog Key`` MUST be populated on every migrated
 # TimeEntry — it's the dedup key on re-runs. Existence-of-the-CF alone is

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -62,6 +62,29 @@ _REQUIRED_USER_PROVENANCE_CFS: tuple[str, ...] = (
     "J2O External URL",
 )
 
+# Regex specs for User provenance CF *values*. Per the migrator
+# (``src/application/components/user_migration.py``,
+# ``_build_user_origin_metadata`` and ``create_missing_users``):
+#
+#   - ``J2O Origin System``: ``"Jira"`` + optional deployment label
+#     ("Cloud", "Server", "Data Center") + optional version.
+#   - ``J2O External URL``: ``<base>/secure/ViewProfile.jspa?<param>=<val>``.
+#
+# ``J2O User ID`` and ``J2O User Key`` are *deliberately not* validated
+# here. Their values are user-input-derived (account IDs, usernames,
+# display names, emails) and the realistic shape varies wildly across
+# Jira deployments — any conservative pattern would false-positive on
+# legitimate edge cases (display names with spaces, mixed-case keys
+# from older Server installs, non-ASCII names). The audit checks they
+# *exist* via the population path; format validation is left to the
+# migration code's own normalization.
+_USER_CF_FORMAT_REGEXES: tuple[tuple[str, str], ...] = (
+    ("J2O Origin System", r"\AJira[\w\s.]*\z"),
+    # ``ViewProfile.jspa?<param>=<value>`` — forward slashes escaped so
+    # the Ruby ``/.../`` regex literal doesn't terminate at ``://``.
+    ("J2O External URL", r"\Ahttps?:\/\/[^\s]+\/secure\/ViewProfile\.jspa\?[^\s]*\z"),
+)
+
 # A project of this size or larger should typically have at least
 # one relation and one watcher across its WPs; below this we don't
 # warn (small/inactive projects legitimately have zero).
@@ -116,6 +139,7 @@ def _build_audit_script(jira_project_key: str) -> str:
     # (Ruby and Python both accept ``\A``, ``\z``, character classes).
     cf_format_pairs = ", ".join(f"{name!r} => /{pattern}/" for name, pattern in _WP_CF_FORMAT_REGEXES)
     te_cf_format_pairs = ", ".join(f"{name!r} => /{pattern}/" for name, pattern in _TE_CF_FORMAT_REGEXES)
+    user_cf_format_pairs = ", ".join(f"{name!r} => /{pattern}/" for name, pattern in _USER_CF_FORMAT_REGEXES)
     return f"""
 (lambda do
   proj_key = {jira_project_key!r}.downcase
@@ -154,6 +178,21 @@ def _build_audit_script(jira_project_key: str) -> str:
   user_provenance = {expected_user_cfs!r}.map {{ |n|
     [n, !CustomField.find_by(type: 'UserCustomField', name: n).nil?]
   }}.to_h
+
+  # Per-CF format-violation count for User provenance CFs. Same shape
+  # as the WP/TE versions (``pluck.count {{ block }}`` streams the
+  # comparison without an intermediate array). Scoped to *all*
+  # populated values across ALL users — User CFs are global and the
+  # audit project doesn't restrict the user set.
+  user_cf_format_violations = {{}}
+  {{ {user_cf_format_pairs} }}.each do |cf_name, regex|
+    cf = CustomField.find_by(type: 'UserCustomField', name: cf_name)
+    next unless cf
+    bad = CustomValue.where(custom_field_id: cf.id, customized_type: 'User').
+      where.not(value: [nil, '']).
+      pluck(:value).count {{ |v| v !~ regex }}
+    user_cf_format_violations[cf_name] = bad
+  end
 
   te_provenance = {expected_te_cfs!r}.map {{ |n|
     [n, !CustomField.find_by(type: 'TimeEntryCustomField', name: n).nil?]
@@ -210,6 +249,7 @@ def _build_audit_script(jira_project_key: str) -> str:
     'wp_provenance_cfs' => wp_provenance,
     'wp_cf_format_violations' => wp_cf_format_violations,
     'te_cf_format_violations' => te_cf_format_violations,
+    'user_cf_format_violations' => user_cf_format_violations,
     'user_provenance_cfs' => user_provenance,
     'te_provenance_cfs' => te_provenance,
     'wp_journal_total' => Journal.where(journable_type: 'WorkPackage', journable_id: wp_ids).count,
@@ -418,6 +458,17 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
             failures.append(
                 f"{count} populated values of TimeEntry CF '{cf_name}' do not match the expected format"
                 " — dedup on re-run depends on this format",
+            )
+
+    # User CF format validation (parallel to WP/TE). Scoped only to the
+    # two CFs whose value formats are deterministic — user IDs and
+    # keys are intentionally not validated (see _USER_CF_FORMAT_REGEXES
+    # docstring).
+    user_cf_violations = metrics.get("user_cf_format_violations", {}) or {}
+    for cf_name, count in user_cf_violations.items():
+        if int(count or 0) > 0:
+            failures.append(
+                f"{count} populated values of User CF '{cf_name}' do not match the expected format",
             )
 
     # Orphan referential integrity. Unlike the type/journal contracts

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -79,7 +79,16 @@ _REQUIRED_USER_PROVENANCE_CFS: tuple[str, ...] = (
 # *exist* via the population path; format validation is left to the
 # migration code's own normalization.
 _USER_CF_FORMAT_REGEXES: tuple[tuple[str, str], ...] = (
-    ("J2O Origin System", r"\AJira[\w\s.]*\z"),
+    # ``Jira`` followed optionally by a whitespace separator and a
+    # mix of label/version/punctuation chars. The mandatory whitespace
+    # after ``Jira`` (when the optional group is present) blocks
+    # typo-style corruptions like ``"Jiraz"`` from passing as valid.
+    # The expanded charset (``()-/``) accepts operator-overridden
+    # deployment labels — ``user_migration._get_origin_system_label``
+    # falls back to ``config.jira_config["deployment"]`` which is a
+    # free-form string that may contain parens, slashes, or hyphens
+    # (e.g. ``"Jira (Server)"``, ``"Jira Data-Center"``).
+    ("J2O Origin System", r"\AJira(?:\s[\w\s.()\-/]*)?\z"),
     # ``ViewProfile.jspa?<param>=<value>`` — forward slashes escaped so
     # the Ruby ``/.../`` regex literal doesn't terminate at ``://``.
     ("J2O External URL", r"\Ahttps?:\/\/[^\s]+\/secure\/ViewProfile\.jspa\?[^\s]*\z"),


### PR DESCRIPTION
## Summary

Closes the User-side leg of the format-validation trio (WP via #178, TE via #181, User here). Two of the four User CFs have deterministic value shapes; the other two are intentionally skipped.

## What's validated

| CF | Regex |
|---|---|
| \`J2O Origin System\` | \`\AJira[\w\s.]*\z\` (matches "Jira", "Jira Cloud", "Jira Server v8.10", "Jira Data Center 9.1") |
| \`J2O External URL\` | \`\Ahttps?:\/\/[^\s]+\/secure\/ViewProfile\.jspa\?[^\s]*\z\` |

## Why not also User ID / User Key?

Their values are user-input-derived: account IDs, usernames, display names with spaces, emails, mixed-case keys from older Server installs, non-ASCII names. **Any conservative regex would false-positive on legitimate edge cases.** The audit already verifies these CFs *exist* via the population path; format validation is left to the migration code's own normalization.

## Test plan

- [x] 5 new unit tests (\`test_user_cf_format_*\`) covering: violation fails, zero passes, multi-violations report each, missing-key silent, null-count doesn't crash
- [x] 42/42 unit tests passing
- [x] Local lint + format clean
- [x] Generated Ruby manually inspected
- [ ] CI sweep