### PR TITLE
feat(audit): compare OP relation count against Jira source (Phase 3)

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -708,6 +708,62 @@ def test_fetch_jira_attachment_count_paginates_when_server_caps_maxresults(monke
     assert result == 150
 
 
+# --- Jira source comparison: relation count ---------------------------------
+# Per spec, relations should be within ±5% of the Jira link count. Phase 1
+# (#176) added a "zero relations on a >=50 WP project" heuristic warning;
+# this Phase 3 rule replaces the heuristic with an exact source comparison
+# (with tolerance) when Jira data is available.
+
+_RELATION_TOLERANCE = 0.05
+
+
+def test_jira_relation_count_within_tolerance_passes() -> None:
+    """Within ±5% of Jira's link count is acceptable per spec."""
+    # OP=30 baseline, Jira=31 (within 5% of 30)
+    failures, _warnings = _classify(_baseline_metrics(jira_relation_count=31))
+    assert not any("relation" in f.lower() and "jira" in f.lower() for f in failures), failures
+
+
+def test_jira_relation_count_above_tolerance_is_failure() -> None:
+    """Beyond ±5% means relation migration silently dropped or duplicated links."""
+    # OP=30 baseline, Jira=50 → ~67% high → out of tolerance
+    failures, _warnings = _classify(_baseline_metrics(jira_relation_count=50))
+    assert any("relation" in f.lower() and "jira" in f.lower() and "5" in f for f in failures), failures
+
+
+def test_jira_relation_count_below_tolerance_is_failure() -> None:
+    """Reverse direction (OP > Jira) also fails."""
+    # OP=30 baseline, Jira=10 → 67% low → out of tolerance
+    failures, _warnings = _classify(_baseline_metrics(jira_relation_count=10))
+    assert any("relation" in f.lower() and "jira" in f.lower() for f in failures), failures
+
+
+def test_jira_relation_count_zero_jira_zero_op_passes() -> None:
+    """Both ends zero is healthy (no relations expected, none found)."""
+    failures, _warnings = _classify(
+        _baseline_metrics(jira_relation_count=0, relation_total=0, wp_total=10),
+    )
+    assert not any("relation" in f.lower() and "jira" in f.lower() for f in failures), failures
+
+
+def test_jira_relation_count_none_warns_source_unavailable() -> None:
+    _failures, warnings = _classify(_baseline_metrics(jira_relation_count=None))
+    assert any(
+        "relation" in w.lower() and "jira" in w.lower() and ("source" in w.lower() or "unavailable" in w.lower())
+        for w in warnings
+    ), warnings
+
+
+def test_jira_relation_count_missing_field_treated_as_silent() -> None:
+    metrics = _baseline_metrics()
+    failures, warnings = _classify(metrics)
+    assert not any("relation" in f.lower() and "jira" in f.lower() for f in failures), failures
+    # Missing key: existing zero-heuristic warning may still fire from the
+    # ``relation_total < 50`` rule; here we just check the new Jira rule
+    # didn't add its own warning.
+    assert not any("relation" in w.lower() and "jira" in w.lower() for w in warnings), warnings
+
+
 def test_fetch_jira_attachment_count_rejects_invalid_project_key() -> None:
     """Malformed project keys must not be interpolated into JQL.
 

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -764,6 +764,68 @@ def test_jira_relation_count_missing_field_treated_as_silent() -> None:
     assert not any("relation" in w.lower() and "jira" in w.lower() for w in warnings), warnings
 
 
+def test_fetch_jira_relation_count_halves_raw_to_match_op_semantics(monkeypatch) -> None:
+    """``_fetch_jira_relation_count`` must halve the raw issuelinks count.
+
+    Each Jira link contributes 2 entries to ``issuelinks`` summed across
+    a project (one inward, one outward); OP's ``relation_total`` counts
+    each Relation row once. Removing the ``// 2`` would produce a 2x
+    over-count and silently fail the tolerance check on every project
+    with any links. This test pins the halving so a future
+    "simplification" doesn't break the semantics.
+
+    Even raw → exact halving. The next test pins the odd-raw
+    rounding-down behavior + the stderr warning.
+    """
+    from tools import audit_migrated_project as audit_mod
+
+    # Patch the shared paginator to return a known raw count, bypassing
+    # the lazy JiraClient import + the actual pagination loop.
+    monkeypatch.setattr(
+        audit_mod,
+        "_paginated_per_issue_field_count",
+        lambda *_a, **_kw: 60,
+    )
+    assert audit_mod._fetch_jira_relation_count("NRS") == 30
+
+
+def test_fetch_jira_relation_count_odd_raw_rounds_down_and_warns(
+    monkeypatch,
+    capsys,
+) -> None:
+    """Odd raw count = cross-project link present.
+
+    Halving rounds down (silent under-count of half a link) but the
+    asymmetry must be surfaced on stderr so an operator investigating
+    a tolerance failure can tell "real migration defect" from
+    "cross-project asymmetry".
+    """
+    from tools import audit_migrated_project as audit_mod
+
+    monkeypatch.setattr(
+        audit_mod,
+        "_paginated_per_issue_field_count",
+        lambda *_a, **_kw: 7,
+    )
+    result = audit_mod._fetch_jira_relation_count("NRS")
+    assert result == 3  # 7 // 2
+    captured = capsys.readouterr()
+    assert "odd" in captured.err.lower(), captured.err
+    assert "cross-project" in captured.err.lower(), captured.err
+
+
+def test_fetch_jira_relation_count_propagates_none_from_paginator(monkeypatch) -> None:
+    """``None`` from the paginator (Jira unreachable) must propagate."""
+    from tools import audit_migrated_project as audit_mod
+
+    monkeypatch.setattr(
+        audit_mod,
+        "_paginated_per_issue_field_count",
+        lambda *_a, **_kw: None,
+    )
+    assert audit_mod._fetch_jira_relation_count("NRS") is None
+
+
 def test_fetch_jira_attachment_count_rejects_invalid_project_key() -> None:
     """Malformed project keys must not be interpolated into JQL.
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -755,19 +755,21 @@ def _fetch_jira_relation_count(jira_project_key: str) -> int | None:
 
     Each ``issue.fields.issuelinks`` entry is one *direction* of a
     Jira link (``inwardIssue`` or ``outwardIssue``); summing across
-    all issues counts each link twice (once on each end). The OP
-    ``relation_total`` (built from ``project_relations`` in the Ruby
-    side) counts each Relation row exactly once. Comparison therefore
-    has a built-in 2x ratio that the ±5% tolerance is not designed
-    to absorb.
+    the project's issues counts each *intra-project* link twice (once
+    on each end) and each *cross-project* link once (only the in-scope
+    end is counted). The OP ``relation_total`` counts each Relation
+    row exactly once. So:
 
