### PR TITLE
feat(audit): compare OP issue count against Jira source

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -565,6 +565,53 @@ def test_te_worklog_key_null_value_does_not_crash() -> None:
     assert any("worklog" in f.lower() for f in failures), failures
 
 
+# --- Jira source comparison: issue count ------------------------------------
+# Without comparing to the Jira source, the audit can verify OP-side
+# consistency but not "did everything actually migrate". A wholesale
+# data loss (1000 Jira issues → 800 OP WPs) would currently pass every
+# OP-side rule. This adds the first source-side check: exact issue count
+# match (per spec: issues should be exact).
+
+
+def test_jira_issue_count_match_passes() -> None:
+    """``jira_issue_count == wp_total`` is the healthy state."""
+    failures, _warnings = _classify(_baseline_metrics(jira_issue_count=100))
+    assert not any("jira" in f.lower() for f in failures), failures
+
+
+def test_jira_issue_count_mismatch_is_failure() -> None:
+    """Any delta between Jira and OP issue counts is a hard failure."""
+    failures, _warnings = _classify(_baseline_metrics(jira_issue_count=120))
+    assert any("jira" in f.lower() and "100" in f and "120" in f for f in failures), failures
+
+
+def test_jira_issue_count_lower_than_wp_total_is_failure() -> None:
+    """Reverse direction (OP > Jira) also fails — both indicate inconsistency."""
+    failures, _warnings = _classify(_baseline_metrics(jira_issue_count=80))
+    assert any("jira" in f.lower() for f in failures), failures
+
+
+def test_jira_issue_count_none_warns_source_unavailable() -> None:
+    """If Jira couldn't be reached, emit a warning, not a failure.
+
+    Audit shouldn't fail closed on Jira-side issues — operators may
+    legitimately run the audit without Jira creds. ``None`` is the
+    sentinel for "source comparison unavailable".
+    """
+    _failures, warnings = _classify(_baseline_metrics(jira_issue_count=None))
+    assert any("jira" in w.lower() and ("source" in w.lower() or "unavailable" in w.lower()) for w in warnings), (
+        warnings
+    )
+
+
+def test_jira_issue_count_missing_field_treated_as_silent() -> None:
+    """Missing key = legacy audit run, must NOT fail or warn (silent contract)."""
+    metrics = _baseline_metrics()
+    failures, warnings = _classify(metrics)
+    assert not any("jira" in f.lower() for f in failures), failures
+    assert not any("jira" in w.lower() for w in warnings), warnings
+
+
 # --- Pre-existing rules still hold (regression guard) -------------------------
 
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -445,6 +445,26 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
                 f"No watchers found across {wp_total} WPs — watcher migration may have silently skipped",
             )
 
+    # Jira source comparison: issue count. The audit is otherwise
+    # OP-side only — without this check, a wholesale loss (e.g. 1000
+    # Jira issues → 800 OP WPs) passes every other rule. Spec mandates
+    # exact match; any delta is a failure. ``None`` = the audit
+    # couldn't reach Jira (no creds / network) — warn so operators see
+    # the gap, but don't block the OP-side report. Missing key = legacy
+    # audit run before this branch — silent (zero false positives on
+    # cached metrics blobs).
+    if "jira_issue_count" in metrics:
+        jira_count = metrics["jira_issue_count"]
+        if jira_count is None:
+            warnings.append(
+                "Jira source comparison unavailable — issue-count check skipped",
+            )
+        elif int(jira_count) != wp_total:
+            failures.append(
+                f"Jira→OP issue count mismatch: Jira reports {jira_count}, OP has"
+                f" {wp_total} ({int(jira_count) - wp_total:+d}) — wholesale data loss",
+            )
+
     # WP CF format validation. The Ruby side counts populated values
     # that don't match the expected regex per CF. Missing key = legacy
     # audit run before this branch — silently skip (zero is healthy).
