### PR TITLE
fix(migrate): fail loud on missing WP mapping in 2 more components

### DIFF
--- a/src/application/components/attachment_provenance_migration.py
+++ b/src/application/components/attachment_provenance_migration.py
@@ -197,8 +197,26 @@ class AttachmentProvenanceMigration(BaseMigration):  # noqa: D101
 
         wp_map = self.mappings.get_mapping("work_package") or {}
         if not wp_map:
-            self.logger.warning("No work package mapping found - skipping provenance migration")
-            return ComponentResult(success=True, updated=0, message="No work packages to process")
+            # FAIL LOUD. Same anti-pattern as the pre-#194 attachments
+            # path — ``success=True`` here masks the real cause
+            # (upstream ``work_packages_skeleton`` didn't persist
+            # its mapping, e.g. ``_save_mapping`` swallowed a write
+            # error per #197). Without the WP map this component
+            # has nothing to do; surface the missing precondition
+            # so the orchestrator's partial-success classifier
+            # flags the run instead of cascading silent successes.
+            msg = (
+                "No work_package mapping available — attachment provenance"
+                " cannot run. Run work_packages_skeleton first (or verify"
+                " its mapping persisted) and re-run this component."
+            )
+            self.logger.error(msg)
+            return ComponentResult(
+                success=False,
+                updated=0,
+                message=msg,
+                errors=["missing_work_package_mapping"],
+            )
 
         # Group jira keys by project for efficient processing. Each entry
         # is normalised through :class:`WorkPackageMappingEntry.from_legacy`

--- a/src/application/components/watcher_migration.py
+++ b/src/application/components/watcher_migration.py
@@ -123,8 +123,26 @@ class WatcherMigration(BaseMigration):
                 continue
             jira_keys.append(str(entry.jira_key))
         if not jira_keys:
-            logger.info("No work package mappings; skipping watcher migration")
-            return result
+            # FAIL LOUD. Same anti-pattern as pre-#194 attachments and
+            # pre-#197 wp_skeleton — silent ``success=True`` here masks
+            # an upstream broken precondition (e.g. ``_save_mapping``
+            # swallowed a write error in ``work_packages_skeleton``).
+            # Without the WP map there are no watchers to migrate, but
+            # this is a *failure mode*, not a success, because every
+            # downstream consumer reading this component's
+            # ``ComponentResult`` would see green and move on.
+            msg = (
+                "No work_package mapping available — watchers cannot be"
+                " correlated to OP work packages. Run work_packages_skeleton"
+                " first (or verify its mapping persisted)."
+            )
+            logger.error(msg)
+            return ComponentResult(
+                success=False,
+                message=msg,
+                errors=["missing_work_package_mapping"],
+                details={},
+            )
 
         # Collect all watchers for bulk creation. Track *why* each
         # watcher was skipped so a post-run summary can distinguish

--- a/tests/unit/test_attachment_provenance_migration.py
+++ b/tests/unit/test_attachment_provenance_migration.py
@@ -78,3 +78,31 @@ def test_attachment_provenance_updates_author_and_timestamp():
     ld = mig._load(mp)
     assert ld.success is True
     assert ld.updated == 2
+
+
+def test_attachment_provenance_fails_loud_on_empty_wp_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Empty WP mapping must FAIL loud, not silently exit success.
+
+    Same anti-pattern as the pre-#194 attachments path. If
+    ``work_packages_skeleton`` doesn't persist its mapping (e.g.
+    ``_save_mapping`` swallows a write error per #197), this
+    component used to return ``success=True, updated=0`` —
+    masking the missing precondition. Pin: empty WP mapping →
+    ``success=False`` with a stable error tag.
+    """
+    import src.config as cfg
+
+    class EmptyMappings:
+        def get_mapping(self, name: str):
+            return {}
+
+    monkeypatch.setattr(cfg, "mappings", EmptyMappings(), raising=False)
+
+    mig = AttachmentProvenanceMigration(jira_client=DummyJira(), op_client=DummyOp())  # type: ignore[arg-type]
+    result = mig.run()
+
+    assert result.success is False, result
+    assert any("missing_work_package_mapping" in str(e) for e in (result.errors or [])), result.errors
+    assert "work_package" in (result.message or "").lower(), result.message

--- a/tests/unit/test_watcher_migration.py
+++ b/tests/unit/test_watcher_migration.py
@@ -272,6 +272,38 @@ def test_skip_reasons_breakdown_sums_to_total_skipped(
     )
 
 
+def test_watcher_migration_fails_loud_on_empty_wp_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    _map_store,
+    tmp_path,
+):
+    """Empty WP mapping must FAIL loud — same anti-pattern as #194/#197.
+
+    If ``work_packages_skeleton`` didn't persist its mapping, the
+    pre-#198 watcher path returned the default ``success=True``
+    result with a "skipping" log line, masking the upstream
+    failure. Pin: empty WP mapping → ``success=False`` with the
+    stable ``missing_work_package_mapping`` error tag.
+    """
+    op = DummyOpClient()
+    # Override autouse fixture with an empty WP mapping (the bug
+    # condition). The cache file is irrelevant — early exit fires
+    # before it's checked.
+    _map_store.set_mapping("work_package", {})
+
+    class DummyJira:
+        def get_issue_watchers(self, key: str):
+            return []
+
+    wm = WatcherMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    wm.data_dir = tmp_path
+
+    res = wm.run()
+
+    assert res.success is False, res
+    assert any("missing_work_package_mapping" in str(e) for e in (res.errors or [])), res.errors
+
+
 def test_skip_reasons_empty_when_all_succeed(
     monkeypatch: pytest.MonkeyPatch,
     _map_store,


### PR DESCRIPTION
## Summary

Sweep continuation of [#194](https://github.com/netresearch/jira-to-openproject/pull/194) + [#197](https://github.com/netresearch/jira-to-openproject/pull/197). Same silent-failure pattern (\`return ComponentResult(success=True, updated=0)\` when the work_package mapping is empty) lived in two more components.

## Fix

Two more loud-fail conversions:

- **\`attachment_provenance_migration.py\`**: was returning \`success=True, updated=0, message="No work packages to process"\` — now \`success=False, errors=["missing_work_package_mapping"]\`.
- **\`watcher_migration.py\`**: was returning the default \`success=True\` \`ComponentResult\` with a "skipping" log line — now \`success=False, errors=["missing_work_package_mapping"]\`.

Both use the same stable error tag (\`missing_work_package_mapping\`) that #194 established, so dashboards / alerts can pattern-match the whole class with one rule.

## Combined surface

After PRs #194, #197, #198: the originating silent-success in \`_save_mapping\` is caught at the source (#197), AND every downstream component that consumed the WP mapping now refuses to silently no-op (#194, #198). The next migration that hits this bug class surfaces multiple loud failures pointing at the same root cause instead of zero.

## Test plan

- [x] 2 new regression tests (one per component)
- [x] 11/11 attachment-provenance + watcher tests passing
- [x] Local lint + format clean
- [ ] CI sweep