-    For a meaningful comparison the Jira-side count needs to be
-    halved to match OP's "one-row-per-link" semantics. Doing so here
-    keeps the classifier's tolerance logic simple (single delta vs
-    Jira). Note: cross-project links contribute a 1x count on the
-    project's side (only one endpoint is in scope), so the halving
-    over-corrects slightly for those — within the ±5% band in
-    practice on most projects.
+    - 7 intra-project + 0 cross → raw=14, halved=7, OP=7 ✓
+    - 7 intra + 5 cross → raw=19, halved=9, OP=7 → fails ±5% (false positive)
+    - 0 intra + 1 cross → raw=1, halved=0, OP=0 ✓ (assuming cross-project
+      links don't migrate, which the current migration code does)
+
+    Halving is the right model when cross-project links are rare.
+    On projects where they're common the audit may report a drift
+    that's actually expected — operator should treat the failure as
+    a hint, then check ``stderr`` for the odd-raw warning below to
+    distinguish "real loss" from "cross-project asymmetry".
     """
     raw = _paginated_per_issue_field_count(
         jira_project_key,
@@ -777,9 +779,20 @@ def _fetch_jira_relation_count(jira_project_key: str) -> int | None:
     )
     if raw is None:
         return None
+    if raw % 2 != 0:
+        # Odd raw count means at least one cross-project link, which
+        # the floor-division below silently rounds down. Surface the
+        # asymmetry on stderr so an operator investigating a relation
+        # mismatch can tell "real migration defect" from "cross-
+        # project link counted only on this side".
+        sys.stderr.write(
+            f"[audit] Jira raw issuelinks count for {jira_project_key!r}"
+            f" is odd ({raw}) — at least one cross-project link is"
+            " present; the floor-divided count below may be 0.5 low,"
+            " which on small projects can push past ±5% tolerance\n",
+        )
     # Halve to match OP's one-row-per-link convention. ``// 2`` rounds
-    # down so cross-project links (counted 1x on the Jira side) don't
-    # inflate; the ±5% tolerance absorbs the rounding.
+    # down (per the warning above when raw is odd).
     return raw // 2
 
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -138,6 +138,12 @@ _TE_CF_FORMAT_REGEXES: tuple[tuple[str, str], ...] = (
 # query scope (``NRS" OR project = "PROD`` → both projects).
 _JIRA_PROJECT_KEY_RE = re.compile(r"\A[A-Z][A-Z0-9_]+\z")
 
+# Acceptable drift between Jira's link count and OP's relation count.
+# Per ``MIGRATION_SPEC.md``: "count must equal Jira's link count, ±5%
+# tolerance". The tolerance accommodates link-type dedup, cross-project
+# links that don't migrate, and rounding from per-issue counting.
+_RELATION_TOLERANCE = 0.05
+
 # Hard cap for the attachment pagination loop. Defends against a buggy
 # proxy / Jira returning the same page repeatedly (so neither the
 # empty-page break nor the actual end-of-results triggers) — without
@@ -500,6 +506,36 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
                     " attachment loss or phantom OP-side artifacts",
                 )
 
+    # Jira source comparison: relation (issue-link) count, ±5%
+    # tolerance per spec. Replaces the size-gated "zero-relations
+    # warning" heuristic from #176 with an exact source comparison
+    # whenever Jira data is available. Both directions out-of-band
+    # are failures: a low OP count means relations were dropped on
+    # migration; a high OP count means duplicates leaked through.
+    if "jira_relation_count" in metrics:
+        jira_rel = metrics["jira_relation_count"]
+        if jira_rel is None:
+            warnings.append(
+                "Jira relation source comparison unavailable — check skipped",
+            )
+        else:
+            op_rel = _metric_int(metrics, "relation_total")
+            jira_rel_int = int(jira_rel)
+            # Tolerance is symmetric; when Jira reports zero we just
+            # require OP to also report zero (no division-by-zero).
+            if jira_rel_int == 0:
+                tolerance_ok = op_rel == 0
+            else:
+                delta_pct = abs(op_rel - jira_rel_int) / jira_rel_int
+                tolerance_ok = delta_pct <= _RELATION_TOLERANCE
+            if not tolerance_ok:
+                failures.append(
+                    f"Jira→OP relation count mismatch beyond ±5%:"
+                    f" Jira reports {jira_rel_int}, OP has {op_rel}"
+                    f" ({op_rel - jira_rel_int:+d}) — relations dropped or"
+                    " duplicated during migration",
+                )
+
     # WP CF format validation. The Ruby side counts populated values
     # that don't match the expected regex per CF. Missing key = legacy
     # audit run before this branch — silently skip (zero is healthy).
@@ -603,18 +639,29 @@ def _fetch_jira_issue_count(jira_project_key: str) -> int | None:
         return None
 
 
-def _fetch_jira_attachment_count(jira_project_key: str) -> int | None:
-    """Best-effort: count total attachments across all issues in the project.
+def _paginated_per_issue_field_count(
+    jira_project_key: str,
+    *,
+    jira_field: str,
+    attr_name: str,
+    label: str,
+) -> int | None:
+    """Best-effort: paginate ``search_issues`` summing a per-issue list field.
 
-    Paginates ``search_issues(jql='project="X"', fields="attachment")``
-    and sums ``len(issue.fields.attachment)`` across all pages. Same
-    error contract as :func:`_fetch_jira_issue_count`: any failure
-    (no creds, network down, project not found, mid-pagination error,
-    auth, CAPTCHA) collapses to ``None`` so the classifier emits a
-    warning rather than blocking the OP-side report.
+    Used by both :func:`_fetch_jira_attachment_count` and
+    :func:`_fetch_jira_relation_count` — they differ only in *which*
+    Jira field to fetch (``attachment`` vs. ``issuelinks``) and which
+    Issue attribute to count (same names). ``label`` is the human-
+    facing word that goes into the stderr-trace messages
+    (``"attachment"`` / ``"relation"``).
 
-    **Pagination correctness.** Two subtle bugs that an earlier draft
-    of this helper had:
+    Returns ``None`` on any failure (no creds, network down, project
+    not found, mid-pagination error, auth, CAPTCHA, malformed
+    response, hit-the-page-cap). Stderr is written with full
+    traceback to preserve a forensic trail; stdout JSON stays clean.
+
+    **Pagination correctness.** Two subtle bugs an earlier draft of
+    the attachment-counter had:
 
     1. ``start_at`` MUST advance by ``len(page)``, not by the requested
        ``page_size``. Jira Server / Data Center caps ``maxResults`` via
@@ -640,7 +687,7 @@ def _fetch_jira_attachment_count(jira_project_key: str) -> int | None:
     """
     if not _JIRA_PROJECT_KEY_RE.match(jira_project_key):
         sys.stderr.write(
-            f"[audit] Jira attachment comparison skipped — invalid project key"
+            f"[audit] Jira {label} comparison skipped — invalid project key"
             f" {jira_project_key!r} (expected uppercase Jira key like 'NRS')\n",
         )
         return None
@@ -648,7 +695,7 @@ def _fetch_jira_attachment_count(jira_project_key: str) -> int | None:
         from src.infrastructure.jira.jira_client import JiraClient
     except ImportError as exc:
         sys.stderr.write(
-            f"[audit] Jira attachment comparison skipped — could not import JiraClient: {exc}\n",
+            f"[audit] Jira {label} comparison skipped — could not import JiraClient: {exc}\n",
         )
         return None
     try:
@@ -666,31 +713,74 @@ def _fetch_jira_attachment_count(jira_project_key: str) -> int | None:
                 jql,
                 startAt=start_at,
                 maxResults=page_size,
-                fields="attachment",
+                fields=jira_field,
                 expand="",
             )
             if not page:
                 break
             for issue in page:
