### PR TITLE
test(audit): pin generated Ruby script parses with ruby -c

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -1040,6 +1040,56 @@ def test_fetch_jira_relation_count_propagates_none_from_paginator(monkeypatch) -
     assert audit_mod._fetch_jira_relation_count("NRS") is None
 
 
+def test_generated_audit_script_parses_as_ruby() -> None:
+    """The generated Ruby script must pass ``ruby -c`` (parse-only).
+
+    Two distinct regex-slash bugs were caught only by live audit runs
+    in this project — PR #178 (URL pattern) and PR #182/#188 (User
+    Origin System pattern). Both shipped because the unit-test loop
+    runs the patterns through Python's ``re``, which has no ``/.../``
+    literal syntax and therefore never sees the parse-time failure.
+
+    This test closes the loop: generate the full Ruby script
+    (including all interpolated regex literals, hash literals, and
+    block syntax) and pipe it to ``ruby -c`` for a parse-only check.
+    Catches the entire class of "valid in Python, broken in Ruby"
+    bugs before they reach production audits — at the cost of a
+    Ruby interpreter on the test runner.
+
+    Skipped if ``ruby`` isn't on PATH (CI environments without Ruby
+    fall through silently rather than failing). The other regex
+    guards in this file (``_audit_regexes_have_no_unescaped_forward_slash_in_ruby_literal``)
+    catch the slash subset without needing Ruby.
+    """
+    import shutil
+    import subprocess
+
+    ruby = shutil.which("ruby")
+    if ruby is None:
+        import pytest as _pytest
+
+        _pytest.skip("ruby not on PATH — script-syntax check needs a Ruby interpreter")
+
+    from tools.audit_migrated_project import _build_audit_script
+
+    script = _build_audit_script("NRS")
+    proc = subprocess.run(
+        [ruby, "-c", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        "Generated audit script failed Ruby parse-check.\n"
+        f"stdout: {proc.stdout!r}\n"
+        f"stderr: {proc.stderr!r}\n"
+        "First 500 chars of script:\n"
+        f"{script[:500]}"
+    )
+    assert "Syntax OK" in proc.stdout, proc.stdout
+
+
 def test_audit_regexes_have_no_unescaped_forward_slash_in_ruby_literal() -> None:
     """Every audit regex must be safe to embed in a Ruby ``/.../`` literal.
 


### PR DESCRIPTION
## Summary

This session caught **two distinct regex-slash bugs ONLY by live audit runs** ([#178](https://github.com/netresearch/jira-to-openproject/pull/178) URL slash, [#182](https://github.com/netresearch/jira-to-openproject/pull/182)/[#188](https://github.com/netresearch/jira-to-openproject/pull/188) Origin System slash). Both shipped because the unit-test loop runs patterns through Python's \`re\`, which has no \`/.../\` literal syntax and never sees the parse-time failure that breaks the live audit.

## What's new

\`test_generated_audit_script_parses_as_ruby\`:

1. Calls \`_build_audit_script("NRS")\` to produce the full Ruby script.
2. Pipes it to \`ruby -c -e <script>\` for a parse-only check.
3. Asserts \`returncode == 0\` and \`"Syntax OK"\` in stdout.

**Confirmed by mutation testing**: with the unescaped-\`/\` form (the #182 bug) \`ruby -c\` exits 1 with the exact SyntaxError that broke the live audit. With the fixed form it exits 0 "Syntax OK". So this test catches the entire bug class — slash escapes, curly-brace mistakes, hash-literal layout, block-syntax mismatches.

## Graceful skip on Ruby-less CI

Skips with a clear message if \`ruby\` isn't on PATH. The in-process \`test_audit_regexes_have_no_unescaped_forward_slash_in_ruby_literal\` (added in #188) covers the slash subset on Ruby-less environments.

## Test plan

- [x] New test passes locally with ruby 4.0.1
- [x] Mutation-tested: confirmed it CATCHES the #182 bug-class when the slash escape is reverted
- [x] 76/76 unit tests passing
- [x] Local lint + format clean
- [ ] CI sweep (will skip if no ruby on the test runner; that's documented behavior)