### PR TITLE
fix(wp-skeleton): post-condition guard for missing mapping file

### DIFF
--- a/src/application/components/work_package_skeleton_migration.py
+++ b/src/application/components/work_package_skeleton_migration.py
@@ -909,6 +909,69 @@ class WorkPackageSkeletonMigration(BaseMigration):
             end_time = datetime.now(tz=UTC)
             duration_seconds = (end_time - start_time).total_seconds()
 
+            # Post-condition: if any work packages were created, the
+            # mapping file MUST exist on disk. Without it, every
+            # downstream component (attachments, watchers, relations,
+            # …) silently skips with an empty mapping — the canonical
+            # silent-failure pattern that caught us in the live TEST
+            # audit (100% attachment loss; ``_wp_lookup_by_jira_key``
+            # returned ``{}`` because the file wasn't there).
+            #
+            # ``_save_mapping`` swallows save errors with a log line
+            # and returns; checking the file here is the
+            # cross-cutting guard that catches both that swallow path
+            # AND any future bug that ends up with a missing /
+            # empty mapping file. Treat as a hard failure so the
+            # orchestrator surfaces it instead of cascading silent
+            # successes downstream.
+            total_created = int(migration_results.get("total_created") or 0)
+            if total_created > 0:
+                if not self.work_package_mapping_file.exists():
+                    msg = (
+                        f"Work-package mapping file was not persisted at"
+                        f" {self.work_package_mapping_file} despite"
+                        f" {total_created} skeletons being created — downstream"
+                        " migrations (attachments, watchers, relations) will"
+                        " silently skip. Likely cause: ``_save_mapping`` swallowed"
+                        " a write error (disk full, permissions, etc.); check"
+                        " the migration log for the underlying error."
+                    )
+                    self.logger.error(msg)
+                    return ComponentResult(
+                        status="error",
+                        success=False,
+                        error="missing_work_package_mapping_file",
+                        message=msg,
+                        timestamp=end_time.isoformat(),
+                        start_time=start_time.isoformat(),
+                        duration_seconds=duration_seconds,
+                    )
+                # File exists — sanity-check it isn't empty
+                # (zero-byte / ``{}`` would also brick downstream).
+                try:
+                    if self.work_package_mapping_file.stat().st_size <= 2:
+                        msg = (
+                            f"Work-package mapping file at"
+                            f" {self.work_package_mapping_file} is empty / ``{{}}``"
+                            f" despite {total_created} skeletons being created"
+                            " — downstream migrations would silently skip."
+                        )
+                        self.logger.error(msg)
+                        return ComponentResult(
+                            status="error",
+                            success=False,
+                            error="empty_work_package_mapping_file",
+                            message=msg,
+                            timestamp=end_time.isoformat(),
+                            start_time=start_time.isoformat(),
+                            duration_seconds=duration_seconds,
+                        )
+                except OSError as stat_exc:
+                    self.logger.warning(
+                        "Could not stat work-package mapping file: %s",
+                        stat_exc,
+                    )
+
             return ComponentResult(
                 status="success",
                 success=True,

--- a/tests/unit/test_work_package_skeleton_post_condition.py
+++ b/tests/unit/test_work_package_skeleton_post_condition.py
@@ -1,0 +1,120 @@
+"""Post-condition guard for ``WorkPackageSkeletonMigration.run``.
+
+Live TEST audit (2026-05-06) caught a 100% attachment loss whose
+upstream cause was the WP-skeleton mapping file not getting persisted
+— ``_save_mapping`` swallows write errors with a log line, and
+``run()`` reported ``success=True`` regardless. Every downstream
+migration (attachments, watchers, relations) then silently skipped
+with an empty mapping.
+
+These tests pin the post-condition added in PR #197: when
+``total_created > 0`` but the mapping file is missing or empty,
+``run()`` returns ``success=False`` with a stable error tag.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.application.components.work_package_skeleton_migration import (
+    WorkPackageSkeletonMigration,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _logger_stub() -> SimpleNamespace:
+    return SimpleNamespace(
+        info=lambda *a, **kw: None,
+        warning=lambda *a, **kw: None,
+        debug=lambda *a, **kw: None,
+        error=lambda *a, **kw: None,
+        exception=lambda *a, **kw: None,
+        success=lambda *a, **kw: None,
+        notice=lambda *a, **kw: None,
+    )
+
+
+def _make_migration(tmp_path: Path) -> WorkPackageSkeletonMigration:
+    """Bypass ``__init__`` so we don't need a real Jira/OP client."""
+    instance = WorkPackageSkeletonMigration.__new__(WorkPackageSkeletonMigration)
+    instance.logger = _logger_stub()
+    instance.work_package_mapping = {}
+    instance.work_package_mapping_file = tmp_path / WorkPackageSkeletonMigration.WORK_PACKAGE_MAPPING_FILE
+    return instance
+
+
+def test_run_fails_loud_when_mapping_file_missing(tmp_path: Path) -> None:
+    """``total_created > 0`` + missing mapping file → ``success=False``.
+
+    Without this guard, ``_save_mapping``'s swallowed write error
+    propagates as ``success=True`` to the orchestrator. Downstream
+    components then see an empty WP map and skip everything —
+    exactly the 100% attachment loss class caught on TEST.
+    """
+    instance = _make_migration(tmp_path)
+    # Simulate "skeletons were created but the save silently failed".
+    instance._migrate_skeletons = MagicMock(
+        return_value={"total_created": 5, "total_skipped": 0, "total_failed": 0},
+    )
+
+    result = instance.run()
+
+    assert result.success is False, result
+    assert result.error == "missing_work_package_mapping_file", result
+    assert "downstream" in (result.message or "").lower(), result.message
+
+
+def test_run_fails_loud_when_mapping_file_empty(tmp_path: Path) -> None:
+    """``total_created > 0`` + zero-byte mapping file → ``success=False``."""
+    instance = _make_migration(tmp_path)
+    # Empty / ``{}`` file — same downstream effect as missing.
+    instance.work_package_mapping_file.write_text("{}")
+    instance._migrate_skeletons = MagicMock(
+        return_value={"total_created": 5, "total_skipped": 0, "total_failed": 0},
+    )
+
+    result = instance.run()
+
+    assert result.success is False, result
+    assert result.error == "empty_work_package_mapping_file", result
+
+
+def test_run_passes_when_mapping_file_has_content(tmp_path: Path) -> None:
+    """Healthy state: file exists, non-empty → ``success=True``."""
+    instance = _make_migration(tmp_path)
+    # Realistic mapping shape (str(jira_id) → entry dict).
+    instance.work_package_mapping_file.write_text(
+        json.dumps({"10001": {"jira_key": "PROJ-1", "openproject_id": 42}}),
+    )
+    instance._migrate_skeletons = MagicMock(
+        return_value={"total_created": 1, "total_skipped": 0, "total_failed": 0},
+    )
+
+    result = instance.run()
+
+    assert result.success is True, result
+    assert result.details["total_created"] == 1
+
+
+def test_run_passes_when_zero_skeletons_created(tmp_path: Path) -> None:
+    """``total_created == 0`` → no post-condition check fires.
+
+    Legitimate state when nothing changed since the last run (re-run
+    on a fully-migrated project). Mapping file may or may not exist;
+    either way, success.
+    """
+    instance = _make_migration(tmp_path)
+    # Mapping file deliberately not created.
+    instance._migrate_skeletons = MagicMock(
+        return_value={"total_created": 0, "total_skipped": 0, "total_failed": 0},
+    )
+
+    result = instance.run()
+
+    assert result.success is True, result


### PR DESCRIPTION
## Summary

Live TEST audit (2026-05-06) caught a **100% attachment loss** whose upstream cause was \`work_package_mapping.json\` not getting persisted. The chain:

1. \`_save_mapping\` swallows write errors (logs at ERROR, returns).
2. \`run()\` returned \`success=True\` regardless.
3. Downstream (attachments, watchers, relations) silently skipped with empty mapping.

[#194](https://github.com/netresearch/jira-to-openproject/pull/194) made attachments fail loud at the cascade gate. This PR adds the *upstream* guard so the failure surfaces at the originating component.

## Fix

Post-condition in \`run()\` after \`_migrate_skeletons()\`:

- \`total_created > 0\` + missing mapping file → \`error="missing_work_package_mapping_file"\`
- \`total_created > 0\` + empty file (\`{}\`) → \`error="empty_work_package_mapping_file"\`
- \`total_created == 0\` → no check (legitimate re-run state)

Stable error tags for dashboard/alert matching.

## Test plan

- [x] 4 new tests pin: missing fails, empty fails, healthy passes, zero-created passes
- [x] 4/4 passing
- [x] Local lint + format clean
- [ ] CI sweep