### PR TITLE
feat(audit): compare OP watcher count against Jira source (Phase 3b)

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -814,6 +814,56 @@ def test_jira_watcher_count_missing_field_treated_as_silent() -> None:
     assert not any("jira" in w.lower() and "watcher" in w.lower() for w in warnings), warnings
 
 
+def test_fetch_jira_watcher_count_handles_dict_and_object_watches(monkeypatch) -> None:
+    """``watches`` may be either a python-jira resource OR a raw dict.
+
+    Defends against the silent-failure path where ``getattr(dict, "watchCount", 0)``
+    returns ``0``: a dict-shaped response would silently zero the
+    count and the classifier would (wrongly) blame the migration.
+    """
+    import sys as _sys
+    import types
+
+    class _ObjWatches:
+        watchCount = 7
+
+    class _Fields:
+        def __init__(self, watches: Any) -> None:
+            self.watches = watches
+
+    class _Issue:
+        def __init__(self, watches: Any) -> None:
+            self.fields = _Fields(watches)
+
+    pages = [
+        # 2 issues with object-shaped watches (7 each)
+        [_Issue(_ObjWatches()), _Issue(_ObjWatches())],
+        # 2 issues with dict-shaped watches (3 + 5)
+        [_Issue({"watchCount": 3}), _Issue({"watchCount": 5})],
+        # 1 issue with no watches attribute (None)
+        [_Issue(None)],
+        [],  # terminator
+    ]
+    page_iter = iter(pages)
+
+    class _FakeUnderlying:
+        def search_issues(self, *_a: Any, **_kw: Any) -> list[Any]:
+            return next(page_iter)
+
+    class _FakeJiraClient:
+        def __init__(self) -> None:
+            self.jira = _FakeUnderlying()
+
+    fake_module = types.ModuleType("src.infrastructure.jira.jira_client")
+    fake_module.JiraClient = _FakeJiraClient  # type: ignore[attr-defined]
+    monkeypatch.setitem(_sys.modules, "src.infrastructure.jira.jira_client", fake_module)
+
+    from tools.audit_migrated_project import _fetch_jira_watcher_count
+
+    # Object pages: 7+7=14, dict pages: 3+5=8, None: 0 → total 22
+    assert _fetch_jira_watcher_count("NRS") == 22
+
+
 def test_fetch_jira_relation_count_halves_raw_to_match_op_semantics(monkeypatch) -> None:
     """``_fetch_jira_relation_count`` must halve the raw issuelinks count.
 

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -764,6 +764,56 @@ def test_jira_relation_count_missing_field_treated_as_silent() -> None:
     assert not any("relation" in w.lower() and "jira" in w.lower() for w in warnings), warnings
 
 
+# --- Jira source comparison: watcher count -----------------------------------
+# Per spec, watchers "should" equal Jira's count (softer than the
+# relation "must" wording). ±5% tolerance lets the audit catch real
+# regressions while tolerating locked/disabled users whose watches
+# can't migrate.
+
+
+def test_jira_watcher_count_within_tolerance_passes() -> None:
+    # OP=50 baseline, Jira=51 → within 5%
+    failures, _warnings = _classify(_baseline_metrics(jira_watcher_count=51))
+    assert not any("watcher" in f.lower() and "jira" in f.lower() for f in failures), failures
+
+
+def test_jira_watcher_count_above_tolerance_is_failure() -> None:
+    # OP=50 baseline, Jira=80 → 60% high → fails
+    failures, _warnings = _classify(_baseline_metrics(jira_watcher_count=80))
+    assert any("watcher" in f.lower() and "jira" in f.lower() for f in failures), failures
+
+
+def test_jira_watcher_count_below_tolerance_is_failure() -> None:
+    # OP=50 baseline, Jira=10 → 80% low → fails
+    failures, _warnings = _classify(_baseline_metrics(jira_watcher_count=10))
+    assert any("watcher" in f.lower() and "jira" in f.lower() for f in failures), failures
+
+
+def test_jira_watcher_count_zero_jira_zero_op_passes() -> None:
+    failures, _warnings = _classify(
+        _baseline_metrics(jira_watcher_count=0, wp_watcher_total=0, wp_total=10),
+    )
+    assert not any("watcher" in f.lower() and "jira" in f.lower() for f in failures), failures
+
+
+def test_jira_watcher_count_none_warns_source_unavailable() -> None:
+    _failures, warnings = _classify(_baseline_metrics(jira_watcher_count=None))
+    assert any(
+        "watcher" in w.lower() and "jira" in w.lower() and ("source" in w.lower() or "unavailable" in w.lower())
+        for w in warnings
+    ), warnings
+
+
+def test_jira_watcher_count_missing_field_treated_as_silent() -> None:
+    metrics = _baseline_metrics()
+    failures, warnings = _classify(metrics)
+    # Existing zero-watchers heuristic warning may fire (it's gated on
+    # ``wp_total>=50``, not on ``jira_watcher_count``); only assert the
+    # NEW Jira-watcher rule didn't add its own failure or warning.
+    assert not any("jira" in f.lower() and "watcher" in f.lower() for f in failures), failures
+    assert not any("jira" in w.lower() and "watcher" in w.lower() for w in warnings), warnings
+
+
 def test_fetch_jira_relation_count_halves_raw_to_match_op_semantics(monkeypatch) -> None:
     """``_fetch_jira_relation_count`` must halve the raw issuelinks count.
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -144,6 +144,13 @@ _JIRA_PROJECT_KEY_RE = re.compile(r"\A[A-Z][A-Z0-9_]+\z")
 # links that don't migrate, and rounding from per-issue counting.
 _RELATION_TOLERANCE = 0.05
 
