### PR TITLE
fix(attachments): fail loud when work_package mapping is missing

### DIFF
--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -510,8 +510,24 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         # See :meth:`_wp_lookup_by_jira_key` for normalisation rules.
         key_to_wp_id = self._wp_lookup_by_jira_key()
         if not key_to_wp_id:
-            self.logger.warning("No work package mapping found - skipping attachment migration")
-            return ComponentResult(success=True, updated=0, message="No work packages to process")
+            # FAIL LOUD. Returning ``success=True`` here used to mask
+            # a 100% attachment loss (caught by the live TEST audit
+            # 2026-05-06: Jira=10, OP=0). The orchestration then
+            # moved on, the audit only saw the OP-side count, and
+            # the missing precondition was invisible — the canonical
+            # silent-failure pattern this rewrite closes.
+            msg = (
+                "No work_package mapping available — attachments cannot be"
+                " correlated to OP work packages. Run the work_packages_skeleton"
+                " component first (or verify it persisted its mapping)."
+            )
+            self.logger.error(msg)
+            return ComponentResult(
+                success=False,
+                updated=0,
+                message=msg,
+                errors=["missing_work_package_mapping"],
+            )
 
         by_project: dict[str, list[str]] = {}
         for jira_key in key_to_wp_id:

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -108,3 +108,41 @@ def test_attachments_migration_end_to_end(tmp_path: Path):
     assert mp.success is True
     assert ld.success is True
     assert ld.updated >= 2
+
+
+def test_attachments_migration_fails_loud_on_empty_wp_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Empty WP mapping must FAIL loud, not silently exit success.
+
+    Caught by the live TEST audit (2026-05-06): TEST showed Jira=10
+    attachments, OP=0 — 100% loss. Root cause: ``run()`` exited
+    early with ``success=True, updated=0`` when
+    ``_wp_lookup_by_jira_key()`` returned an empty dict (because
+    the WP migration hadn't completed or hadn't persisted its
+    mapping). The ``success=True`` verdict masked the real failure
+    — the orchestrator moved on, the audit only saw the OP-side
+    count, and the missing precondition was invisible.
+
+    Pin: empty WP mapping → ``ComponentResult(success=False)`` with
+    a ``missing_work_package_mapping`` error tag and a message
+    pointing the operator at the precondition. The orchestration
+    will then surface it instead of silently swallowing.
+    """
+    import src.config as cfg
+
+    # Override the autouse fixture's mapping with an EMPTY one.
+    class EmptyMappings:
+        def get_mapping(self, name: str):
+            return {}
+
+    monkeypatch.setattr(cfg, "mappings", EmptyMappings(), raising=False)
+
+    mig = AttachmentsMigration(jira_client=DummyJira(), op_client=DummyOp())  # type: ignore[arg-type]
+    result = mig.run()
+
+    assert result.success is False, f"Empty WP mapping must fail loud, not silently succeed. Got: {result}"
+    assert "work_package" in (result.message or "").lower(), result.message
+    # Error tag for downstream consumers (audit, dashboards, alerts)
+    assert any("missing_work_package_mapping" in str(e) for e in (result.errors or [])), result.errors


### PR DESCRIPTION
## Summary

Live TEST audit (2026-05-06) caught a **100% attachment loss**: Jira reported 10 attachments on the project, OP had 0. The migration component had reported \`success=True, updated=0\` and the orchestration moved on — a textbook silent failure.

**Root cause**: \`AttachmentsMigration.run()\` exited early with \`success=True\` when \`_wp_lookup_by_jira_key()\` returned an empty dict (because the WP mapping file was empty or never persisted). The success verdict hid the failure from any consumer reading \`ComponentResult.success\`.

## Fix

Flip to **fail loud**:
- \`success=False\` with a clear message naming the missing precondition
- \`errors=["missing_work_package_mapping"]\` (stable tag for dashboards/alerts)
- Log at ERROR level

Two outcomes:
1. The orchestration's partial-success classifier (\`_component_has_errors\`) now correctly marks the run as failed.
2. The audit will see this loud failure and operators can address the precondition.

## Test plan

- [x] New test pins \`success=False\` + error tag + message
- [x] 2/2 attachment tests passing
- [x] Local lint + format clean
- [ ] CI sweep