### PR TITLE
fix(users): skip-reason breakdown for avatar sync + double-count fix

### DIFF
--- a/src/application/components/user_migration.py
+++ b/src/application/components/user_migration.py
@@ -778,15 +778,46 @@ class UserMigration(BaseMigration):
             "cache": cache_entry,
         }
 
-    def _sync_user_avatars(self, jobs: list[dict[str, Any]]) -> dict[str, int]:
+    def _sync_user_avatars(self, jobs: list[dict[str, Any]]) -> dict[str, Any]:
+        """Download Jira user avatars and upload them to OpenProject.
+
+        Returns a dict with:
+
+        - ``uploaded`` (int): avatars successfully transferred + set on OP.
+        - ``skipped`` (int): aggregate of *every* job that didn't upload —
+          including idempotent re-run hits. NOT a "real loss" count;
+          inspect ``skip_reasons`` below to subtract the expected
+          buckets (notably ``cached_digest_match``).
+        - ``skip_reasons`` (dict[str, int]): breakdown by reason. Sums
+          to ``skipped`` by construction. Buckets:
+
+          - ``cached_digest_match`` — *expected*; idempotent re-run.
+          - ``download_failed`` — Jira returned no avatar bytes.
+          - ``local_persist_failed`` — host write failed.
+          - ``container_transfer_failed`` — ``docker cp`` raised.
+          - ``set_avatar_api_raised`` — OP API call raised an exception.
+          - ``set_avatar_api_returned_false`` — OP API returned
+            cleanly with ``success=False`` (semantic rejection).
+
+        Consumers reading ``skipped`` for alerting / dashboards SHOULD
+        compute ``skipped - skip_reasons.get("cached_digest_match", 0)``
+        for "actual failures" — otherwise idempotent re-runs trigger
+        false alarms.
+        """
         if not jobs:
-            return {"uploaded": 0, "skipped": 0}
+            return {"uploaded": 0, "skipped": 0, "skip_reasons": {}}
 
         try:
             self.op_client.ensure_local_avatars_enabled()
         except Exception as exc:
             self.logger.warning("Failed to ensure local avatars are enabled: %s", exc)
-            return {"uploaded": 0, "skipped": len(jobs)}
+            # Whole batch fails one bucket — surface so consumers can
+            # tell "OP-side avatar feature off" from per-row failures.
+            return {
+                "uploaded": 0,
+                "skipped": len(jobs),
+                "skip_reasons": {"local_avatars_disabled": len(jobs)},
+            }
 
         avatar_dir = self.data_dir / "avatars"
         avatar_dir.mkdir(parents=True, exist_ok=True)

--- a/src/application/components/user_migration.py
+++ b/src/application/components/user_migration.py
@@ -51,6 +51,7 @@ import logging
 import mimetypes
 import re
 import uuid
+from collections import Counter
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -791,7 +792,14 @@ class UserMigration(BaseMigration):
         avatar_dir.mkdir(parents=True, exist_ok=True)
 
         uploaded = 0
-        skipped = 0
+        # Track *why* each avatar was skipped, mirroring the relation
+        # and watcher migrations (PR #190). The aggregate ``skipped``
+        # in the returned dict is preserved for backward compat; the
+        # ``skip_reasons`` breakdown distinguishes "expected"
+        # (``cached_digest_match`` — idempotent re-run, NOT a real
+        # loss) from "real" failures (download / persist / transfer /
+        # set-API).
+        skip_reasons: Counter[str] = Counter()
 
         for job in jobs:
             jira_key = job["jira_key"]
@@ -800,7 +808,7 @@ class UserMigration(BaseMigration):
 
             download = self.jira_client.download_user_avatar(avatar_url)
             if not download:
-                skipped += 1
+                skip_reasons["download_failed"] += 1
                 continue
 
             data, content_type = download
@@ -814,7 +822,7 @@ class UserMigration(BaseMigration):
                     "Skipping avatar upload for %s (digest match)",
                     jira_key,
                 )
-                skipped += 1
+                skip_reasons["cached_digest_match"] += 1
                 continue
 
             ext = self._guess_avatar_extension(content_type, avatar_url)
