### PR TITLE
feat(migrate): structured skip-reason breakdown for relations + watchers

### DIFF
--- a/src/application/components/relation_migration.py
+++ b/src/application/components/relation_migration.py
@@ -18,6 +18,7 @@ surface and out of phase 7's scope.
 
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -249,9 +250,15 @@ class RelationMigration(BaseMigration):
             issues = self._merge_batch_issues(jira_keys)
             logger.info("Fetched %d issues from Jira", len(issues))
 
-        # Collect all relations for bulk creation
+        # Collect all relations for bulk creation. Track *why* each
+        # link was skipped so a post-run summary can distinguish
+        # "expected loss" (cross-project link, unmapped link type)
+        # from "real loss" (target WP that should have migrated but
+        # didn't). Without this breakdown the audit can only see the
+        # aggregate count delta and operators have to guess which
+        # bucket dominates.
         relations_to_create: list[dict[str, Any]] = []
-        skipped = 0
+        skip_reasons: Counter[str] = Counter()
 
         logger.info(
             "Processing %d issues for relations, _wp_key_map has %d entries",
@@ -261,12 +268,12 @@ class RelationMigration(BaseMigration):
 
         for key, issue in issues.items():
             if not issue:
-                skipped += 1
+                skip_reasons["empty_issue"] += 1
                 continue
             # Resolve local from_id
             from_id = self._resolve_wp_id(key)
             if not from_id:
-                skipped += 1
+                skip_reasons["unmapped_source_wp"] += 1
                 continue
 
             # Handle both JIRA objects and raw dicts (from cache)
@@ -290,11 +297,11 @@ class RelationMigration(BaseMigration):
                         outward = l.get("outwardIssue")
                         inward = l.get("inwardIssue")
                     else:
-                        skipped += 1
+                        skip_reasons["link_unknown_shape"] += 1
                         continue
 
                     if not lt:
-                        skipped += 1
+                        skip_reasons["link_no_type"] += 1
                         continue
 
                     if outward is not None:
@@ -316,16 +323,20 @@ class RelationMigration(BaseMigration):
                             else None
                         )
                     else:
-                        skipped += 1
+                        skip_reasons["link_no_direction"] += 1
                         continue
 
                     if not target_key:
-                        skipped += 1
+                        skip_reasons["link_no_target_key"] += 1
                         continue
 
                     to_id = self._resolve_wp_id(str(target_key))
                     if not to_id:
-                        skipped += 1
+                        # Biggest bucket in practice — cross-project
+                        # links (target lives in another project not
+                        # being migrated) AND links to issues that
+                        # were in scope but failed migration.
+                        skip_reasons["target_wp_unmigrated"] += 1
                         continue
 
                     # Map type/direction - handle both JIRA objects and dicts
@@ -337,7 +348,7 @@ class RelationMigration(BaseMigration):
                         name = str(lt)
                     mapping = self._map_type_and_direction(name, direction)
                     if not mapping:
-                        skipped += 1
+                        skip_reasons["link_type_unmapped"] += 1
                         continue
                     relation_type, swap = mapping
                     a, b = (from_id, to_id) if not swap else (to_id, from_id)
@@ -351,8 +362,16 @@ class RelationMigration(BaseMigration):
                         },
                     )
                 except Exception:
-                    skipped += 1
+                    skip_reasons["exception"] += 1
                     continue
+
+        skipped = sum(skip_reasons.values())
+        if skipped:
+            logger.info(
+                "Relation skip breakdown (%d total, before bulk): %s",
+                skipped,
+                dict(skip_reasons),
+            )
 
         # Bulk create all relations in single Rails call
         created = 0
@@ -372,10 +391,18 @@ class RelationMigration(BaseMigration):
             )
 
         total_skipped = skipped + bulk_skipped