+# Acceptable drift between Jira's watcher count and OP's. The spec
+# says watchers "should" match (line 40, weaker than the relation
+# rule's "must equal"); ±5% lets the audit catch real migration
+# regressions while tolerating the occasional locked/disabled user
+# whose Jira watch couldn't carry over.
+_WATCHER_TOLERANCE = 0.05
+
 # Hard cap for the attachment pagination loop. Defends against a buggy
 # proxy / Jira returning the same page repeatedly (so neither the
 # empty-page break nor the actual end-of-results triggers) — without
@@ -506,6 +513,33 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
                     " attachment loss or phantom OP-side artifacts",
                 )
 
+    # Jira source comparison: watcher count, ±5% tolerance. The spec
+    # uses "should equal" rather than "must equal" for watchers
+    # (locked users / disabled accounts won't migrate their watches),
+    # so this is a softer signal than the relation rule but still
+    # catches wholesale watcher loss.
+    if "jira_watcher_count" in metrics:
+        jira_watch = metrics["jira_watcher_count"]
+        if jira_watch is None:
+            warnings.append(
+                "Jira watcher source comparison unavailable — check skipped",
+            )
+        else:
+            op_watch = _metric_int(metrics, "wp_watcher_total")
+            jira_watch_int = int(jira_watch)
+            if jira_watch_int == 0:
+                tolerance_ok = op_watch == 0
+            else:
+                delta_pct = abs(op_watch - jira_watch_int) / jira_watch_int
+                tolerance_ok = delta_pct <= _WATCHER_TOLERANCE
+            if not tolerance_ok:
+                failures.append(
+                    f"Jira→OP watcher count mismatch beyond ±5%:"
+                    f" Jira reports {jira_watch_int}, OP has {op_watch}"
+                    f" ({op_watch - jira_watch_int:+d}) — watch records dropped"
+                    " or duplicated during migration",
+                )
+
     # Jira source comparison: relation (issue-link) count, ±5%
     # tolerance per spec. Replaces the size-gated "zero-relations
     # warning" heuristic from #176 with an exact source comparison
@@ -750,6 +784,74 @@ def _fetch_jira_attachment_count(jira_project_key: str) -> int | None:
     )
 
 