@@ -825,7 +833,7 @@ class UserMigration(BaseMigration):
                     handle.write(data)
             except Exception as exc:
                 self.logger.warning("Failed to persist avatar for %s: %s", jira_key, exc)
-                skipped += 1
+                skip_reasons["local_persist_failed"] += 1
                 continue
 
             container_name = f"j2o_avatar_{job['openproject_id']}_{uuid.uuid4().hex}.{ext}"
@@ -834,11 +842,12 @@ class UserMigration(BaseMigration):
                 self.op_client.transfer_file_to_container(local_path, container_path)
             except Exception as exc:
                 self.logger.warning("Failed to copy avatar for %s to container: %s", jira_key, exc)
-                skipped += 1
+                skip_reasons["container_transfer_failed"] += 1
                 with suppress(OSError):
                     local_path.unlink()
                 continue
 
+            api_raised = False
             try:
                 result = self.op_client.set_user_avatar(
                     user_id=job["openproject_id"],
@@ -848,7 +857,8 @@ class UserMigration(BaseMigration):
                 )
             except Exception as exc:
                 self.logger.warning("Failed to set avatar for %s: %s", jira_key, exc)
-                skipped += 1
+                skip_reasons["set_avatar_api_raised"] += 1
+                api_raised = True
                 result = {"success": False}
             finally:
                 try:
@@ -868,11 +878,30 @@ class UserMigration(BaseMigration):
                     "digest": digest,
                     "url": avatar_url,
                 }
-            else:
-                skipped += 1
+            elif not api_raised:
+                # ``api_raised=False`` here means the API call returned
+                # cleanly with ``success=False`` — distinct from the
+                # raised case (already counted above as
+                # ``set_avatar_api_raised``). The pre-#190 code
+                # incremented ``skipped`` in both branches, double-
+                # counting raised calls; the ``api_raised`` guard
+                # corrects that.
+                skip_reasons["set_avatar_api_returned_false"] += 1
+
+        skipped = sum(skip_reasons.values())
+        if skipped:
+            self.logger.info(
+                "Avatar upload skip breakdown (%d total): %s",
+                skipped,
+                dict(skip_reasons),
+            )
 
         self._save_avatar_cache()
-        return {"uploaded": uploaded, "skipped": skipped}
+        return {
+            "uploaded": uploaded,
+            "skipped": skipped,
+            "skip_reasons": dict(skip_reasons),
+        }
 
     def _guess_avatar_extension(self, content_type: str, avatar_url: str) -> str:
         candidate = ""

--- a/tests/unit/test_user_avatar_sync.py
+++ b/tests/unit/test_user_avatar_sync.py
@@ -58,7 +58,7 @@ def _job(jira_key: str, cache: dict[str, str] | None = None) -> dict[str, object
 def test_sync_user_avatars_uploads_and_caches(migration: UserMigration):
     result = migration._sync_user_avatars([_job("USER1")])
 
-    assert result == {"uploaded": 1, "skipped": 0}
+    assert result == {"uploaded": 1, "skipped": 0, "skip_reasons": {}}
     assert "USER1" in migration._avatar_cache
     assert migration.op_client.ensure_local_avatars_enabled.called
     migration.op_client.transfer_file_to_container.assert_called_once()
@@ -88,6 +88,76 @@ def test_sync_user_avatars_skips_when_digest_matches(migration: UserMigration):
         [_job("USER1", cache=migration._avatar_cache["USER1"])],
     )
 
-    assert result == {"uploaded": 0, "skipped": 1}
+    # Idempotent re-run: cached digest match. The ``skip_reasons``
+    # breakdown lets an operator subtract this "expected" skip from
+    # the aggregate when interpreting an audit run — it is NOT a
+    # real loss.
+    assert result == {
+        "uploaded": 0,
+        "skipped": 1,
+        "skip_reasons": {"cached_digest_match": 1},
+    }
     migration.op_client.transfer_file_to_container.assert_not_called()
     migration.op_client.set_user_avatar.assert_not_called()