@@ -509,13 +529,43 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     return failures, warnings
 
 
+def _fetch_jira_issue_count(jira_project_key: str) -> int | None:
+    """Best-effort: ask Jira how many issues live in this project.
+
+    Returns ``None`` if Jira can't be reached for any reason (no
+    creds, network down, project not found, auth error). The audit
+    must not fail closed on Jira-side issues — operators may
+    legitimately run it without Jira creds, and the OP-side checks
+    still produce useful output. A ``None`` flows through ``_classify``
+    as a warning ("source comparison unavailable"), not a failure.
+
+    Imported lazily so the module imports cleanly even when Jira
+    config is absent (e.g. in unit tests that exercise the
+    classifier directly).
+    """
+    try:
+        from src.infrastructure.jira.jira_client import JiraClient
+    except ImportError:
+        return None
+    try:
+        jira = JiraClient()
+        return int(jira.get_issue_count(jira_project_key))
+    except Exception:
+        return None
+
+
 def _execute_audit(jira_project_key: str) -> dict[str, Any]:
     """Run the audit Ruby expression via the OpenProject client and return parsed metrics."""
     op_client = OpenProjectClient()
     script = _build_audit_script(jira_project_key)
     # File-based path: writes the JSON to a container tempfile and reads
     # it back, avoiding tmux scrollback parsing.
-    return op_client.execute_json_query(script, timeout=120)
+    metrics: dict[str, Any] = op_client.execute_json_query(script, timeout=120)
+    # Best-effort source comparison. Any Jira-side error collapses to
+    # ``None`` and surfaces as a warning in the classifier; the OP-side
+    # report is still valid.
+    metrics["jira_issue_count"] = _fetch_jira_issue_count(jira_project_key)
+    return metrics
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import traceback
 from typing import Any
 
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
@@ -545,12 +546,26 @@ def _fetch_jira_issue_count(jira_project_key: str) -> int | None:
     """
     try:
         from src.infrastructure.jira.jira_client import JiraClient
-    except ImportError:
+    except ImportError as exc:
+        sys.stderr.write(
+            f"[audit] Jira source comparison skipped — could not import JiraClient: {exc}\n",
+        )
         return None
     try:
         jira = JiraClient()
         return int(jira.get_issue_count(jira_project_key))
-    except Exception:
+    except Exception as exc:
+        # Surface the underlying error on stderr so operators can tell
+        # "no creds" (expected) from "JiraClient is broken" (a real
+        # bug). The audit's stdout JSON stays clean; the warning
+        # emitted by ``_classify`` keeps the high-level signal, while
+        # the trace below preserves a forensic trail. ``ValueError``
+        # from ``int(...)`` (malformed upstream response) and network
+        # errors land here together — the trace tells them apart.
+        sys.stderr.write(
+            f"[audit] Jira source comparison skipped — {type(exc).__name__}: {exc}\n",
+        )
+        sys.stderr.write(traceback.format_exc())
         return None
 
 


### PR DESCRIPTION
## Summary

The audit has been **OP-side only** since #175. A wholesale data loss (1000 Jira issues → 800 OP WPs) currently passes every existing rule because the 800 WPs themselves can be perfectly consistent. This adds the first source-side check.

## What's new

**Failure rule**: `jira_issue_count != wp_total` → `Jira→OP issue count mismatch: ... wholesale data loss`. Per `MIGRATION_SPEC.md`, issues must match exactly.

**Best-effort Jira call**: `_fetch_jira_issue_count` lazily imports `JiraClient` (audit module still imports cleanly without Jira config — needed for unit tests that exercise `_classify` directly) and swallows any exception into `None`. Failure modes captured: no creds, network down, project not found, auth failure, CAPTCHA.

**Warning when source unavailable**: A `None` value emits a warning ("Jira source comparison unavailable — issue-count check skipped"), not a failure. The audit must still produce a useful OP-side report when Jira is down or creds aren't set.

**Missing-key contract**: When `jira_issue_count` is absent from the metrics dict (legacy audit run, hand-constructed test dict), the rule stays silent. Only fires when the key is explicitly present.

## Phase 1 of source-side comparison

Future PR candidates per spec:
- Attachment count (**exact match**)
- Relation count (±5%)
- Journal count (±10%)

Each requires per-issue pagination through the Jira API; each lands in its own follow-up.

## Test plan

- [x] 5 new unit tests (match, mismatch ±, None warning, missing-key silent)
- [x] 49/49 unit tests passing
- [x] Local lint + format clean
- [x] Lazy import verified — module loads without Jira creds
- [ ] CI sweep