### PR TITLE
feat(audit): compare OP attachment count against Jira source (Phase 2)

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -656,6 +656,72 @@ def test_jira_attachment_count_missing_field_treated_as_silent() -> None:
     assert not any("attachment" in w.lower() and "jira" in w.lower() for w in warnings), warnings
 
 
+def test_fetch_jira_attachment_count_paginates_when_server_caps_maxresults(monkeypatch) -> None:
+    """The helper must page through all results when Jira caps maxResults.
+
+    Jira Server / Data Center enforces ``jira.search.views.default.max``
+    (commonly 50). Requesting ``maxResults=100`` then receiving 50
+    must still mean "page complete, more may follow". An earlier draft
+    used ``if len(page) < page_size: break`` which silently truncated
+    the count to page 1 — the exact silent-failure class this tool
+    exists to catch.
+
+    The fake returns 50 items per page (capping the helper's request
+    of 100) across two pages, then an empty terminator. With correct
+    pagination the helper sums attachments across BOTH pages.
+    """
+    import sys as _sys
+    import types
+
+    class _FakeFields:
+        def __init__(self, attachments_per_issue: int) -> None:
+            self.attachment = [object()] * attachments_per_issue
+
+    class _FakeIssue:
+        def __init__(self, attachments_per_issue: int) -> None:
+            self.fields = _FakeFields(attachments_per_issue)
+
+    pages = [
+        [_FakeIssue(1) for _ in range(50)],  # page 1: 50 issues × 1 attachment
+        [_FakeIssue(2) for _ in range(50)],  # page 2: 50 issues × 2 attachments
+        [],  # page 3: empty terminator
+    ]
+    page_iter = iter(pages)
+
+    class _FakeUnderlying:
+        def search_issues(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+            return next(page_iter)
+
+    class _FakeJiraClient:
+        def __init__(self) -> None:
+            self.jira = _FakeUnderlying()
+
+    fake_module = types.ModuleType("src.infrastructure.jira.jira_client")
+    fake_module.JiraClient = _FakeJiraClient  # type: ignore[attr-defined]
+    monkeypatch.setitem(_sys.modules, "src.infrastructure.jira.jira_client", fake_module)
+
+    from tools.audit_migrated_project import _fetch_jira_attachment_count
+
+    result = _fetch_jira_attachment_count("NRS")
+    # Correct pagination: 50×1 + 50×2 = 150. Buggy pagination would
+    # have stopped after page 1 and returned 50.
+    assert result == 150
+
+
+def test_fetch_jira_attachment_count_rejects_invalid_project_key() -> None:
+    """Malformed project keys must not be interpolated into JQL.
+
+    Defends against a stray quote in argv silently changing the query
+    scope (e.g. ``NRS" OR project = "PROD`` would query both projects).
+    """
+    from tools.audit_migrated_project import _fetch_jira_attachment_count
+
+    # Each malformed key short-circuits before any Jira call would be
+    # attempted — no monkeypatch needed.
+    for bad in ('NRS"', "nrs", "NRS PROD", "", "1NRS", "NR-S"):
+        assert _fetch_jira_attachment_count(bad) is None
+
+
 # --- Pre-existing rules still hold (regression guard) -------------------------
 
 

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -612,6 +612,50 @@ def test_jira_issue_count_missing_field_treated_as_silent() -> None:
     assert not any("jira" in w.lower() for w in warnings), warnings
 
 
+# --- Jira source comparison: attachment count -------------------------------
+# Per spec: attachment count must EXACTLY equal Jira's. Any silent
+# attachment loss (file-too-large, OP backend rejected, transformer bug)
+# would currently slip through every other rule.
+
+
+def test_jira_attachment_count_match_passes() -> None:
+    failures, _warnings = _classify(
+        _baseline_metrics(jira_attachment_count=0, wp_attachment_total=0),
+    )
+    assert not any("attachment" in f.lower() for f in failures), failures
+
+
+def test_jira_attachment_count_mismatch_is_failure() -> None:
+    """Any non-zero delta is a hard failure — exact match required by spec."""
+    failures, _warnings = _classify(
+        _baseline_metrics(jira_attachment_count=42, wp_attachment_total=40),
+    )
+    assert any("attachment" in f.lower() and "42" in f and "40" in f for f in failures), failures
+
+
+def test_jira_attachment_count_zero_jira_with_op_attachments_is_failure() -> None:
+    """OP > Jira = phantom attachments somehow appeared in OP. Real bug."""
+    failures, _warnings = _classify(
+        _baseline_metrics(jira_attachment_count=0, wp_attachment_total=5),
+    )
+    assert any("attachment" in f.lower() for f in failures), failures
+
+
+def test_jira_attachment_count_none_warns_source_unavailable() -> None:
+    _failures, warnings = _classify(_baseline_metrics(jira_attachment_count=None))
+    assert any("attachment" in w.lower() and ("source" in w.lower() or "unavailable" in w.lower()) for w in warnings), (
+        warnings
+    )
+
+
+def test_jira_attachment_count_missing_field_treated_as_silent() -> None:
+    """Missing key = legacy audit run; rule must not fire."""
+    metrics = _baseline_metrics()
+    failures, warnings = _classify(metrics)
+    assert not any("attachment" in f.lower() and "jira" in f.lower() for f in failures), failures
+    assert not any("attachment" in w.lower() and "jira" in w.lower() for w in warnings), warnings
+
+
 # --- Pre-existing rules still hold (regression guard) -------------------------
 
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -466,6 +466,26 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
                 f" {wp_total} ({int(jira_count) - wp_total:+d}) — wholesale data loss",
             )
 
