### PR TITLE
docs(spec): document audit ruleset (PRs #175 → #186)

### DIFF
--- a/docs/MIGRATION_SPEC.md
+++ b/docs/MIGRATION_SPEC.md
@@ -59,3 +59,76 @@ reports a warning.
 | `spent_on` | `jira.worklog.started` parsed to a Date | **must** match the original date (UTC tolerance) |
 | `comments` | `jira.worklog.comment` | **should** match (truncated to 1000 chars) |
 | Provenance CF `J2O Origin Worklog Key` | `<issue_key>:<worklog_id>` | **must** be populated for dedup on re-run |
+
+## Audit ruleset
+
+`tools/audit_migrated_project.py` enforces the spec above as a set of
+named rules. Each rule emits either a **failure** (non-zero exit code,
+blocks merge gates) or a **warning** (informational). The table is the
+authoritative list — add entries here when introducing new rules so
+operators have a single reference for what the audit checks.
+
+### OP-side rules (no Jira required)
+
+| Rule | Severity | Trigger | Spec line | Added |
+|---|---|---|---|---|
+| Audit aborted | failure | Ruby returns `error` (project not found) | — | #175 |
+| No work packages | failure | `wp_total == 0` | — | #175 |
+| Missing `author_id` | failure | `wp_with_author < wp_total` | per-WP `author_id` | #175 |
+| Missing `subject` | failure | `wp_with_subject < wp_total` | per-WP `subject` | #175 |
+| Bug A (assignee coverage) | failure | `wp_with_assignee / wp_total < 5%` | per-WP `assigned_to_id` | #175 |
+| Bug E (timestamps) | failure | `>50%` of WPs created in last 24h | per-WP `created_at` | #175 |
+| Bug D (WP CFs missing) | failure | Any of the 8 `WorkPackageCustomField` provenance CFs absent | per-instance | #175 |
+| Bug D (User CFs missing) | failure | Any of the 4 `UserCustomField` provenance CFs absent | per-instance | #175 |
+| Bug D (TE CFs missing) | failure | Any of the 6 `TimeEntryCustomField` provenance CFs absent | per-instance | #175 |
+| Bug B (TE hours uniform) | failure | All TE hours collapsed to one value | per-instance | #175 |
+| TE Worklog Key population | failure | `te_with_worklog_key < te_total` | per-TE worklog key | #179 |
+| WP type/status/priority NULL | failure | `wp_with_type/status/priority < wp_total` | per-WP `type_id`/`status_id`/`priority_id` | #176 |
+| Journal count below WP count | failure | `wp_journal_total < wp_total` (Rails auto-emits ≥1 per create) | per-instance | #176 |
+| WP CF format violation | failure | Any populated WP provenance CF value doesn't match its regex | per-WP provenance | #178 |
+| TE CF format violation | failure | `J2O Origin Worklog Key` value doesn't match `<KEY>:<id>` or `tempo:<id>` | per-TE worklog key | #181 |
+| User CF format violation | failure | `J2O Origin System` or `J2O External URL` value malformed | per-User provenance | #182 |
+| Orphan relations | failure | Any `Relation` references a deleted WP | per-instance | #177 |
+| Orphan watchers | failure | Any `Watcher` references a deleted user | per-instance | #177 |
+| Zero relations on big project | warning | `wp_total >= 50 ∧ relation_total == 0` | per-instance | #176 |
+| Zero watchers on big project | warning | `wp_total >= 50 ∧ wp_watcher_total == 0` | per-instance | #176 |
+| Description coverage low | warning | `<50%` of WPs have a description | per-WP `description` | #175 |
+
+### Source-side rules (require Jira credentials)
+
+Each compares an OP-side count to the Jira source. When Jira is
+unreachable, every source-side rule degrades to a **warning** ("source
+unavailable") rather than blocking — operators may legitimately run
+the audit without Jira creds, and the OP-side rules still produce a
+useful report.
+
+| Rule | Severity | Trigger | Spec line | Added |
+|---|---|---|---|---|
+| Issue count mismatch | failure | `jira_issue_count != wp_total` (exact) | per-instance (issues exact) | #183 |
+| Attachment count mismatch | failure | `jira_attachment_count != wp_attachment_total` (exact) | per-collection attachments | #184 |
+| Relation count drift | failure | `&#124;Δ&#124; / jira_relation_count > 5%` | per-collection relations ±5% | #185 |
+| Watcher count drift | failure | `&#124;Δ&#124; / jira_watcher_count > 5%` | per-collection watchers | #186 |
+| Source unavailable (any of the 4) | warning | Jira fetch returned `None` | — | #183–#186 |
+
+### Hardening contracts
+
+- **Ruby/Python schema-skew guard.** Numeric metrics flow through
+  `_metric_int(metrics, key)` which coerces both *missing key* and
+  `None`-value to `0`. A future Ruby change emitting `null` doesn't
+  crash `_classify`; a stale Ruby script omitting a key fires the
+  rule loud rather than silently passing. (#176, #180)
+- **Pagination safety.** Every Jira-side helper paginates by
+  advancing `start_at += len(page)` (NOT by the requested
+  `page_size` — Jira Server caps `maxResults` and the obvious
+  heuristic silently truncates after page 1). A `for…else` cap at
+  `_PAGINATION_MAX_PAGES` defends against a buggy upstream returning
+  the same page repeatedly. (#184, #185)
+- **JQL-injection guard.** Project keys are regex-validated against
+  `\A[A-Z][A-Z0-9_]+\z` before being interpolated into JQL — a stray
+  quote in argv would otherwise silently change the query scope. (#184)
+- **Best-effort error contract.** All Jira-side helpers log
+  `type(exc).__name__: str(exc)` plus `traceback.format_exc()` to
+  stderr and return `None` on any failure. The classifier converts
+  `None` to a "source unavailable" warning. The forensic trail lets
+  operators distinguish "no creds" (expected) from "JiraClient
+  broken" (a real bug). (#183)


### PR DESCRIPTION
## Summary

\`MIGRATION_SPEC.md\` hasn't been touched since #175 introduced the audit tool. In the 11 PRs since, the audit has grown to **21 OP-side rules + 4 source-side comparisons + 4 hardening contracts** with no single reference. Operators running \`audit_migrated_project.py\` had to grep \`_classify\` to understand what the failures meant.

## What's new

Three new tables in \`docs/MIGRATION_SPEC.md\`:

1. **OP-side rules** — every rule with severity, trigger, spec line, and the PR that added it.
2. **Source-side rules** — the 4 Jira comparisons (issues exact, attachments exact, relations ±5%, watchers ±5%) + the unified "source unavailable" degradation.
3. **Hardening contracts** — the four cross-cutting invariants (null-coercion, pagination safety, JQL-injection guard, best-effort error trail) so future maintainers don't strip them as "defensive overengineering".

The "Added" column gives every rule a citation — a future PR dropping a rule must explain why the pinning PR's class of bug no longer applies.

## Test plan

- [x] Pure docs change — 72/72 unit tests still passing
- [x] Local lint clean
- [ ] CI sweep