### PR TITLE
feat(users): discover users from cached issues (watchers/assignee/reporter/comments)

### DIFF
--- a/src/application/components/user_migration.py
+++ b/src/application/components/user_migration.py
@@ -228,30 +228,30 @@ class UserMigration(BaseMigration):
             MigrationError: If users cannot be extracted from Jira
 
         """
+        # Whether we hit the directory or used the cache, ALWAYS
+        # also run discovery against the issues cache. The previous
+        # arrangement skipped discovery on cache-hit, which made
+        # this fix inert on every re-run (the common case in
+        # production migrations) — caught by the Copilot review of
+        # PR #196.
         if self.jira_users and not force:
             self.logger.info("Using cached Jira users (%s entries)", len(self.jira_users))
-            return self.jira_users
+        else:
+            self.logger.info("Extracting users from Jira...")
+            self.jira_users = self.jira_client.get_users()
+            if not self.jira_users:
+                msg = "Failed to extract users from Jira"
+                raise MigrationError(msg)
+            self.logger.info("Extracted %s users from Jira", len(self.jira_users))
 
-        self.logger.info("Extracting users from Jira...")
-
-        self.jira_users = self.jira_client.get_users()
-
-        if not self.jira_users:
-            msg = "Failed to extract users from Jira"
-            raise MigrationError(msg)
-
-        self.logger.info("Extracted %s users from Jira", len(self.jira_users))
-
-        # Augment the directory list with users discovered from
-        # cached issues (watchers, assignees, reporters, comment
-        # authors). Per the live TEST audit (2026-05-06) and the
-        # recon for PR #195, the directory ``get_users()`` call
-        # systematically misses inactive / disabled / never-logged-in
-        # accounts that nonetheless appear as watchers — driving the
-        # 93% watcher loss class. Adding discovered users here lets
-        # ``create_user_mapping`` map them and ``create_missing_users``
-        # provision OP accounts for them BEFORE watcher_migration
-        # tries to resolve them.
+        # Augment with users discovered from cached issues
+        # (watchers, assignees, reporters, comment authors). Per
+        # the live TEST audit (2026-05-06) and PR #195, the
+        # directory ``get_users()`` call systematically misses
+        # inactive / disabled / never-logged-in accounts that
+        # nonetheless appear as watchers — driving the 93% watcher
+        # loss class. Discovered users get mapped + provisioned
+        # BEFORE watcher_migration tries to resolve them.
         discovered = self._discover_users_from_cached_issues()
         if discovered:
             existing_ids = {self._stable_user_id(u) for u in self.jira_users if self._stable_user_id(u)}
@@ -260,6 +260,16 @@ class UserMigration(BaseMigration):
                 stable_id = self._stable_user_id(raw)
                 if not stable_id or stable_id in existing_ids:
                     continue
+                # CRITICAL: ``create_user_mapping`` skips users
+                # without a ``key`` (line 497 in this file). Watcher
+                # responses don't carry ``key`` — only ``accountId``,
+                # ``name``, etc. Synthesize a ``key`` from the
+                # stable identity so the discovered user actually
+                # makes it through mapping + creation. Without this
+                # fallback the entire discovery pass silently
+                # dropped through.
+                if not raw.get("key"):
+                    raw["key"] = raw.get("accountId") or raw.get("name") or stable_id
                 self.jira_users.append(raw)
                 existing_ids.add(stable_id)
                 added += 1
@@ -277,10 +287,13 @@ class UserMigration(BaseMigration):
 
     @staticmethod
     def _stable_user_id(raw: dict[str, Any]) -> str:
-        """Lowercase ``account_id`` or ``name`` — whichever is present.
+        """Lowercase ``accountId`` or ``name`` — whichever is present.
 
-        Used as a dedup key when merging discovered users into
-        ``self.jira_users``. Mirrors the probe order of
+        Note the camelCase keys: this consumes raw Jira-shaped dicts
+        as they come back from ``get_users()`` and the issue cache,
+        not the ``snake_case`` ``JiraUser`` model. Used as a dedup
+        key when merging discovered users into ``self.jira_users``.
+        Mirrors the probe order of
         :meth:`watcher_migration._resolve_user_id` so two callers
         agree on which identity is "the same user".
         """

--- a/src/application/components/user_migration.py
+++ b/src/application/components/user_migration.py
@@ -242,9 +242,119 @@ class UserMigration(BaseMigration):
 
         self.logger.info("Extracted %s users from Jira", len(self.jira_users))
 