+    # Jira source comparison: attachment count. Per spec, attachments
+    # must match exactly — any non-zero delta means silent attachment
+    # loss (file-too-large, backend rejected, transformer bug) or a
+    # phantom OP-side artifact. ``None`` warns ("source unavailable")
+    # without blocking the OP-side report. Missing key = legacy run.
+    if "jira_attachment_count" in metrics:
+        jira_att = metrics["jira_attachment_count"]
+        if jira_att is None:
+            warnings.append(
+                "Jira attachment source comparison unavailable — check skipped",
+            )
+        else:
+            op_att = _metric_int(metrics, "wp_attachment_total")
+            if int(jira_att) != op_att:
+                failures.append(
+                    f"Jira→OP attachment count mismatch: Jira reports {jira_att},"
+                    f" OP has {op_att} ({int(jira_att) - op_att:+d}) — silent"
+                    " attachment loss or phantom OP-side artifacts",
+                )
+
     # WP CF format validation. The Ruby side counts populated values
     # that don't match the expected regex per CF. Missing key = legacy
     # audit run before this branch — silently skip (zero is healthy).
@@ -569,6 +589,69 @@ def _fetch_jira_issue_count(jira_project_key: str) -> int | None:
         return None
 
 
+def _fetch_jira_attachment_count(jira_project_key: str) -> int | None:
+    """Best-effort: count total attachments across all issues in the project.
+
+    Paginates ``search_issues(jql='project="X"', fields="attachment")``
+    and sums ``len(issue.fields.attachment)`` across all pages. Same
+    error contract as :func:`_fetch_jira_issue_count`: any failure
+    (no creds, network down, project not found, mid-pagination error,
+    auth, CAPTCHA) collapses to ``None`` so the classifier emits a
+    warning rather than blocking the OP-side report.
+
+    Pagination is required because Jira has no aggregate-attachment
+    JQL. For a 10K-issue project with ``maxResults=100`` this is ~100
+    calls — the Jira client's adaptive rate-limiter handles that
+    gracefully. There is no hard cap; very large projects (>50K
+    issues) may take a minute, which is acceptable for a one-shot
+    post-migration audit.
+
+    The lazy import + broad ``except`` mirror the issue-count helper
+    so the audit module imports cleanly without Jira config — the
+    classifier unit tests rely on this.
+    """
+    try:
+        from src.infrastructure.jira.jira_client import JiraClient
+    except ImportError as exc:
+        sys.stderr.write(
+            f"[audit] Jira attachment comparison skipped — could not import JiraClient: {exc}\n",
+        )
+        return None
+    try:
+        jira = JiraClient()
+        # ``jira.jira`` is the underlying ``python-jira`` JIRA instance
+        # used elsewhere in src/infrastructure/jira/ for paginated
+        # search calls (see jira_search_service.py:64-72).
+        underlying = jira.jira
+        page_size = 100
+        start_at = 0
+        total = 0
+        jql = f'project = "{jira_project_key}"'
+        while True:
+            page = underlying.search_issues(
+                jql,
+                startAt=start_at,
+                maxResults=page_size,
+                fields="attachment",
+                expand="",
+            )
+            if not page:
+                break
+            for issue in page:
+                attachments = getattr(issue.fields, "attachment", None) or []
+                total += len(attachments)
+            if len(page) < page_size:
+                break
+            start_at += page_size
+    except Exception as exc:
+        sys.stderr.write(
+            f"[audit] Jira attachment comparison skipped — {type(exc).__name__}: {exc}\n",
+        )
+        sys.stderr.write(traceback.format_exc())
+        return None
+    return total
+
+
 def _execute_audit(jira_project_key: str) -> dict[str, Any]:
     """Run the audit Ruby expression via the OpenProject client and return parsed metrics."""
     op_client = OpenProjectClient()