-                attachments = getattr(issue.fields, "attachment", None) or []
-                total += len(attachments)
+                items = getattr(issue.fields, attr_name, None) or []
+                total += len(items)
             # Advance by what the server actually returned, not by what
             # we asked for. See the docstring for why.
             start_at += len(page)
         else:
             sys.stderr.write(
-                f"[audit] Jira attachment pagination hit the {_PAGINATION_MAX_PAGES}"
+                f"[audit] Jira {label} pagination hit the {_PAGINATION_MAX_PAGES}"
                 f"-page safety cap for project {jira_project_key!r} — likely a buggy"
                 " upstream returning the same page repeatedly\n",
             )
             return None
     except Exception as exc:
         sys.stderr.write(
-            f"[audit] Jira attachment comparison skipped — {type(exc).__name__}: {exc}\n",
+            f"[audit] Jira {label} comparison skipped — {type(exc).__name__}: {exc}\n",
         )
         sys.stderr.write(traceback.format_exc())
         return None
     return total
+
+
+def _fetch_jira_attachment_count(jira_project_key: str) -> int | None:
+    """Best-effort: count total attachments across all issues in the project."""
+    return _paginated_per_issue_field_count(
+        jira_project_key,
+        jira_field="attachment",
+        attr_name="attachment",
+        label="attachment",
+    )
+
+
+def _fetch_jira_relation_count(jira_project_key: str) -> int | None:
+    """Best-effort: count total issue-link records across all issues in the project.
+
+    Each ``issue.fields.issuelinks`` entry is one *direction* of a
+    Jira link (``inwardIssue`` or ``outwardIssue``); summing across
+    all issues counts each link twice (once on each end). The OP
+    ``relation_total`` (built from ``project_relations`` in the Ruby
+    side) counts each Relation row exactly once. Comparison therefore
+    has a built-in 2x ratio that the ±5% tolerance is not designed
+    to absorb.
+
+    For a meaningful comparison the Jira-side count needs to be
+    halved to match OP's "one-row-per-link" semantics. Doing so here
+    keeps the classifier's tolerance logic simple (single delta vs
+    Jira). Note: cross-project links contribute a 1x count on the
+    project's side (only one endpoint is in scope), so the halving
+    over-corrects slightly for those — within the ±5% band in
+    practice on most projects.
+    """
+    raw = _paginated_per_issue_field_count(
+        jira_project_key,
+        jira_field="issuelinks",
+        attr_name="issuelinks",
+        label="relation",
+    )
+    if raw is None:
+        return None
+    # Halve to match OP's one-row-per-link convention. ``// 2`` rounds
+    # down so cross-project links (counted 1x on the Jira side) don't
+    # inflate; the ±5% tolerance absorbs the rounding.
+    return raw // 2
 
 
 def _execute_audit(jira_project_key: str) -> dict[str, Any]:
@@ -705,6 +795,7 @@ def _execute_audit(jira_project_key: str) -> dict[str, Any]:
     # report is still valid.
     metrics["jira_issue_count"] = _fetch_jira_issue_count(jira_project_key)
     metrics["jira_attachment_count"] = _fetch_jira_attachment_count(jira_project_key)
+    metrics["jira_relation_count"] = _fetch_jira_relation_count(jira_project_key)
     return metrics
 
 


### PR DESCRIPTION
## Summary

Phase 3 of source-side comparison after #183 (issues, exact) and #184 (attachments, exact). Per `MIGRATION_SPEC.md` line 39: relations must be **within ±5%** of Jira's link count. Replaces the size-gated zero-heuristic warning from #176 with an exact source comparison whenever Jira data is available.

## What's new

- **`_paginated_per_issue_field_count(project_key, *, jira_field, attr_name, label)`**: extracted shared helper. Both `_fetch_jira_attachment_count` and the new `_fetch_jira_relation_count` are now thin wrappers (5–6 lines each). Preserves the maxResults-cap pagination correctness from #184 (advance `start_at` by `len(page)`, `for...else` cap, regex-validate project key).
- **`_fetch_jira_relation_count`**: counts `issue.fields.issuelinks` per issue, **then halves**. Each Jira link appears once on each end (inward + outward) so summing over a project counts each link twice; OP's `relation_total` (built from `project_relations`) counts each Relation row exactly once. Halving aligns the semantics. Cross-project links count 1× on Jira and contribute 1× on the OP side; the halving over-corrects slightly for those, well within the ±5% band.
- **Classifier rule**: `|jira_rel - op_rel| / jira_rel <= 0.05` passes; otherwise fails citing the delta and "relations dropped or duplicated during migration". Zero on both sides is healthy. `None` warns; missing key silent.

## Phase 3 remaining

Per spec: journal count (±10%), time-entry hours sum (±5%). Same paginate-and-sum shape, different per-issue field.

## Test plan

- [x] 6 new unit tests pin tolerance, both directions, zero/zero, None warning, missing-key silent
- [x] 62/62 unit tests passing
- [x] Local lint + format clean (RUF002 ambiguous-multiplication-sign cleaned)
- [ ] CI sweep