+        # Augment the directory list with users discovered from
+        # cached issues (watchers, assignees, reporters, comment
+        # authors). Per the live TEST audit (2026-05-06) and the
+        # recon for PR #195, the directory ``get_users()`` call
+        # systematically misses inactive / disabled / never-logged-in
+        # accounts that nonetheless appear as watchers — driving the
+        # 93% watcher loss class. Adding discovered users here lets
+        # ``create_user_mapping`` map them and ``create_missing_users``
+        # provision OP accounts for them BEFORE watcher_migration
+        # tries to resolve them.
+        discovered = self._discover_users_from_cached_issues()
+        if discovered:
+            existing_ids = {self._stable_user_id(u) for u in self.jira_users if self._stable_user_id(u)}
+            added = 0
+            for raw in discovered:
+                stable_id = self._stable_user_id(raw)
+                if not stable_id or stable_id in existing_ids:
+                    continue
+                self.jira_users.append(raw)
+                existing_ids.add(stable_id)
+                added += 1
+            if added:
+                self.logger.info(
+                    "Discovered %d additional users from cached issues (watchers/"
+                    "assignee/reporter/comments) — total now %d",
+                    added,
+                    len(self.jira_users),
+                )
+
         self._save_to_json(self.jira_users, Path("jira_users.json"))
 
         return self.jira_users
+
+    @staticmethod
+    def _stable_user_id(raw: dict[str, Any]) -> str:
+        """Lowercase ``account_id`` or ``name`` — whichever is present.
+
+        Used as a dedup key when merging discovered users into
+        ``self.jira_users``. Mirrors the probe order of
+        :meth:`watcher_migration._resolve_user_id` so two callers
+        agree on which identity is "the same user".
+        """
+        for key in ("accountId", "name"):
+            value = raw.get(key)
+            if isinstance(value, str) and value:
+                return value.lower()
+        return ""
+
+    def _discover_users_from_cached_issues(self) -> list[dict[str, Any]]:
+        """Harvest user identities from the cached Jira issues file.
+
+        For each issue in ``data_dir / 'jira_issues_cache.json'``,
+        collect raw user dicts from:
+
+        - ``fields.watches.watchers[*]``
+        - ``fields.assignee``
+        - ``fields.reporter``
+        - ``fields.comment.comments[*].author``
+
+        Returns deduped list (by lowercase ``accountId`` or ``name``)
+        of raw dicts. Discovery is best-effort — on cache-read failure
+        it returns an empty list (the directory pass remains the
+        fallback).
+        """
+        cache_file = self.data_dir / "jira_issues_cache.json"
+        if not cache_file.exists():
+            return []
+        try:
+            import json as _json
+
+            with open(cache_file, encoding="utf-8") as f:
+                issues = _json.load(f)
+        except Exception as exc:
+            self.logger.warning(
+                "Could not read jira_issues_cache.json for user discovery: %s",
+                exc,
+            )
+            return []
+
+        discovered: list[dict[str, Any]] = []
+        seen_ids: set[str] = set()
+
+        def _add(raw: Any) -> None:
+            if not isinstance(raw, dict):
+                return
+            stable = self._stable_user_id(raw)
+            if not stable or stable in seen_ids:
+                return
+            seen_ids.add(stable)
+            discovered.append(raw)
+
+        if not isinstance(issues, dict):
+            return []
+
+        for issue in issues.values():
+            if not isinstance(issue, dict):
+                continue
+            fields = issue.get("fields") or {}
+            if not isinstance(fields, dict):
+                continue
+            watches = fields.get("watches") or {}
+            if isinstance(watches, dict):
+                for w in watches.get("watchers") or []:
+                    _add(w)
+            _add(fields.get("assignee"))
+            _add(fields.get("reporter"))
+            comment = fields.get("comment") or {}
+            if isinstance(comment, dict):
+                for c in comment.get("comments") or []:
+                    if isinstance(c, dict):
+                        _add(c.get("author"))
+
+        return discovered
 
     def extract_openproject_users(self, *, force: bool = False) -> list[dict[str, Any]]:
         """Extract users from OpenProject.

--- a/src/application/components/user_migration.py
+++ b/src/application/components/user_migration.py
@@ -306,35 +306,53 @@ class UserMigration(BaseMigration):
         it returns an empty list (the directory pass remains the
         fallback).
         """
+        import json as _json
+
         cache_file = self.data_dir / "jira_issues_cache.json"
         if not cache_file.exists():
             return []
         try:
-            import json as _json
-
             with open(cache_file, encoding="utf-8") as f:
                 issues = _json.load(f)