@@ -580,6 +663,7 @@ def _execute_audit(jira_project_key: str) -> dict[str, Any]:
     # ``None`` and surfaces as a warning in the classifier; the OP-side
     # report is still valid.
     metrics["jira_issue_count"] = _fetch_jira_issue_count(jira_project_key)
+    metrics["jira_attachment_count"] = _fetch_jira_attachment_count(jira_project_key)
     return metrics
 
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import traceback
 from typing import Any
@@ -131,6 +132,19 @@ _REQUIRED_TE_PROVENANCE_CFS: tuple[str, ...] = (
 _TE_CF_FORMAT_REGEXES: tuple[tuple[str, str], ...] = (
     ("J2O Origin Worklog Key", r"\A([A-Z][A-Z0-9_]+-\d+:\d+|tempo:\d+)\z"),
 )
+
+# Validated against argv before being interpolated into a JQL string —
+# a stray quote in a malformed key would otherwise silently change the
+# query scope (``NRS" OR project = "PROD`` → both projects).
+_JIRA_PROJECT_KEY_RE = re.compile(r"\A[A-Z][A-Z0-9_]+\z")
+
+# Hard cap for the attachment pagination loop. Defends against a buggy
+# proxy / Jira returning the same page repeatedly (so neither the
+# empty-page break nor the actual end-of-results triggers) — without
+# this cap, ``start_at`` would grow unboundedly and the audit would
+# pound the rate-limiter forever. 1000 pages × 100 issues/page =
+# 100k issues, well above any real project.
+_PAGINATION_MAX_PAGES = 1000
 
 
 def _build_audit_script(jira_project_key: str) -> str:
@@ -599,17 +613,37 @@ def _fetch_jira_attachment_count(jira_project_key: str) -> int | None:
     auth, CAPTCHA) collapses to ``None`` so the classifier emits a
     warning rather than blocking the OP-side report.
 