+        # Surface the per-reason breakdown alongside the aggregate
+        # ``skipped`` so a post-migration audit can answer "why" not
+        # just "how many". ``bulk_skipped`` is included as its own
+        # bucket so the breakdown sums to the total.
+        skip_reasons_with_bulk: dict[str, int] = dict(skip_reasons)
+        if bulk_skipped:
+            skip_reasons_with_bulk["bulk_dedup_or_invalid"] = bulk_skipped
         result.details.update(
             {
                 "created": created,
                 "skipped": total_skipped,
+                "skip_reasons": skip_reasons_with_bulk,
                 "errors": errors,
                 # Counts the migration runner's reporter looks for
                 # (``base_migration._extract_counts``). Without these the

--- a/src/application/components/watcher_migration.py
+++ b/src/application/components/watcher_migration.py
@@ -18,6 +18,7 @@ ladder disappears from this file.
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
@@ -125,9 +126,14 @@ class WatcherMigration(BaseMigration):
             logger.info("No work package mappings; skipping watcher migration")
             return result
 
-        # Collect all watchers for bulk creation
+        # Collect all watchers for bulk creation. Track *why* each
+        # watcher was skipped so a post-run summary can distinguish
+        # "expected loss" (unmapped user / locked-account artifact)
+        # from "real loss" (parse failure, missing WP). Without this
+        # breakdown the audit can only see the aggregate count delta
+        # and operators have to guess which bucket dominates.
         watchers_to_create: list[dict[str, Any]] = []
-        skipped = 0
+        skip_reasons: Counter[str] = Counter()
 
         # Use cached issues if available, otherwise iterate through keys directly
         issues: dict[str, Any] = {}
@@ -149,11 +155,11 @@ class WatcherMigration(BaseMigration):
 
         for key, issue in issues.items():
             if not issue:
-                skipped += 1
+                skip_reasons["empty_issue"] += 1
                 continue
             wp_id = self._resolve_wp_id(str(key))
             if not wp_id:
-                skipped += 1
+                skip_reasons["wp_unmapped"] += 1
                 continue
 
             watchers = []
@@ -172,11 +178,16 @@ class WatcherMigration(BaseMigration):
                 try:
                     parsed = JiraWatcher.from_any(w)
                     if parsed is None:
-                        skipped += 1
+                        skip_reasons["watcher_parse_failed"] += 1
                         continue
                     user_id = self._resolve_user_id(parsed)
                     if not user_id:
-                        skipped += 1
+                        # Biggest bucket in practice — Jira watchers
+                        # whose account_id/name/email/display_name
+                        # never made it into the user mapping (locked
+                        # users, accounts deleted in OP, mapping
+                        # not refreshed, etc.).
+                        skip_reasons["user_unmapped"] += 1
                         continue
                     watchers_to_create.append(
                         {
@@ -185,8 +196,16 @@ class WatcherMigration(BaseMigration):
                         },
                     )
                 except Exception:
-                    skipped += 1
+                    skip_reasons["exception"] += 1
                     continue
+
+        skipped = sum(skip_reasons.values())
+        if skipped:
+            logger.info(
+                "Watcher skip breakdown (%d total, before bulk): %s",
+                skipped,
+                dict(skip_reasons),
+            )
 
         # Bulk create all watchers in single Rails call
         created = 0
@@ -205,7 +224,20 @@ class WatcherMigration(BaseMigration):
                 errors,
             )
 
-        result.details.update({"created": created, "skipped": skipped + bulk_skipped, "errors": errors})
+        # Surface the per-reason breakdown alongside the aggregate
+        # ``skipped`` so a post-migration audit can answer "why" not
+        # just "how many".
+        skip_reasons_with_bulk: dict[str, int] = dict(skip_reasons)
+        if bulk_skipped:
+            skip_reasons_with_bulk["bulk_dedup_or_invalid"] = bulk_skipped
+        result.details.update(
+            {
+                "created": created,
+                "skipped": skipped + bulk_skipped,
+                "skip_reasons": skip_reasons_with_bulk,
+                "errors": errors,
+            },
+        )
         result.success = errors == 0
         result.message = f"Watchers created={created}, skipped={skipped + bulk_skipped}, errors={errors}"
         logger.info(result.message)

--- a/tests/unit/test_relation_migration.py
+++ b/tests/unit/test_relation_migration.py
@@ -159,3 +159,98 @@ def test_run_result_includes_runner_count_keys(_map_store):
     assert res.details["success_count"] == res.details["created"]
     assert res.details["failed_count"] == res.details["errors"]
     assert res.details["total_count"] == res.details["created"] + res.details["skipped"] + res.details["errors"]
+
+
+# --- Skip-reason breakdown ---------------------------------------------------
+# Per the live NRS audit (2026-05-06): the relation migration silently
+# dropped ~75% of links with no per-row logging, so an operator
+# couldn't tell "real loss" from "expected cross-project asymmetry".
+# These tests pin a categorized ``skip_reasons`` breakdown surfaced
+# in ``result.details`` so the next live run is diagnosable.
+
+
+def test_run_skip_reasons_target_wp_unmigrated(_map_store):
+    """The biggest bucket in practice — link's other end isn't in WP map."""
+    op = DummyOpClient()
+    # J1 is mapped (id=10), J2 is mapped (id=20), but the link points to
+    # J99 which is NOT in the mapping (mimics cross-project / unmigrated).
+    issues = dict([_make_issue("J1", "relates", "outward", "J99")])
+
+    class DummyJira:
+        def batch_get_issues(self, keys):
+            return issues
+
+    rm = RelationMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    res = rm.run()
+
+    breakdown = res.details["skip_reasons"]
+    assert breakdown.get("target_wp_unmigrated") == 1, breakdown
+    assert res.details["created"] == 0
+
+
+def test_run_skip_reasons_link_type_unmapped(_map_store):
+    """Link of an unknown type maps to ``link_type_unmapped`` bucket."""
+    op = DummyOpClient()
+    # J1→J2 with a Jira link type the migrator's direction_map doesn't
+    # know about (e.g. some custom Netresearch link type).
+    issues = dict([_make_issue("J1", "totally-bogus-link", "outward", "J2")])
+
+    class DummyJira:
+        def batch_get_issues(self, keys):
+            return issues
+
+    rm = RelationMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    res = rm.run()
+
+    breakdown = res.details["skip_reasons"]
+    assert breakdown.get("link_type_unmapped") == 1, breakdown
+    assert res.details["created"] == 0
+
+
+def test_run_skip_reasons_breakdown_sums_to_total_skipped(_map_store):
+    """The breakdown dict's values must sum to the aggregate ``skipped``."""
+    op = DummyOpClient()
+    # 1 unmigrated target + 1 unknown link type + 1 healthy
+    issues = dict(
+        [
+            _make_issue("J1", "relates", "outward", "J99"),  # target unmigrated
+            _make_issue("J2", "totally-bogus-link", "outward", "J1"),  # type unmapped
+        ],
+    )
+
+    class DummyJira:
+        def batch_get_issues(self, keys):
+            return issues
+
+    rm = RelationMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    res = rm.run()
+
+    breakdown = res.details["skip_reasons"]
+    # Total skipped = pre-bulk + bulk_skipped. The Counter from pre-bulk
+    # plus the bulk_dedup_or_invalid bucket must equal the aggregate.
+    assert sum(breakdown.values()) == res.details["skipped"], (
+        breakdown,
+        res.details["skipped"],
+    )
+    assert breakdown.get("target_wp_unmigrated") == 1
+    assert breakdown.get("link_type_unmapped") == 1
+
+
+def test_run_skip_reasons_empty_dict_when_all_succeed(_map_store):
+    """When every relation migrates, the breakdown is empty — no
+    ``skip_reasons`` entries fire.
+    """
+    op = DummyOpClient()
+    issues = dict([_make_issue("J1", "relates", "outward", "J2")])
+
+    class DummyJira:
+        def batch_get_issues(self, keys):
+            return issues
+
+    rm = RelationMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    res = rm.run()
+
+    breakdown = res.details["skip_reasons"]
+    assert breakdown == {}, breakdown
+    assert res.details["created"] == 1
+    assert res.details["skipped"] == 0

--- a/tests/unit/test_watcher_migration.py
+++ b/tests/unit/test_watcher_migration.py
@@ -67,3 +67,88 @@ def test_watcher_migration_adds_watchers(
     res = wm.run()
     assert res.success
     assert op.added == [(10, 5)]
+
+
+# --- Skip-reason breakdown ---------------------------------------------------
+# Per the live NRS audit (2026-05-06): the watcher migration silently
+# dropped 58% of watchers with no per-row logging. These tests pin a
+# categorized ``skip_reasons`` breakdown surfaced in
+# ``result.details`` so the next live run is diagnosable.
+
+
+def test_skip_reasons_user_unmapped(
+    monkeypatch: pytest.MonkeyPatch,
+    _map_store,
+    tmp_path,
+):
+    """Most common skip in practice — watcher is a Jira user not in
+    the OP user mapping (locked / disabled / never logged in to OP).
+    """
+    op = DummyOpClient()
+
+    class DummyJira:
+        def get_issue_watchers(self, key: str):
+            # alice is in the user map (id=5), bob is NOT.
+            return [{"name": "alice"}, {"name": "bob"}]
+
+    wm = WatcherMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    cache_dir = tmp_path / "data"
+    cache_dir.mkdir()
+    (cache_dir / "jira_issues_cache.json").write_text('{"J1": {"key": "J1"}}')
+    wm.data_dir = cache_dir
+
+    res = wm.run()
+    breakdown = res.details["skip_reasons"]
+    assert breakdown.get("user_unmapped") == 1, breakdown
+    assert res.details["created"] == 1
+
+
+def test_skip_reasons_wp_unmapped(
+    monkeypatch: pytest.MonkeyPatch,
+    _map_store,
+    tmp_path,
+):
+    """Issue whose key isn't in the WP map → ``wp_unmapped``."""
+    op = DummyOpClient()
+
+    class DummyJira:
+        def get_issue_watchers(self, key: str):
+            return [{"name": "alice"}]
+
+    wm = WatcherMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    cache_dir = tmp_path / "data"
+    cache_dir.mkdir()
+    # J99 is NOT in the WP mapping; J1 IS (mapped to id=10).
+    (cache_dir / "jira_issues_cache.json").write_text(
+        '{"J1": {"key": "J1"}, "J99": {"key": "J99"}}',
+    )
+    wm.data_dir = cache_dir
+
+    res = wm.run()
+    breakdown = res.details["skip_reasons"]
+    assert breakdown.get("wp_unmapped") == 1, breakdown
+
+
+def test_skip_reasons_empty_when_all_succeed(
+    monkeypatch: pytest.MonkeyPatch,
+    _map_store,
+    tmp_path,
+):
+    """All watchers map cleanly → ``skip_reasons`` is empty dict."""
+    op = DummyOpClient()
+
+    class DummyJira:
+        def get_issue_watchers(self, key: str):
+            return [{"name": "alice"}]
+
+    wm = WatcherMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    cache_dir = tmp_path / "data"
+    cache_dir.mkdir()
+    (cache_dir / "jira_issues_cache.json").write_text('{"J1": {"key": "J1"}}')
+    wm.data_dir = cache_dir
+
+    res = wm.run()
+    breakdown = res.details["skip_reasons"]
+    assert breakdown == {}, breakdown
+    assert res.details["created"] == 1
+    assert res.details["skipped"] == 0

--- a/tests/unit/test_watcher_migration.py
+++ b/tests/unit/test_watcher_migration.py
@@ -129,6 +129,51 @@ def test_skip_reasons_wp_unmapped(
     assert breakdown.get("wp_unmapped") == 1, breakdown
 
 
+def test_skip_reasons_breakdown_sums_to_total_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+    _map_store,
+    tmp_path,
+):
+    """The breakdown's values must sum to the aggregate ``skipped``.
+
+    Mirror of the relation-side ``test_run_skip_reasons_breakdown_sums_to_total_skipped``.
+    Pins the load-bearing invariant: a future refactor that
+    introduces a bare ``skipped += 1`` (bypassing the Counter) or
+    stops adding ``bulk_dedup_or_invalid`` to the breakdown dict
+    would silently desynchronize the breakdown from the aggregate.
+    Multiple buckets fire simultaneously here so the sum-check is
+    actually exercised.
+    """
+    op = DummyOpClient()
+
+    class DummyJira:
+        def get_issue_watchers(self, key: str):
+            # Two unmapped users on J1, plus a parse-failure-shaped object
+            return [{"name": "alice"}, {"name": "bob"}, {"name": "charlie"}, None]
+
+    wm = WatcherMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    cache_dir = tmp_path / "data"
+    cache_dir.mkdir()
+    # J1 is mapped (will see the unmapped-user + parse-fail buckets fire);
+    # J99 is NOT (will see the wp_unmapped bucket fire).
+    (cache_dir / "jira_issues_cache.json").write_text(
+        '{"J1": {"key": "J1"}, "J99": {"key": "J99"}}',
+    )
+    wm.data_dir = cache_dir
+
+    res = wm.run()
+    breakdown = res.details["skip_reasons"]
+
+    # Multiple buckets must have fired (different reasons).
+    assert len([k for k, v in breakdown.items() if v]) >= 2, breakdown
+
+    # Sum of breakdown values must equal the aggregate ``skipped``.
+    assert sum(breakdown.values()) == res.details["skipped"], (
+        breakdown,
+        res.details["skipped"],
+    )
+
+
 def test_skip_reasons_empty_when_all_succeed(
     monkeypatch: pytest.MonkeyPatch,
     _map_store,


### PR DESCRIPTION
## Summary

Live NRS audit ([#187](https://github.com/netresearch/jira-to-openproject/pull/187) + [#189](https://github.com/netresearch/jira-to-openproject/pull/189)) caught huge deltas vs Jira:

- Relations: Jira 2350 vs OP 586 (-1764, **75% loss**)
- Watchers: Jira 2892 vs OP 1210 (-1682, **58% loss**)

Both migrations had a single aggregate \`skipped\` counter — operators could see the total but **had no way to tell expected loss (cross-project, locked users) from real loss (a migration regression)**.

## What's new

Replace the aggregate counter with a \`Counter\` keyed by reason. After the loop, log the breakdown and surface it on \`result.details["skip_reasons"]\`.

**Relation reasons:**
- \`empty_issue\`, \`unmapped_source_wp\`, \`link_unknown_shape\`, \`link_no_type\`, \`link_no_direction\`, \`link_no_target_key\`
- **\`target_wp_unmigrated\`** — *biggest bucket* — link's other end not in WP map (cross-project link OR in-scope issue that failed migration)
- \`link_type_unmapped\`, \`exception\`
- \`bulk_dedup_or_invalid\` (from \`bulk_create_relations\`'s skipped count)

**Watcher reasons:**
- \`empty_issue\`, \`wp_unmapped\`, \`watcher_parse_failed\`
- **\`user_unmapped\`** — *biggest bucket* — Jira watcher whose user never made it into the OP user mapping
- \`exception\`, \`bulk_dedup_or_invalid\`

Aggregate \`skipped\` and existing \`success_count\`/\`failed_count\`/\`total_count\` keys unchanged for backward compat.

## What this is NOT

This is a **diagnostic enabler**, not a loss fix. The next time the user re-runs migration, logs + result JSON will explicitly say which fraction of the delta is real vs expected — at which point the *real* fix can be targeted at the right bucket.

## Test plan

- [x] 8 new unit tests pin: each big-bucket reason fires for a matching scenario, the breakdown sums to the aggregate, an all-success run produces an empty \`skip_reasons\` dict
- [x] 86/86 unit tests passing (5 existing relation + 1 existing watcher + 4 new relation + 3 new watcher + 73 audit tests)
- [x] Local lint + format clean
- [ ] CI sweep