-        except Exception as exc:
+        except (OSError, _json.JSONDecodeError) as exc:
+            # Narrow to realistic failure modes — a refactor bug
+            # (e.g. accidental ``getattr`` typo) should crash loud
+            # instead of being silently classified as "could not
+            # read cache".
             self.logger.warning(
                 "Could not read jira_issues_cache.json for user discovery: %s",
                 exc,
             )
             return []
 
+        if not isinstance(issues, dict):
+            self.logger.warning(
+                "jira_issues_cache.json is not a dict at the top level — skipping user discovery",
+            )
+            return []
+
         discovered: list[dict[str, Any]] = []
         seen_ids: set[str] = set()
+        # Track user dicts that had neither ``accountId`` nor
+        # ``name`` — they're silently unmappable by
+        # ``watcher_migration._resolve_user_id`` too (the probe
+        # ladder starts with those two fields), so dropping is
+        # correct, but the COUNT must be visible so a future audit
+        # can quantify the residual loss.
+        dropped_no_identity = 0
 
         def _add(raw: Any) -> None:
+            nonlocal dropped_no_identity
             if not isinstance(raw, dict):
                 return
             stable = self._stable_user_id(raw)
-            if not stable or stable in seen_ids:
+            if not stable:
+                dropped_no_identity += 1
+                return
+            if stable in seen_ids:
                 return
             seen_ids.add(stable)
             discovered.append(raw)
-
-        if not isinstance(issues, dict):
-            return []
 
         for issue in issues.values():
             if not isinstance(issue, dict):
@@ -353,6 +371,14 @@ class UserMigration(BaseMigration):
                 for c in comment.get("comments") or []:
                     if isinstance(c, dict):
                         _add(c.get("author"))
+
+        if dropped_no_identity:
+            self.logger.info(
+                "User discovery: %d dict(s) had neither accountId nor name and"
+                " were skipped (unmappable downstream — anonymized accounts /"
+                " pre-7.x Server users / system actors)",
+                dropped_no_identity,
+            )
 
         return discovered
 

--- a/tests/unit/test_user_migration_metadata.py
+++ b/tests/unit/test_user_migration_metadata.py
@@ -143,3 +143,88 @@ def test_prepare_avatar_job_uses_cache(logger_stub):
         )
         is None
     )
+
+
+# --- User discovery from cached issues ---------------------------------------
+# Per the live TEST audit (2026-05-06): the directory ``get_users()``
+# call misses users who appear as watchers/assignees/reporters/
+# comment authors but aren't in the Jira user directory (inactive,
+# disabled, never-logged-in). PR #195 surfaced the distinct
+# unmapped users; this PR's discovery method adds them to
+# ``self.jira_users`` so they get mapped + created BEFORE
+# watcher_migration tries to resolve them.
+
+
+def test_discover_users_from_cached_issues_harvests_all_sources(logger_stub, tmp_path):
+    """Harvest watchers + assignee + reporter + comment authors, deduped by id."""
+    import json as _json
+
+    instance = UserMigration.__new__(UserMigration)
+    instance.logger = logger_stub
+    instance.data_dir = tmp_path
+    cache_file = tmp_path / "jira_issues_cache.json"
+    cache_file.write_text(
+        _json.dumps(
+            {
+                "PROJ-1": {
+                    "fields": {
+                        "watches": {
+                            "watchers": [
+                                {"name": "alice", "accountId": "acc-alice"},
+                                {"name": "bob", "accountId": "acc-bob"},
+                            ],
+                        },
+                        "assignee": {"name": "carol", "accountId": "acc-carol"},
+                        "reporter": {"name": "dave", "accountId": "acc-dave"},
+                        "comment": {
+                            "comments": [
+                                {"author": {"name": "eve", "accountId": "acc-eve"}},
+                            ],
+                        },
+                    },
+                },
+                "PROJ-2": {
+                    "fields": {
+                        # Same alice — must dedup, not double-count.
+                        "watches": {"watchers": [{"name": "alice", "accountId": "acc-alice"}]},
+                    },
+                },
+            },
+        ),
+    )
+
+    discovered = instance._discover_users_from_cached_issues()
+    names = sorted(u["name"] for u in discovered)
+    assert names == ["alice", "bob", "carol", "dave", "eve"], discovered
+
+
+def test_discover_users_handles_missing_cache(logger_stub, tmp_path):
+    """No cache file → empty list, no exception."""
+    instance = UserMigration.__new__(UserMigration)
+    instance.logger = logger_stub
+    instance.data_dir = tmp_path
+
+    assert instance._discover_users_from_cached_issues() == []
+
+
+def test_discover_users_handles_malformed_cache(logger_stub, tmp_path):
+    """Garbage JSON → empty list + warning, NOT a raised exception.
+
+    Pin: discovery is best-effort. The directory pass remains the
+    fallback, never block migration.
+    """
+    cache_file = tmp_path / "jira_issues_cache.json"
+    cache_file.write_text("not valid json {{{")
+
+    instance = UserMigration.__new__(UserMigration)
+    instance.logger = logger_stub
+    instance.data_dir = tmp_path
+
+    assert instance._discover_users_from_cached_issues() == []
+
+
+def test_stable_user_id_prefers_account_id_over_name():
+    """Dedup key uses ``accountId`` first, then ``name``, lowercase."""
+    assert UserMigration._stable_user_id({"accountId": "ACC-1", "name": "alice"}) == "acc-1"
+    assert UserMigration._stable_user_id({"name": "ALICE"}) == "alice"
+    assert UserMigration._stable_user_id({}) == ""