-    Pagination is required because Jira has no aggregate-attachment
-    JQL. For a 10K-issue project with ``maxResults=100`` this is ~100
-    calls — the Jira client's adaptive rate-limiter handles that
-    gracefully. There is no hard cap; very large projects (>50K
-    issues) may take a minute, which is acceptable for a one-shot
-    post-migration audit.
+    **Pagination correctness.** Two subtle bugs that an earlier draft
+    of this helper had:
+
+    1. ``start_at`` MUST advance by ``len(page)``, not by the requested
+       ``page_size``. Jira Server / Data Center caps ``maxResults`` via
+       ``jira.search.views.default.max`` (commonly 50 or 100,
+       configurable). Requesting 100 and receiving 50 must still mean
+       "page complete, more may follow". The obvious heuristic
+       ``if len(page) < page_size: break`` silently truncates the
+       entire project past page 1 — the exact silent-failure class
+       this audit tool exists to catch.
+    2. The loop needs a hard cap. A buggy proxy that returns the same
+       page repeatedly (``len(page) == page_size`` forever) would
+       otherwise spin until the rate-limiter melts. ``for...else``
+       fires ``return None`` if the cap is hit so a buggy upstream
+       presents as "source unavailable" rather than a silent count.
+
+    Project key is regex-validated before the JQL is built — a stray
+    quote in argv would otherwise silently change the query scope
+    (``NRS" OR project = "PROD`` would query both).
 
     The lazy import + broad ``except`` mirror the issue-count helper
     so the audit module imports cleanly without Jira config — the
     classifier unit tests rely on this.
     """
+    if not _JIRA_PROJECT_KEY_RE.match(jira_project_key):
+        sys.stderr.write(
+            f"[audit] Jira attachment comparison skipped — invalid project key"
+            f" {jira_project_key!r} (expected uppercase Jira key like 'NRS')\n",
+        )
+        return None
     try:
         from src.infrastructure.jira.jira_client import JiraClient
     except ImportError as exc:
@@ -627,7 +661,7 @@ def _fetch_jira_attachment_count(jira_project_key: str) -> int | None:
         start_at = 0
         total = 0
         jql = f'project = "{jira_project_key}"'
-        while True:
+        for _ in range(_PAGINATION_MAX_PAGES):
             page = underlying.search_issues(
                 jql,
                 startAt=start_at,
@@ -640,9 +674,16 @@ def _fetch_jira_attachment_count(jira_project_key: str) -> int | None:
             for issue in page:
                 attachments = getattr(issue.fields, "attachment", None) or []
                 total += len(attachments)
-            if len(page) < page_size:
-                break
-            start_at += page_size
+            # Advance by what the server actually returned, not by what
+            # we asked for. See the docstring for why.
+            start_at += len(page)
+        else:
+            sys.stderr.write(
+                f"[audit] Jira attachment pagination hit the {_PAGINATION_MAX_PAGES}"
+                f"-page safety cap for project {jira_project_key!r} — likely a buggy"
+                " upstream returning the same page repeatedly\n",
+            )
+            return None
     except Exception as exc:
         sys.stderr.write(
             f"[audit] Jira attachment comparison skipped — {type(exc).__name__}: {exc}\n",


### PR DESCRIPTION
## Summary

Phase 2 of source-side comparison after #183 (issue count). Per `MIGRATION_SPEC.md`: **attachment count must match exactly between Jira and OP**. Until now this class of silent failure (file-too-large, OP backend rejected, transformer bug) passed every other rule because they all verified internal OP consistency.

## What's new

**Helper**: `_fetch_jira_attachment_count(project_key) -> int | None`
- Paginates `search_issues(jql='project="X"', fields="attachment")` via the underlying python-jira client
- Sums per-issue `issue.fields.attachment` lists across all pages
- Same error contract as #183's issue-count helper: any failure → `None` + stderr trace
- ~100 calls for a 10K-issue project at `maxResults=100`; the Jira client's adaptive rate-limiter handles it; ~1 min for very large projects (>50K issues), acceptable for one-shot post-migration audit

**Classifier rule**:
- `jira_attachment_count != wp_attachment_total` → failure with "silent attachment loss or phantom OP-side artifacts" framing
- `None` → warning ("source unavailable")
- Missing key → silent (legacy audit run contract — same as #183)

## Phase 3 candidates per spec

- Relation count (±5%)
- Journal count (±10%)
- Time-entry hours sum (±5%)

Each follows the same pagination shape but with tolerance bands instead of exact match.

## Test plan

- [x] 5 new unit tests (`test_jira_attachment_count_*`) covering: match, mismatch (both directions), None warns, missing-key silent
- [x] 54/54 unit tests passing
- [x] Lazy import + module loads without Jira creds (matches #183)
- [x] Local lint + format clean
- [ ] CI sweep