### PR TITLE
fix(audit): escape forward slash in User Origin System regex

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -926,6 +926,47 @@ def test_fetch_jira_relation_count_propagates_none_from_paginator(monkeypatch) -
     assert audit_mod._fetch_jira_relation_count("NRS") is None
 
 
+def test_audit_regexes_have_no_unescaped_forward_slash_in_ruby_literal() -> None:
+    """Every audit regex must be safe to embed in a Ruby ``/.../`` literal.
+
+    Ruby's regex literal terminates at any unescaped ``/`` — even one
+    inside a character class. Python's ``re`` engine has no equivalent
+    rule (no literal syntax), so the unit-test loop happily accepts a
+    pattern that crashes on the live audit. Pin all three regex maps
+    here so the next slash-in-charclass slip fails CI instead of a
+    real audit run.
+
+    Caught a real bug shipped in #182: the Origin System pattern
+    had an unescaped forward slash inside its character class which
+    broke the Ruby parser when the script was loaded in the OP
+    rails console.
+    """
+    import re as _re
+
+    from tools.audit_migrated_project import (
+        _TE_CF_FORMAT_REGEXES,
+        _USER_CF_FORMAT_REGEXES,
+        _WP_CF_FORMAT_REGEXES,
+    )
+
+    # Match an unescaped ``/`` — i.e. one not preceded by a backslash.
+    # Negative lookbehind handles the simple case; doubled backslash
+    # before slash (escape of escape) isn't a pattern any of these
+    # specs use, so the simple lookbehind is correct here.
+    unescaped_slash = _re.compile(r"(?<!\\)/")
+    for label, regexes in (
+        ("WP", _WP_CF_FORMAT_REGEXES),
+        ("User", _USER_CF_FORMAT_REGEXES),
+        ("TE", _TE_CF_FORMAT_REGEXES),
+    ):
+        for cf_name, pattern in regexes:
+            assert not unescaped_slash.search(pattern), (
+                f"{label} CF regex {cf_name!r} contains an unescaped '/'"
+                f" — this WILL break the Ruby /.../ literal at audit run time:\n"
+                f"  {pattern}"
+            )
+
+
 def test_fetch_jira_attachment_count_rejects_invalid_project_key() -> None:
     """Malformed project keys must not be interpolated into JQL.
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -90,7 +90,13 @@ _USER_CF_FORMAT_REGEXES: tuple[tuple[str, str], ...] = (
     # falls back to ``config.jira_config["deployment"]`` which is a
     # free-form string that may contain parens, slashes, or hyphens
     # (e.g. ``"Jira (Server)"``, ``"Jira Data-Center"``).
-    ("J2O Origin System", r"\AJira(?:\s[\w\s.()\-/]*)?\z"),
+    # Forward slash inside the character class MUST be escaped — the
+    # Ruby ``/.../`` regex literal terminates at any unescaped ``/``,
+    # even one inside ``[...]``. Without ``\/`` the audit's generated
+    # Ruby script ends up with a syntax error at load time. Python's
+    # ``re`` engine accepts the unescaped form (no ``/.../`` literal
+    # syntax), so the regression is invisible to the unit-test loop.
+    ("J2O Origin System", r"\AJira(?:\s[\w\s.()\-\/]*)?\z"),
     # ``ViewProfile.jspa?<param>=<value>`` — forward slashes escaped so
     # the Ruby ``/.../`` regex literal doesn't terminate at ``://``.
     ("J2O External URL", r"\Ahttps?:\/\/[^\s]+\/secure\/ViewProfile\.jspa\?[^\s]*\z"),


### PR DESCRIPTION
## Summary

**Caught by a live audit run on NRS** — the Ruby script generated by the audit's \`_build_audit_script\` crashed at \`load\` time with a \`SyntaxError\` on the user_cf_format_violations hash literal. The Origin System pattern shipped in #182 had an unescaped \`/\` inside its character class:

\`\`\`
\AJira(?:\s[\w\s.()\-/]*)?\z
\`\`\`

When interpolated into Ruby's \`/.../\` regex literal, the inner \`/\` terminates the literal prematurely. Result: every audit run silently does nothing on the OP side, polls for a result file that never appears, and times out (595 s on the NRS run).

Python's \`re\` engine has no literal syntax, so the unit-test loop happily accepted the broken pattern. **Same class of bug** as the URL pattern's \`\/\` escape (PR #178), but the User-side regex in #182 missed it.

## Fix

1. **Pattern**: \`[\w\s.()\-/]\` → \`[\w\s.()\-\/]\`. Behavior identical in both engines.
2. **Regression guard**: \`test_audit_regexes_have_no_unescaped_forward_slash_in_ruby_literal\` scans all three regex maps and fails CI on any new unescaped \`/\`.

## Test plan

- [x] Generated Ruby manually re-inspected; \`{... 'J2O Origin System' => /\AJira(?:\s[\w\s.()\-\/]*)?\z/ ...}\` now parses
- [x] 73/73 unit tests passing including the new guard
- [x] Local lint + format clean
- [ ] CI sweep
- [ ] Live audit re-run (in parallel with this PR's CI)