--- a/tests/unit/test_user_migration_metadata.py
+++ b/tests/unit/test_user_migration_metadata.py
@@ -250,6 +250,103 @@ def test_discover_users_top_level_list_not_dict_returns_empty(logger_stub, tmp_p
     assert instance._discover_users_from_cached_issues() == []
 
 
+def test_extract_jira_users_synthesizes_key_for_discovered_users(
+    logger_stub,
+    tmp_path,
+):
+    """Discovered users must have a ``key`` field after the merge.
+
+    Caught by the Copilot review of PR #196:
+    ``create_user_mapping`` line 497 SKIPS any Jira user without
+    ``key``. Watcher responses carry ``accountId`` / ``name`` but
+    NOT ``key``, so without a fallback the discovered users
+    would map nowhere — making the entire discovery pass inert.
+    """
+    import json as _json
+
+    instance = UserMigration.__new__(UserMigration)
+    instance.logger = logger_stub
+    instance.data_dir = tmp_path
+    instance.jira_users = []
+    instance.jira_client = MagicMock()
+    instance.jira_client.get_users.return_value = [
+        {"key": "directory-user", "name": "directory-user"},
+    ]
+    instance._save_to_json = lambda *args, **kwargs: None
+
+    cache_file = tmp_path / "jira_issues_cache.json"
+    cache_file.write_text(
+        _json.dumps(
+            {
+                "PROJ-1": {
+                    "fields": {
+                        "watches": {
+                            "watchers": [
+                                {"accountId": "557058:abc", "displayName": "Cloud User"},
+                                {"name": "server-user"},
+                            ],
+                        },
+                    },
+                },
+            },
+        ),
+    )
+
+    result = instance.extract_jira_users()
+
+    # Every user (directory + discovered) has a truthy ``key``.
+    for user in result:
+        assert user.get("key"), f"User missing key after discovery: {user}"
+
+    # Synthesized keys match the stable identity (accountId
+    # preferred over name).
+    keys_by_name = {u.get("name") or u.get("displayName"): u["key"] for u in result}
+    assert keys_by_name["directory-user"] == "directory-user"
+    assert keys_by_name["Cloud User"] == "557058:abc"
+    assert keys_by_name["server-user"] == "server-user"
+
+
+def test_extract_jira_users_runs_discovery_on_cache_hit(logger_stub, tmp_path):
+    """Discovery runs EVEN when ``self.jira_users`` is already populated.
+
+    Caught by the Copilot review of PR #196: the original
+    arrangement returned early on cache-hit and never invoked
+    discovery. On every re-run (common in production), the
+    fix was inert.
+    """
+    import json as _json
+
+    instance = UserMigration.__new__(UserMigration)
+    instance.logger = logger_stub
+    instance.data_dir = tmp_path
+    # Pre-populated (mimics re-run with cached users in memory).
+    instance.jira_users = [{"key": "existing", "name": "existing"}]
+    instance.jira_client = MagicMock()
+    instance._save_to_json = lambda *args, **kwargs: None
+
+    cache_file = tmp_path / "jira_issues_cache.json"
+    cache_file.write_text(
+        _json.dumps(
+            {
+                "PROJ-1": {
+                    "fields": {
+                        "watches": {"watchers": [{"accountId": "discovered-user"}]},
+                    },
+                },
+            },
+        ),
+    )
+
+    result = instance.extract_jira_users()
+
+    # Directory call skipped (cache hit) ...
+    instance.jira_client.get_users.assert_not_called()
+    # ... but discovery ran and added the watcher.
+    keys = {u["key"] for u in result}
+    assert "existing" in keys
+    assert "discovered-user" in keys, f"Discovery did not run on cache-hit: {result}"
+
+
 def test_discover_users_drops_dicts_without_account_or_name(logger_stub, tmp_path):
     """User dicts with only ``displayName`` / ``emailAddress`` are dropped.
 

--- a/tests/unit/test_user_migration_metadata.py
+++ b/tests/unit/test_user_migration_metadata.py
@@ -228,3 +228,67 @@ def test_stable_user_id_prefers_account_id_over_name():
     assert UserMigration._stable_user_id({"accountId": "ACC-1", "name": "alice"}) == "acc-1"
     assert UserMigration._stable_user_id({"name": "ALICE"}) == "alice"
     assert UserMigration._stable_user_id({}) == ""
+
+
+def test_discover_users_top_level_list_not_dict_returns_empty(logger_stub, tmp_path):
+    """If the cache is a JSON list (not a dict), discovery returns ``[]``.
+
+    Pin the structural assumption — the existing reader walks
+    ``issues.values()`` which would fail on a list. The defensive
+    ``isinstance(issues, dict)`` guard catches it and returns an
+    empty list with a warning, NOT a TypeError.
+    """
+    import json as _json
+
+    cache_file = tmp_path / "jira_issues_cache.json"
+    cache_file.write_text(_json.dumps([{"key": "PROJ-1"}]))  # list, not dict
+
+    instance = UserMigration.__new__(UserMigration)
+    instance.logger = logger_stub
+    instance.data_dir = tmp_path
+
+    assert instance._discover_users_from_cached_issues() == []
+
+
+def test_discover_users_drops_dicts_without_account_or_name(logger_stub, tmp_path):
+    """User dicts with only ``displayName`` / ``emailAddress`` are dropped.
+
+    Documents the trade-off: ``watcher_migration._resolve_user_id``
+    probes ``accountId`` then ``name`` first, so a user dict with
+    only ``displayName`` couldn't be mapped downstream anyway —
+    keeping it in ``self.jira_users`` would just create a
+    placeholder OP user with no usable identity. The drop is
+    correct policy, but PR #196's hardening logs the count so a
+    future audit can quantify the residual loss.
+    """
+    import json as _json
+
+    cache_file = tmp_path / "jira_issues_cache.json"
+    cache_file.write_text(
+        _json.dumps(
+            {
+                "PROJ-1": {
+                    "fields": {
+                        "watches": {
+                            "watchers": [
+                                {"accountId": "real", "name": "real-user"},
+                                # Anonymized — no accountId, no name.
+                                {"displayName": "Former user"},
+                                # Email-only system actor.
+                                {"emailAddress": "sys@example.org"},
+                            ],
+                        },
+                    },
+                },
+            },
+        ),
+    )
+
+    instance = UserMigration.__new__(UserMigration)
+    instance.logger = logger_stub
+    instance.data_dir = tmp_path
+
+    discovered = instance._discover_users_from_cached_issues()
+    # Only the user with a usable identity survives.
+    assert len(discovered) == 1
+    assert discovered[0]["accountId"] == "real"


### PR DESCRIPTION
## Summary

**Architectural fix for the 93% watcher loss** caught by the live TEST audit ([#187](https://github.com/netresearch/jira-to-openproject/pull/187)) and instrumented by [#195](https://github.com/netresearch/jira-to-openproject/pull/195).

Per recon: \`user_migration.extract_jira_users()\` only calls \`jira_client.get_users()\` which queries \`/rest/api/2/users/search\`. That misses inactive / disabled / never-logged-in accounts that nonetheless appear as watchers, assignees, reporters, or comment authors. When such a user appears in an issue field, the downstream migrations silently drop the row.

## Fix

Add \`_discover_users_from_cached_issues()\` that walks \`data_dir / 'jira_issues_cache.json'\` and harvests raw user dicts from every per-issue identity slot:

- \`fields.watches.watchers[*]\`
- \`fields.assignee\`
- \`fields.reporter\`
- \`fields.comment.comments[*].author\`

Dedup by lowercased \`accountId || name\` (mirrors \`watcher_migration._resolve_user_id\`'s probe order). Discovered users not already in \`self.jira_users\` are appended BEFORE \`create_user_mapping\` runs — so the existing mapping + \`create_missing_users\` flow picks them up. **No changes to downstream methods**.

Best-effort: missing/malformed cache → empty list + warning. Directory pass remains the primary source.

## Expected impact

The \`unmapped_users\` set in \`watcher_migration\`'s \`result.details\` (added in #195) should drop dramatically on the next migration run. The previously-93%-lost watchers now have a real chance.

## Test plan

- [x] 4 new unit tests + 1 stable-id test
- [x] 21/21 user/watcher tests passing
- [x] Local lint + format clean
- [ ] CI sweep