### PR TITLE
feat(audit): fail on under-populated J2O Origin Key, warn on others

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -1090,6 +1090,75 @@ def test_generated_audit_script_parses_as_ruby() -> None:
     assert "Syntax OK" in proc.stdout, proc.stdout
 
 
+def test_wp_origin_key_under_populated_is_failure() -> None:
+    """``J2O Origin Key`` is a hard-requirement (per spec line 27).
+
+    Caught by the live TEST audit: TEST showed every WP CF with
+    ``populated: 0`` because the migration ran before #175 wired
+    them up. The audit's existing rule only checks ``exists``, not
+    ``populated`` — so the gap was invisible. Without ``J2O Origin
+    Key`` populated, dedup on re-run is broken AND the audit can't
+    identify which Jira issue each WP came from.
+    """
+    metrics = _baseline_metrics()
+    # Override Origin Key to populated=50 (with wp_total=100 baseline)
+    metrics["wp_provenance_cfs"]["J2O Origin Key"] = {
+        "exists": True,
+        "populated": 50,
+    }
+    failures, _warnings = _classify(metrics)
+    assert any("Origin Key" in f and ("populated" in f.lower() or "/100" in f) for f in failures), failures
+
+
+def test_wp_other_cfs_under_populated_is_warning() -> None:
+    """Other WP provenance CFs are 'should' per spec — warning, not failure."""
+    metrics = _baseline_metrics()
+    # ``J2O Origin URL`` is "should" per spec, not hard-required.
+    metrics["wp_provenance_cfs"]["J2O Origin URL"] = {
+        "exists": True,
+        "populated": 70,
+    }
+    failures, warnings = _classify(metrics)
+    # Not in failures
+    assert not any("Origin URL" in f for f in failures), failures
+    # But surfaced as a warning so operators see it
+    assert any("Origin URL" in w for w in warnings), warnings
+
+
+def test_wp_origin_key_fully_populated_passes() -> None:
+    """Healthy state: every WP has Origin Key populated."""
+    metrics = _baseline_metrics()
+    # Baseline already has populated=100 for all CFs; explicit for clarity.
+    metrics["wp_provenance_cfs"]["J2O Origin Key"] = {
+        "exists": True,
+        "populated": 100,
+    }
+    failures, _warnings = _classify(metrics)
+    assert not any("Origin Key" in f for f in failures), failures
+
+
+def test_wp_cf_population_silent_when_cf_missing_entirely() -> None:
+    """If a CF doesn't exist at all, the existing missing-CF rule fires.
+
+    The new under-populated rule must not double-fire — only the
+    missing-CF rule should claim that CF, with a clear "missing"
+    message rather than confusing population numbers.
+    """
+    metrics = _baseline_metrics()
+    metrics["wp_provenance_cfs"]["J2O Origin Key"] = {
+        "exists": False,
+        "populated": 0,
+    }
+    failures, _warnings = _classify(metrics)
+    # The missing-CF rule fires (Bug D indicator)
+    assert any("CFs missing" in f and "Origin Key" in f for f in failures), failures
+    # The new under-populated rule does NOT also fire — would be a
+    # confusing double-message.
+    assert not any("Origin Key" in f and "populated" in f.lower() and "CFs missing" not in f for f in failures), (
+        failures
+    )
+
+
 def test_audit_regexes_have_no_unescaped_forward_slash_in_ruby_literal() -> None:
     """Every audit regex must be safe to embed in a Ruby ``/.../`` literal.
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -404,6 +404,33 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     missing_cfs = [name for name, info in wp_provenance.items() if not info.get("exists")]
     if missing_cfs:
         failures.append(f"WP provenance CFs missing: {missing_cfs} (Bug D indicator)")
+
+    # Per-CF *population* check — distinct from the existence check
+    # above. A CF can ``exists=True, populated=0`` when the migration
+    # created the CustomField record but never wrote any CustomValue
+    # rows (e.g. migration ran before the populating fix landed).
+    # Caught by the live TEST audit: every WP CF showed populated=0
+    # because the migration was pre-#175. Per spec, ``J2O Origin
+    # Key`` is hard-required ("must" line 27); the others are "should"
+    # — fail vs warn accordingly. Skip CFs that didn't exist (the
+    # missing-CF rule above already claims them with a clearer
+    # message).
+    for cf_name, info in wp_provenance.items():
+        if not info.get("exists"):
+            continue
+        populated = int(info.get("populated") or 0)
+        if populated >= wp_total:
+            continue
+        if cf_name == "J2O Origin Key":
+            failures.append(
+                f"WP CF '{cf_name}' under-populated: {populated}/{wp_total}"
+                " — hard-required per spec (dedup + provenance broken)",
+            )
+        else:
+            warnings.append(
+                f"WP CF '{cf_name}' under-populated: {populated}/{wp_total}",
+            )
+
     user_provenance = metrics.get("user_provenance_cfs", {}) or {}
     missing_user_cfs = [n for n, exists in user_provenance.items() if not exists]
     if missing_user_cfs:


### PR DESCRIPTION
## Summary

**Discovered by the live TEST audit**: every WP provenance CF showed \`populated: 0\` because that migration ran before [#175](https://github.com/netresearch/jira-to-openproject/pull/175) wired up the populating flow. The audit's existing \`wp_provenance_cfs\` rule only checks \`exists\`, not \`populated\` — so the gap was invisible.

Without \`J2O Origin Key\` populated, dedup on re-run breaks AND the audit can't identify which Jira issue each WP came from. Per \`MIGRATION_SPEC.md\` line 27, this CF is **hard-required** ("must"), not "should".

## What's new

A population check that walks every existing WP CF:

- **Failure** when \`J2O Origin Key\` has \`populated < wp_total\` (hard requirement)
- **Warning** when any other WP CF has \`populated < wp_total\` ("should" per spec)
- Skips CFs with \`exists=False\` (existing missing-CF rule already claims them — no double-fire)

## Test plan

- [x] 4 new unit tests: hard-required failure, "should" warning, healthy passes, no-double-fire contract
- [x] 80/80 unit tests passing
- [x] Local lint + format clean
- [ ] CI sweep