### PR TITLE
feat(watchers): log distinct unmapped Jira users with full identity

### DIFF
--- a/src/application/components/watcher_migration.py
+++ b/src/application/components/watcher_migration.py
@@ -135,6 +135,16 @@ class WatcherMigration(BaseMigration):
         watchers_to_create: list[dict[str, Any]] = []
         skip_reasons: Counter[str] = Counter()
 
+        # Track DISTINCT unmapped watcher identities. Per the live
+        # TEST audit (2026-05-06) the watcher migration dropped 93%
+        # of watchers; the dominant bucket was ``user_unmapped`` —
+        # Jira users not in the OP user mapping (locked / disabled /
+        # never-synced accounts). The aggregate ``skip_reasons``
+        # count tells the operator HOW MANY watcher rows were
+        # dropped; this set tells them WHICH users to fix. Stored
+        # as a set so a user watching N issues only logs once.
+        unmapped_users: set[str] = set()
+
         # Use cached issues if available, otherwise iterate through keys directly
         issues: dict[str, Any] = {}
         cache_file = self.data_dir / "jira_issues_cache.json"
@@ -188,6 +198,20 @@ class WatcherMigration(BaseMigration):
                         # users, accounts deleted in OP, mapping
                         # not refreshed, etc.).
                         skip_reasons["user_unmapped"] += 1
+                        # Record the distinct identity. Prefer the
+                        # most stable probe (account_id) and fall
+                        # back through the same probe order
+                        # ``_resolve_user_id`` uses, so the logged
+                        # value is the one an operator would search
+                        # the user mapping for.
+                        identity = (
+                            parsed.account_id
+                            or parsed.name
+                            or parsed.email_address
+                            or parsed.display_name
+                            or "<unknown>"
+                        )
+                        unmapped_users.add(str(identity))
                         continue
                     watchers_to_create.append(
                         {
@@ -205,6 +229,22 @@ class WatcherMigration(BaseMigration):
                 "Watcher skip breakdown (%d total, before bulk): %s",
                 skipped,
                 dict(skip_reasons),
+            )
+
+        if unmapped_users:
+            # Log a sample so the migration log is forensically
+            # actionable but doesn't blow up on huge projects. The
+            # full set is returned on ``result.details["unmapped_users"]``
+            # for downstream consumers (audit, dashboards) that want
+            # the exhaustive list.
+            sample = sorted(unmapped_users)[:20]
+            logger.warning(
+                "Watcher migration: %d distinct Jira user(s) not in OP user"
+                " mapping (sample of up to 20: %s).%s Add these to the user"
+                " mapping or create them in OP, then re-run.",
+                len(unmapped_users),
+                sample,
+                "" if len(unmapped_users) <= 20 else f" {len(unmapped_users) - 20} more elided.",
             )
 
         # Bulk create all watchers in single Rails call
@@ -235,6 +275,8 @@ class WatcherMigration(BaseMigration):
                 "created": created,
                 "skipped": skipped + bulk_skipped,
                 "skip_reasons": skip_reasons_with_bulk,
+                "unmapped_users": sorted(unmapped_users),
+                "unmapped_user_count": len(unmapped_users),
                 "errors": errors,
             },
         )

--- a/src/application/components/watcher_migration.py
+++ b/src/application/components/watcher_migration.py
@@ -231,13 +231,20 @@ class WatcherMigration(BaseMigration):
                 dict(skip_reasons),
             )
 
-        if unmapped_users:
+        # Sort the distinct identities once. Both the warning-sample
+        # (first 20) and the ``result.details["unmapped_users"]``
+        # full list use the same sorted view — sorting twice was
+        # avoidable O(n log n) on large projects.
+        sorted_unmapped_users = sorted(unmapped_users)
+
+        if sorted_unmapped_users:
             # Log a sample so the migration log is forensically
             # actionable but doesn't blow up on huge projects. The
-            # full set is returned on ``result.details["unmapped_users"]``
-            # for downstream consumers (audit, dashboards) that want
-            # the exhaustive list.
-            sample = sorted(unmapped_users)[:20]
+            # full sorted list is returned on
+            # ``result.details["unmapped_users"]`` for downstream
+            # consumers (audit, dashboards) that want the exhaustive
+            # list.
+            sample = sorted_unmapped_users[:20]
             logger.warning(
                 "Watcher migration: %d distinct Jira user(s) not in OP user"
                 " mapping (sample of up to 20: %s).%s Add these to the user"
@@ -275,8 +282,8 @@ class WatcherMigration(BaseMigration):
                 "created": created,
                 "skipped": skipped + bulk_skipped,
                 "skip_reasons": skip_reasons_with_bulk,
-                "unmapped_users": sorted(unmapped_users),
-                "unmapped_user_count": len(unmapped_users),
+                "unmapped_users": sorted_unmapped_users,
+                "unmapped_user_count": len(sorted_unmapped_users),
                 "errors": errors,
             },
         )