+
+
+def test_sync_user_avatars_set_avatar_raise_counts_once_not_twice(
+    migration: UserMigration,
+):
+    """Pre-#190 double-count regression guard.
+
+    The old code incremented ``skipped`` twice on a raised
+    ``set_user_avatar`` call: once in the ``except`` block, then
+    *again* in the post-finally ``else`` branch (because the except
+    set ``result = {"success": False}``). That made the aggregate
+    ``skipped`` overcount transient API failures by 2x. The
+    ``api_raised`` guard in the refactored code counts each failure
+    exactly once.
+    """
+    # Force the API call to raise — so the except path fires.
+    migration.op_client.set_user_avatar.side_effect = RuntimeError("boom")
+
+    result = migration._sync_user_avatars([_job("USER_RAISE")])
+
+    # 1 failed avatar = 1 skip, NOT 2 (the pre-#190 bug).
+    assert result["skipped"] == 1, result
+    assert result["uploaded"] == 0
+    # And only the "raised" bucket fires; the "returned_false"
+    # bucket must stay empty so an operator can tell network/raise
+    # failures from semantic-rejection failures.
+    breakdown = result["skip_reasons"]
+    assert breakdown.get("set_avatar_api_raised") == 1, breakdown
+    assert breakdown.get("set_avatar_api_returned_false", 0) == 0, breakdown
+
+
+def test_sync_user_avatars_skip_reasons_sum_to_aggregate(migration: UserMigration):
+    """The breakdown's values must sum to the aggregate ``skipped``.
+
+    Mirror of the relation/watcher sum-equality tests. Pins the
+    invariant against future refactor regressions where a bare
+    ``skipped += 1`` slips back in.
+    """
+    # Three jobs, each hitting a different bucket.
+    migration.jira_client.download_user_avatar.side_effect = [
+        None,  # download fail
+        (b"x", "image/png"),  # success → uploaded
+        (b"x", "image/png"),  # success → uploaded
+    ]
+
+    # Make the SECOND avatar's set_user_avatar raise; the third
+    # returns success=False cleanly.
+    migration.op_client.set_user_avatar.side_effect = [
+        RuntimeError("transient"),
+        {"success": False},
+    ]
+
+    jobs = [_job("U1"), _job("U2"), _job("U3")]
+    result = migration._sync_user_avatars(jobs)
+
+    breakdown = result["skip_reasons"]
+    assert sum(breakdown.values()) == result["skipped"], (breakdown, result)
+    # Three distinct buckets fired (each test case hit a different
+    # failure mode):
+    assert breakdown["download_failed"] == 1
+    assert breakdown["set_avatar_api_raised"] == 1
+    assert breakdown["set_avatar_api_returned_false"] == 1


### PR DESCRIPTION
## Summary

Continues [#190](https://github.com/netresearch/jira-to-openproject/pull/190)'s skip-reason pattern in \`user_migration._sync_user_avatars\`. Six distinct avatar-sync failure modes were previously collapsed into a single \`skipped\` counter — operators couldn't tell idempotent re-run hits (cached digest matches, NOT real losses) from real transport / API failures.

**Bonus: real bug found and fixed in passing.** The pre-#190 code incremented \`skipped\` *twice* on a raised \`set_user_avatar\` call — once in the \`except\`, then again in the post-finally \`else\` (because \`except\` set \`result["success"]=False\`). The aggregate \`skipped\` over-counted transient API failures by 2x. An \`api_raised\` flag now gates the \`elif\` so each failure counts exactly once.

## New buckets

- \`download_failed\` — Jira \`download_user_avatar\` returned None
- \`cached_digest_match\` — idempotent re-run, **NOT** a real loss
- \`local_persist_failed\` — host write failed
- \`container_transfer_failed\` — \`docker cp\` raised
- \`set_avatar_api_raised\` — OP API call raised
- \`set_avatar_api_returned_false\` — OP API returned cleanly with \`success=False\`

## Test plan

- [x] Updated 2 existing tests for new return shape
- [x] New \`test_sync_user_avatars_set_avatar_raise_counts_once_not_twice\` regression-guards the double-count fix
- [x] New \`test_sync_user_avatars_skip_reasons_sum_to_aggregate\` pins sum-equality (mirrors relation/watcher)
- [x] 93/93 unit tests passing
- [x] Local lint + format clean
- [ ] CI sweep