+def _fetch_jira_watcher_count(jira_project_key: str) -> int | None:
+    """Best-effort: sum ``watchCount`` across all issues in the project.
+
+    Each ``issue.fields.watches.watchCount`` is the number of distinct
+    users watching that issue. Summing across project issues gives the
+    total ``(user, issue)`` watch pairs — the same shape OP stores in
+    its ``Watcher`` table (one row per pair).
+
+    Implementation parallels :func:`_paginated_per_issue_field_count`
+    but reads a per-issue *scalar* (``watches.watchCount``) instead of
+    a list length. The whole shared-helper-via-``label`` approach
+    would only make the parameterization noisier here, so this is a
+    near-copy with the value-extraction line as the only divergence.
+    All the pagination correctness invariants from #184 still apply
+    (advance by ``len(page)``, hard cap via ``for...else``, regex-
+    validate the project key).
+    """
+    if not _JIRA_PROJECT_KEY_RE.match(jira_project_key):
+        sys.stderr.write(
+            f"[audit] Jira watcher comparison skipped — invalid project key"
+            f" {jira_project_key!r} (expected uppercase Jira key like 'NRS')\n",
+        )
+        return None
+    try:
+        from src.infrastructure.jira.jira_client import JiraClient
+    except ImportError as exc:
+        sys.stderr.write(
+            f"[audit] Jira watcher comparison skipped — could not import JiraClient: {exc}\n",
+        )
+        return None
+    try:
+        jira = JiraClient()
+        underlying = jira.jira
+        page_size = 100
+        start_at = 0
+        total = 0
+        jql = f'project = "{jira_project_key}"'
+        for _ in range(_PAGINATION_MAX_PAGES):
+            page = underlying.search_issues(
+                jql,
+                startAt=start_at,
+                maxResults=page_size,
+                fields="watches",
+                expand="",
+            )
+            if not page:
+                break
+            for issue in page:
+                watches = getattr(issue.fields, "watches", None)
+                if watches is not None:
+                    total += int(getattr(watches, "watchCount", 0) or 0)
+            start_at += len(page)
+        else:
+            sys.stderr.write(
+                f"[audit] Jira watcher pagination hit the {_PAGINATION_MAX_PAGES}"
+                f"-page safety cap for project {jira_project_key!r} — likely a buggy"
+                " upstream returning the same page repeatedly\n",
+            )
+            return None
+    except Exception as exc:
+        sys.stderr.write(
+            f"[audit] Jira watcher comparison skipped — {type(exc).__name__}: {exc}\n",
+        )
+        sys.stderr.write(traceback.format_exc())
+        return None
+    return total
+
+
 def _fetch_jira_relation_count(jira_project_key: str) -> int | None:
     """Best-effort: count total issue-link records across all issues in the project.
 
@@ -809,6 +911,7 @@ def _execute_audit(jira_project_key: str) -> dict[str, Any]:
     metrics["jira_issue_count"] = _fetch_jira_issue_count(jira_project_key)
     metrics["jira_attachment_count"] = _fetch_jira_attachment_count(jira_project_key)
     metrics["jira_relation_count"] = _fetch_jira_relation_count(jira_project_key)
+    metrics["jira_watcher_count"] = _fetch_jira_watcher_count(jira_project_key)
     return metrics
 
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -792,6 +792,14 @@ def _fetch_jira_watcher_count(jira_project_key: str) -> int | None:
     total ``(user, issue)`` watch pairs — the same shape OP stores in
     its ``Watcher`` table (one row per pair).
 
+    **Permission scope caveat.** ``watchCount`` is filtered by the
+    calling user's *view voters and watchers* project permission. If
+    the audit token has less scope than the migration admin token did,
+    this helper will systematically *under*-report and the classifier
+    will then incorrectly flag ``OP > Jira`` as "duplicates leaked
+    through" — when the real cause is missing audit-token permission.
+    Run the audit with the same scope as the migration ran with.
+
     Implementation parallels :func:`_paginated_per_issue_field_count`
     but reads a per-issue *scalar* (``watches.watchCount``) instead of
     a list length. The whole shared-helper-via-``label`` approach
@@ -833,8 +841,18 @@ def _fetch_jira_watcher_count(jira_project_key: str) -> int | None:
                 break
             for issue in page:
                 watches = getattr(issue.fields, "watches", None)
-                if watches is not None:
-                    total += int(getattr(watches, "watchCount", 0) or 0)
+                if watches is None:
+                    continue
+                # ``python-jira`` usually returns ``Watcher`` resource
+                # objects but some code paths (raw cache, partial
+                # responses) yield a dict. ``getattr`` on a dict
+                # returns the default and would silently zero the
+                # count — explicitly branch on shape.
+                if isinstance(watches, dict):
+                    raw_count = watches.get("watchCount", 0)
+                else:
+                    raw_count = getattr(watches, "watchCount", 0)
+                total += int(raw_count or 0)
             start_at += len(page)
         else:
             sys.stderr.write(


### PR DESCRIPTION
## Summary

Phase 3b after #185 (relations). Per `MIGRATION_SPEC.md` line 40: watchers "should equal" Jira's count — ±5% tolerance lets the audit catch real regressions while tolerating locked/disabled users whose watches can't carry over.

## What's new

`_fetch_jira_watcher_count` paginates `search_issues(fields="watches")` and sums `issue.fields.watches.watchCount` per issue. Each `watchCount` is distinct watching users on that issue; the sum gives total `(user, issue)` watch pairs — the same shape OP stores in `Watcher`. Direct comparison, **no halving needed** (unlike relations).

Classifier rule mirrors the relation one: zero/zero healthy, in-tolerance silent, out-of-tolerance failure with delta + direction + cause hint. `None` warns; missing key silent.

## Why a near-copy of `_paginated_per_issue_field_count`?

The shared helper sums *list lengths* (`len(issue.fields.attachment)`). Watchers need a per-issue *scalar* (`watches.watchCount`). Parameterizing value-extraction would muddy the helper for only two callers. The copy is intentional — pagination correctness invariants from #184 (advance by `len(page)`, hard cap, regex-validate project key) are preserved.

## Test plan

- [x] 6 new unit tests pin band, both directions, zero/zero, None warning, missing-key silent
- [x] 71/71 unit tests passing
- [x] Local lint + format clean
- [ ] CI sweep