--- a/tests/unit/test_watcher_migration.py
+++ b/tests/unit/test_watcher_migration.py
@@ -129,6 +129,104 @@ def test_skip_reasons_wp_unmapped(
     assert breakdown.get("wp_unmapped") == 1, breakdown
 
 
+def test_unmapped_users_set_is_distinct(
+    monkeypatch: pytest.MonkeyPatch,
+    _map_store,
+    tmp_path,
+):
+    """Same Jira user watching N issues counts ONCE in the unmapped set.
+
+    Per the live TEST audit (2026-05-06): 38 watcher rows missing,
+    but likely only ~10 distinct users. Telling the operator
+    "10 users to fix" is far more actionable than "38 watchers
+    skipped". Pin the dedup so a future regression that increments
+    a list (instead of a set) is caught.
+    """
+    op = DummyOpClient()
+
+    class DummyJira:
+        def get_issue_watchers(self, key: str):
+            # Same unmapped user (bob) appears on every issue.
+            return [{"name": "bob"}]
+
+    wm = WatcherMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    cache_dir = tmp_path / "data"
+    cache_dir.mkdir()
+    # 3 issues all mapped to the same WP, all watched by ``bob``.
+    _map_store.set_mapping(
+        "work_package",
+        {
+            "J1": {"openproject_id": 10},
+            "J2": {"openproject_id": 11},
+            "J3": {"openproject_id": 12},
+        },
+    )
+    (cache_dir / "jira_issues_cache.json").write_text(
+        '{"J1": {"key": "J1"}, "J2": {"key": "J2"}, "J3": {"key": "J3"}}',
+    )
+    wm.data_dir = cache_dir
+
+    res = wm.run()
+    # 3 watcher rows dropped (one per issue) but only 1 distinct user.
+    assert res.details["unmapped_user_count"] == 1, res.details
+    assert res.details["unmapped_users"] == ["bob"], res.details
+    # Aggregate skip count still matches all the dropped rows.
+    assert res.details["skip_reasons"].get("user_unmapped") == 3, res.details
+
+
+def test_unmapped_users_records_identity_via_probe_order(
+    monkeypatch: pytest.MonkeyPatch,
+    _map_store,
+    tmp_path,
+):
+    """Recorded identity matches ``_resolve_user_id``'s probe order.
+
+    Operators search the user mapping with the SAME identity the
+    resolver tried. Logging ``account_id`` first (then name, email,
+    display_name) means the operator can paste the logged value
+    straight into the mapping key.
+    """
+    op = DummyOpClient()
+
+    class DummyJira:
+        def get_issue_watchers(self, key: str):
+            # Watcher with both account_id AND name; account_id wins.
+            return [{"accountId": "557058:abc", "name": "fallback-name"}]
+
+    wm = WatcherMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    cache_dir = tmp_path / "data"
+    cache_dir.mkdir()
+    (cache_dir / "jira_issues_cache.json").write_text('{"J1": {"key": "J1"}}')
+    wm.data_dir = cache_dir
+
+    res = wm.run()
+    # account_id wins over name in the probe order.
+    assert res.details["unmapped_users"] == ["557058:abc"], res.details
+
+
+def test_unmapped_users_empty_when_all_mapped(
+    monkeypatch: pytest.MonkeyPatch,
+    _map_store,
+    tmp_path,
+):
+    """All watchers map cleanly → unmapped_users is empty list."""
+    op = DummyOpClient()
+
+    class DummyJira:
+        def get_issue_watchers(self, key: str):
+            return [{"name": "alice"}]
+
+    wm = WatcherMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    cache_dir = tmp_path / "data"
+    cache_dir.mkdir()
+    (cache_dir / "jira_issues_cache.json").write_text('{"J1": {"key": "J1"}}')
+    wm.data_dir = cache_dir
+
+    res = wm.run()
+    assert res.details["unmapped_users"] == [], res.details
+    assert res.details["unmapped_user_count"] == 0
+
+
 def test_skip_reasons_breakdown_sums_to_total_skipped(
     monkeypatch: pytest.MonkeyPatch,
     _map_store,


### PR DESCRIPTION
## Summary

Live TEST audit ([#187](https://github.com/netresearch/jira-to-openproject/pull/187)+) caught 93% watcher loss with \`user_unmapped\` as the dominant skip bucket. PR #190's \`skip_reasons\` count tells operators HOW MANY watcher rows were dropped, but not WHICH users to fix.

## Fix

Track DISTINCT unmapped watcher identities (not row counts) and surface them on:
- \`result.details["unmapped_users"]\` — sorted list, paste-ready for the user-mapping config
- \`result.details["unmapped_user_count"]\` — distinct count
- WARNING log at end-of-run: count + sample of 20 (full list in \`result.details\`)

Recorded identity uses the same probe order (\`account_id → name → email → display_name\`) the resolver uses — operators paste straight into the mapping key.

## What this is NOT

The architectural fix (user_migration discovering users from watchers + auto-creating them) is a separate, bigger PR. This diagnostic enables operators to FIX the gap with the existing mapping mechanism in the meantime.

## Test plan

- [x] 3 new unit tests: distinct dedup, probe-order priority, empty-when-all-mapped
- [x] 8/8 watcher tests passing (5 existing + 3 new)
- [x] Local lint + format clean
- [ ] CI sweep