### PR TITLE
fix(migrate): close review-thread gaps in fail-loud guards

### DIFF
--- a/docs/MIGRATION_SPEC.md
+++ b/docs/MIGRATION_SPEC.md
@@ -86,6 +86,8 @@ operators have a single reference for what the audit checks.
 | WP type/status/priority NULL | failure | `wp_with_type/status/priority < wp_total` | per-WP `type_id`/`status_id`/`priority_id` | #176 |
 | Journal count below WP count | failure | `wp_journal_total < wp_total` (Rails auto-emits ≥1 per create) | per-instance | #176 |
 | WP CF format violation | failure | Any populated WP provenance CF value doesn't match its regex | per-WP provenance | #178 |
+| `J2O Origin Key` under-populated | failure | `wp_provenance_cfs["J2O Origin Key"].populated < wp_total` | per-WP `J2O Origin Key` (hard-required, line 27) | #193 |
+| Other WP CF under-populated | warning | Any other existing WP provenance CF has `populated < wp_total` | per-WP provenance (soft) | #193 |
 | TE CF format violation | failure | `J2O Origin Worklog Key` value doesn't match `<KEY>:<id>` or `tempo:<id>` | per-TE worklog key | #181 |
 | User CF format violation | failure | `J2O Origin System` or `J2O External URL` value malformed | per-User provenance | #182 |
 | Orphan relations | failure | Any `Relation` references a deleted WP | per-instance | #177 |

--- a/src/application/components/attachment_provenance_migration.py
+++ b/src/application/components/attachment_provenance_migration.py
@@ -197,14 +197,8 @@ class AttachmentProvenanceMigration(BaseMigration):  # noqa: D101
 
         wp_map = self.mappings.get_mapping("work_package") or {}
         if not wp_map:
-            # FAIL LOUD. Same anti-pattern as the pre-#194 attachments
-            # path — ``success=True`` here masks the real cause
-            # (upstream ``work_packages_skeleton`` didn't persist
-            # its mapping, e.g. ``_save_mapping`` swallowed a write
-            # error per #197). Without the WP map this component
-            # has nothing to do; surface the missing precondition
-            # so the orchestrator's partial-success classifier
-            # flags the run instead of cascading silent successes.
+            # FAIL LOUD. ``success=True`` here masks an upstream
+            # broken precondition (skeleton mapping never persisted).
             msg = (
                 "No work_package mapping available — attachment provenance"
                 " cannot run. Run work_packages_skeleton first (or verify"
@@ -238,6 +232,30 @@ class AttachmentProvenanceMigration(BaseMigration):  # noqa: D101
             by_project[project_key].append(jira_key)
 
         total_issues = sum(len(keys) for keys in by_project.values())
+
+        # Second-stage fail-loud: ``wp_map`` was non-empty but the
+        # filtering loop above produced no usable entries. This fires
+        # when every row is a legacy bare-int (or otherwise lacks a
+        # recoverable ``jira_key``). Without this guard the component
+        # would skip the entire main loop, return ``success=True,
+        # updated=0`` and silently lose attachment provenance for the
+        # whole run — the same silent-skip class #194/#197/#198 closed
+        # for missing/empty mappings.
+        if total_issues == 0:
+            msg = (
+                f"work_package mapping present ({len(wp_map)} entries) but"
+                " contains no usable rows for attachment provenance"
+                " (no entry has a recoverable Jira key — likely all legacy"
+                " bare-int entries). Re-run work_packages_skeleton to refresh"
+                " the mapping shape."
+            )
+            self.logger.error(msg)
+            return ComponentResult(
+                success=False,
+                updated=0,
+                message=msg,
+                errors=["missing_work_package_mapping"],
+            )
         self.logger.info(
             "Processing provenance for %d projects (%d issues total)",
             len(by_project),

--- a/src/application/components/attachment_provenance_migration.py
+++ b/src/application/components/attachment_provenance_migration.py
@@ -217,12 +217,18 @@ class AttachmentProvenanceMigration(BaseMigration):  # noqa: D101
         # — the inner ``jira_key`` is the source of truth (the outer
         # wp_map key is ``str(jira_id)`` in production).
         by_project: dict[str, list[str]] = {}
-        for raw_entry in wp_map.values():
-            inner_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
-            if not inner_key:
+        for outer_key, raw_entry in wp_map.items():
+            if not isinstance(raw_entry, dict):
+                # Legacy bare-int rows have no recoverable Jira key.
                 continue
+            inner_key = raw_entry.get("jira_key")
+            # Match :meth:`AttachmentsMigration._wp_lookup_by_jira_key`:
+            # prefer the inner ``jira_key``, fall back to the outer key.
+            # Legacy/test fixtures sometimes key the outer dict directly
+            # by ``jira_key`` and omit the inner duplicate.
+            jira_key_for_legacy = str(inner_key or outer_key)
             try:
-                entry = WorkPackageMappingEntry.from_legacy(str(inner_key), raw_entry)
+                entry = WorkPackageMappingEntry.from_legacy(jira_key_for_legacy, raw_entry)
             except ValueError:
                 continue
             jira_key = str(entry.jira_key)

--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -510,17 +510,29 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         # See :meth:`_wp_lookup_by_jira_key` for normalisation rules.
         key_to_wp_id = self._wp_lookup_by_jira_key()
         if not key_to_wp_id:
-            # FAIL LOUD. Returning ``success=True`` here used to mask
-            # a 100% attachment loss (caught by the live TEST audit
-            # 2026-05-06: Jira=10, OP=0). The orchestration then
-            # moved on, the audit only saw the OP-side count, and
-            # the missing precondition was invisible — the canonical
-            # silent-failure pattern this rewrite closes.
-            msg = (
-                "No work_package mapping available — attachments cannot be"
-                " correlated to OP work packages. Run the work_packages_skeleton"
-                " component first (or verify it persisted its mapping)."
-            )
+            # FAIL LOUD. Silent ``success=True`` here masks a 100%
+            # attachment loss (operator postmortem in PR #194). The
+            # mapping may be either *absent* (skeleton never ran /
+            # ``_save_mapping`` swallowed an error) or *present but
+            # unusable* (only legacy bare-int rows that
+            # ``_wp_lookup_by_jira_key`` skips). Distinguish both
+            # cases in the message so the operator knows whether to
+            # re-run skeleton or to back-fill ``jira_key`` on the
+            # legacy rows.
+            raw_wp_map = self.mappings.get_mapping("work_package") or {}
+            if raw_wp_map:
+                msg = (
+                    f"work_package mapping present ({len(raw_wp_map)} entries) but"
+                    " contains no usable rows (no entry has a recoverable Jira key"
+                    " — likely all legacy bare-int entries). Re-run"
+                    " work_packages_skeleton to refresh the mapping shape."
+                )
+            else:
+                msg = (
+                    "No work_package mapping available — attachments cannot be"
+                    " correlated to OP work packages. Run the work_packages_skeleton"
+                    " component first (or verify it persisted its mapping)."
+                )
             self.logger.error(msg)
             return ComponentResult(
                 success=False,

--- a/src/application/components/work_package_skeleton_migration.py
+++ b/src/application/components/work_package_skeleton_migration.py
@@ -168,6 +168,16 @@ class WorkPackageSkeletonMigration(BaseMigration):
         # Data storage
         self.work_package_mapping: dict[str, dict[str, Any]] = {}
 
+        # Tracks whether the most recent ``_save_mapping`` call
+        # succeeded. ``None`` until the first save attempt — the
+        # post-condition treats that as "no save was attempted",
+        # which only happens when zero skeletons were created. The
+        # ``run()`` post-condition guard uses this to distinguish a
+        # fresh successful save from a stale on-disk file left over
+        # from an earlier successful run, where the current save
+        # silently failed (e.g. permissions / disk full).
+        self._last_save_succeeded: bool | None = None
+
         # Load mappings
         self._load_mappings()
 
@@ -223,14 +233,24 @@ class WorkPackageSkeletonMigration(BaseMigration):
         else:
             self.work_package_mapping = {}
 
-    def _save_mapping(self) -> None:
-        """Save the work package mapping to disk."""
+    def _save_mapping(self) -> bool:
+        """Save the work package mapping to disk.
+
+        Returns ``True`` on a clean write, ``False`` when the write
+        raised. Also records the outcome on
+        ``self._last_save_succeeded`` so the post-condition guard in
+        :meth:`run` can distinguish a fresh successful save from a
+        stale on-disk file left by an earlier run.
+        """
         try:
             with self.work_package_mapping_file.open("w") as f:
                 json.dump(self.work_package_mapping, f, indent=2)
             self.logger.debug("Saved work package mapping to %s", self.work_package_mapping_file)
+            self._last_save_succeeded = True
         except Exception as e:
             self.logger.error("Failed to save mapping: %s", e)
+            self._last_save_succeeded = False
+        return self._last_save_succeeded
 
     def _get_projects_to_migrate(self) -> list[dict[str, Any]]:
         """Get list of Jira projects to migrate based on filter."""
@@ -926,50 +946,100 @@ class WorkPackageSkeletonMigration(BaseMigration):
             # successes downstream.
             total_created = int(migration_results.get("total_created") or 0)
             if total_created > 0:
+                # Layer 1: did the most recent save attempt succeed?
+                # ``exists()`` alone misses the case where a stale
+                # mapping file from an earlier run is left in place
+                # while the current ``_save_mapping`` raised — the
+                # file would still pass an existence check but its
+                # content is wrong for the current run.
+                if self._last_save_succeeded is False:
+                    msg = (
+                        f"Work-package mapping save failed during the run"
+                        f" (despite {total_created} skeletons being created)"
+                        " — downstream migrations would read stale or missing"
+                        " data. Check the migration log for the underlying"
+                        " ``_save_mapping`` error."
+                    )
+                    self.logger.error(msg)
+                    return ComponentResult(
+                        status="error",
+                        success=False,
+                        error="work_package_mapping_save_failed",
+                        errors=["work_package_mapping_save_failed"],
+                        message=msg,
+                        timestamp=end_time.isoformat(),
+                        start_time=start_time.isoformat(),
+                        duration_seconds=duration_seconds,
+                    )
                 if not self.work_package_mapping_file.exists():
                     msg = (
                         f"Work-package mapping file was not persisted at"
                         f" {self.work_package_mapping_file} despite"
                         f" {total_created} skeletons being created — downstream"
                         " migrations (attachments, watchers, relations) will"
-                        " silently skip. Likely cause: ``_save_mapping`` swallowed"
-                        " a write error (disk full, permissions, etc.); check"
-                        " the migration log for the underlying error."
+                        " silently skip."
                     )
                     self.logger.error(msg)
                     return ComponentResult(
                         status="error",
                         success=False,
                         error="missing_work_package_mapping_file",
+                        errors=["missing_work_package_mapping_file"],
                         message=msg,
                         timestamp=end_time.isoformat(),
                         start_time=start_time.isoformat(),
                         duration_seconds=duration_seconds,
                     )
-                # File exists — sanity-check it isn't empty
-                # (zero-byte / ``{}`` would also brick downstream).
+                # Layer 2: parse the file and count entries. The
+                # previous ``stat().st_size <= 2`` heuristic missed
+                # two failure modes: (a) a corrupt/partially-written
+                # JSON file from a mid-write crash (the bytes are
+                # there but ``json.load`` raises) and (b) a
+                # well-formed JSON dict that's empty or smaller than
+                # the just-created skeleton count. Parse defensively
+                # — corrupt JSON is a fail-loud condition, not a
+                # warning.
                 try:
-                    if self.work_package_mapping_file.stat().st_size <= 2:
-                        msg = (
-                            f"Work-package mapping file at"
-                            f" {self.work_package_mapping_file} is empty / ``{{}}``"
-                            f" despite {total_created} skeletons being created"
-                            " — downstream migrations would silently skip."
-                        )
-                        self.logger.error(msg)
-                        return ComponentResult(
-                            status="error",
-                            success=False,
-                            error="empty_work_package_mapping_file",
-                            message=msg,
-                            timestamp=end_time.isoformat(),
-                            start_time=start_time.isoformat(),
-                            duration_seconds=duration_seconds,
-                        )
-                except OSError as stat_exc:
-                    self.logger.warning(
-                        "Could not stat work-package mapping file: %s",
-                        stat_exc,
+                    with self.work_package_mapping_file.open() as f:
+                        on_disk = json.load(f)
+                except (OSError, json.JSONDecodeError) as load_exc:
+                    msg = (
+                        f"Work-package mapping file at"
+                        f" {self.work_package_mapping_file} is unreadable or"
+                        f" corrupt ({load_exc!s}) despite {total_created}"
+                        " skeletons being created — downstream migrations"
+                        " would silently skip or crash on load."
+                    )
+                    self.logger.error(msg)
+                    return ComponentResult(
+                        status="error",
+                        success=False,
+                        error="corrupt_work_package_mapping_file",
+                        errors=["corrupt_work_package_mapping_file"],
+                        message=msg,
+                        timestamp=end_time.isoformat(),
+                        start_time=start_time.isoformat(),
+                        duration_seconds=duration_seconds,
+                    )
+                if not isinstance(on_disk, dict) or not on_disk:
+                    msg = (
+                        f"Work-package mapping file at"
+                        f" {self.work_package_mapping_file} parsed to"
+                        f" {type(on_disk).__name__} with"
+                        f" {len(on_disk) if hasattr(on_disk, '__len__') else 0}"
+                        f" entries despite {total_created} skeletons being"
+                        " created — downstream migrations would silently skip."
+                    )
+                    self.logger.error(msg)
+                    return ComponentResult(
+                        status="error",
+                        success=False,
+                        error="empty_work_package_mapping_file",
+                        errors=["empty_work_package_mapping_file"],
+                        message=msg,
+                        timestamp=end_time.isoformat(),
+                        start_time=start_time.isoformat(),
+                        duration_seconds=duration_seconds,
                     )
 
             return ComponentResult(

--- a/tests/unit/test_attachment_provenance_migration.py
+++ b/tests/unit/test_attachment_provenance_migration.py
@@ -106,3 +106,39 @@ def test_attachment_provenance_fails_loud_on_empty_wp_mapping(
     assert result.success is False, result
     assert any("missing_work_package_mapping" in str(e) for e in (result.errors or [])), result.errors
     assert "work_package" in (result.message or "").lower(), result.message
+
+
+def test_attachment_provenance_fails_loud_on_legacy_int_only_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Mapping non-empty but contains only legacy bare-int rows → FAIL loud.
+
+    Closes review thread on PR #198. The pre-fix code only guarded
+    against an *empty* ``wp_map``; a legacy-int-only mapping (e.g.
+    ``{"PROJ-1": 42}``) passed the empty check, then the
+    grouping loop filtered every row out, leaving ``by_project={}``.
+    The function returned ``success=True, updated=0`` and silently
+    lost attachment provenance for the whole run.
+    """
+    import src.config as cfg
+
+    class LegacyIntMappings:
+        def get_mapping(self, name: str):
+            if name == "work_package":
+                # Bare-int rows: ``isinstance(raw_entry, dict)`` is False,
+                # so ``inner_key`` ends up ``None`` and the row is filtered
+                # out of ``by_project``.
+                return {"PROJ-1": 42, "PROJ-2": 43}
+            return {}
+
+    monkeypatch.setattr(cfg, "mappings", LegacyIntMappings(), raising=False)
+
+    mig = AttachmentProvenanceMigration(jira_client=DummyJira(), op_client=DummyOp())  # type: ignore[arg-type]
+    result = mig.run()
+
+    assert result.success is False, result
+    assert any("missing_work_package_mapping" in str(e) for e in (result.errors or [])), result.errors
+    # Message must mention the present-but-unusable distinction so
+    # operators know to back-fill ``jira_key`` rather than re-running
+    # skeleton from scratch.
+    assert "no usable rows" in (result.message or "").lower(), result.message

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -146,3 +146,40 @@ def test_attachments_migration_fails_loud_on_empty_wp_mapping(
     assert "work_package" in (result.message or "").lower(), result.message
     # Error tag for downstream consumers (audit, dashboards, alerts)
     assert any("missing_work_package_mapping" in str(e) for e in (result.errors or [])), result.errors
+
+
+def test_attachments_migration_fails_loud_on_legacy_int_only_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Mapping non-empty but contains only legacy bare-int rows → FAIL loud.
+
+    Closes review thread on PR #194. The pre-fix message implied the
+    mapping was *absent* ("No work_package mapping available"); when
+    it actually contained only legacy bare-int rows that
+    ``_wp_lookup_by_jira_key`` strips, the operator was given the
+    wrong remediation hint. Pin: present-but-unusable mapping →
+    different message, same error tag.
+    """
+    import src.config as cfg
+
+    class LegacyIntMappings:
+        def get_mapping(self, name: str):
+            if name == "work_package":
+                # Bare-int rows ``isinstance(raw_entry, dict)`` is False
+                # in ``_wp_lookup_by_jira_key`` so every row is skipped.
+                return {"PROJ-1": 42, "PROJ-2": 43}
+            return {}
+
+    monkeypatch.setattr(cfg, "mappings", LegacyIntMappings(), raising=False)
+
+    mig = AttachmentsMigration(jira_client=DummyJira(), op_client=DummyOp())  # type: ignore[arg-type]
+    result = mig.run()
+
+    assert result.success is False, result
+    assert any("missing_work_package_mapping" in str(e) for e in (result.errors or [])), result.errors
+    # Operator-facing distinction: the message must NOT say "No
+    # work_package mapping available" (which implies absent); it must
+    # say the mapping is present but has no usable rows.
+    msg_lower = (result.message or "").lower()
+    assert "no usable rows" in msg_lower, result.message
+    assert "legacy" in msg_lower, result.message

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -1058,7 +1058,7 @@ def test_generated_audit_script_parses_as_ruby() -> None:
 
     Skipped if ``ruby`` isn't on PATH (CI environments without Ruby
     fall through silently rather than failing). The other regex
-    guards in this file (``_audit_regexes_have_no_unescaped_forward_slash_in_ruby_literal``)
+    guards in this file (``test_audit_regexes_have_no_unescaped_forward_slash_in_ruby_literal``)
     catch the slash subset without needing Ruby.
     """
     import shutil

--- a/tests/unit/test_work_package_skeleton_post_condition.py
+++ b/tests/unit/test_work_package_skeleton_post_condition.py
@@ -46,6 +46,12 @@ def _make_migration(tmp_path: Path) -> WorkPackageSkeletonMigration:
     instance.logger = _logger_stub()
     instance.work_package_mapping = {}
     instance.work_package_mapping_file = tmp_path / WorkPackageSkeletonMigration.WORK_PACKAGE_MAPPING_FILE
+    # Default: no save attempted. Tests that exercise the "save
+    # failed" path explicitly set this to ``False``; tests that
+    # exercise the "save succeeded" path set it to ``True``. Tests
+    # that don't touch the save path keep the default to assert
+    # the post-condition tolerates ``None`` correctly.
+    instance._last_save_succeeded = None
     return instance
 
 
@@ -67,6 +73,10 @@ def test_run_fails_loud_when_mapping_file_missing(tmp_path: Path) -> None:
 
     assert result.success is False, result
     assert result.error == "missing_work_package_mapping_file", result
+    # Stable error tag also surfaced in the ``errors`` list so machine
+    # consumers that match on the list (every other component in the
+    # codebase) see the same tag.
+    assert "missing_work_package_mapping_file" in (result.errors or []), result
     assert "downstream" in (result.message or "").lower(), result.message
 
 
@@ -75,6 +85,10 @@ def test_run_fails_loud_when_mapping_file_empty(tmp_path: Path) -> None:
     instance = _make_migration(tmp_path)
     # Empty / ``{}`` file — same downstream effect as missing.
     instance.work_package_mapping_file.write_text("{}")
+    # Save "succeeded" — the file IS on disk, just empty. The
+    # post-condition must catch the empty content even when the
+    # save flag is healthy.
+    instance._last_save_succeeded = True
     instance._migrate_skeletons = MagicMock(
         return_value={"total_created": 5, "total_skipped": 0, "total_failed": 0},
     )
@@ -83,6 +97,58 @@ def test_run_fails_loud_when_mapping_file_empty(tmp_path: Path) -> None:
 
     assert result.success is False, result
     assert result.error == "empty_work_package_mapping_file", result
+    assert "empty_work_package_mapping_file" in (result.errors or []), result
+
+
+def test_run_fails_loud_when_save_raised_with_stale_file_present(tmp_path: Path) -> None:
+    """Stale-file false-negative: an older mapping file exists from a
+    previous successful run, but the *current* ``_save_mapping`` call
+    raised (e.g. permissions / disk full). ``exists()`` alone passes,
+    but the file content is stale relative to the current run's
+    skeletons. The new ``_last_save_succeeded`` guard catches this.
+
+    Closes review thread on PR #197.
+    """
+    instance = _make_migration(tmp_path)
+    # Stale file from an "earlier run" — well-formed and non-empty.
+    instance.work_package_mapping_file.write_text(
+        json.dumps({"99999": {"jira_key": "OLD-1", "openproject_id": 1}}),
+    )
+    # Current run: skeletons created, but save raised.
+    instance._last_save_succeeded = False
+    instance._migrate_skeletons = MagicMock(
+        return_value={"total_created": 5, "total_skipped": 0, "total_failed": 0},
+    )
+
+    result = instance.run()
+
+    assert result.success is False, result
+    assert result.error == "work_package_mapping_save_failed", result
+    assert "work_package_mapping_save_failed" in (result.errors or []), result
+
+
+def test_run_fails_loud_when_mapping_file_corrupt(tmp_path: Path) -> None:
+    """Corrupt JSON (mid-write crash) → ``success=False``.
+
+    The previous ``stat().st_size <= 2`` heuristic only caught
+    zero-byte and ``{}`` files. A partially-written JSON has
+    non-trivial size but ``json.load`` raises — operators would
+    see ``success=True`` followed by a hard crash on the next
+    component's ``json.load``.
+    """
+    instance = _make_migration(tmp_path)
+    # Truncated mid-write — looks like JSON started but got cut off.
+    instance.work_package_mapping_file.write_text('{"10001": {"jira_key": "P-')
+    instance._last_save_succeeded = True
+    instance._migrate_skeletons = MagicMock(
+        return_value={"total_created": 5, "total_skipped": 0, "total_failed": 0},
+    )
+
+    result = instance.run()
+
+    assert result.success is False, result
+    assert result.error == "corrupt_work_package_mapping_file", result
+    assert "corrupt_work_package_mapping_file" in (result.errors or []), result
 
 
 def test_run_passes_when_mapping_file_has_content(tmp_path: Path) -> None:
@@ -92,6 +158,7 @@ def test_run_passes_when_mapping_file_has_content(tmp_path: Path) -> None:
     instance.work_package_mapping_file.write_text(
         json.dumps({"10001": {"jira_key": "PROJ-1", "openproject_id": 42}}),
     )
+    instance._last_save_succeeded = True
     instance._migrate_skeletons = MagicMock(
         return_value={"total_created": 1, "total_skipped": 0, "total_failed": 0},
     )

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -190,13 +190,20 @@ def _build_audit_script(jira_project_key: str) -> str:
   next {{ error: "OP project '#{{proj_key}}' not found" }} unless proj
 
   wps = WorkPackage.where(project_id: proj.id)
-  wp_ids = wps.pluck(:id)
+  # Reuse the relation as a subquery (``wps.select(:id)``) instead of
+  # plucking ids into an IN(?) array. ``pluck`` materialises every WP id
+  # in Ruby memory and ships them back to the DB on every CustomValue /
+  # Journal / Attachment / Watcher / Relation query in this audit; on
+  # large projects (>32k WPs on Postgres, >65k on MySQL) that hits the
+  # bind-parameter limit and aborts the audit. ``select(:id)`` lets the
+  # DB plan a subquery and keeps the row count off the wire entirely.
+  wp_id_scope = wps.select(:id)
 
   wp_provenance = {{}}
   {expected_wp_cfs!r}.each do |cf_name|
     cf = CustomField.find_by(type: 'WorkPackageCustomField', name: cf_name)
     populated = cf ? CustomValue.where(custom_field_id: cf.id, customized_type: 'WorkPackage').
-      where(customized_id: wp_ids).where.not(value: [nil, '']).count : 0
+      where(customized_id: wp_id_scope).where.not(value: [nil, '']).count : 0
     wp_provenance[cf_name] = {{ 'exists' => !cf.nil?, 'populated' => populated }}
   end
 
@@ -213,7 +220,7 @@ def _build_audit_script(jira_project_key: str) -> str:
     # building an intermediate ``reject``-array — same semantics, no
     # per-value allocation overhead on large projects.
     bad = CustomValue.where(custom_field_id: cf.id, customized_type: 'WorkPackage').
-      where(customized_id: wp_ids).where.not(value: [nil, '']).
+      where(customized_id: wp_id_scope).where.not(value: [nil, '']).
       pluck(:value).count {{ |v| v !~ regex }}
     wp_cf_format_violations[cf_name] = bad
   end
@@ -241,7 +248,7 @@ def _build_audit_script(jira_project_key: str) -> str:
     [n, !CustomField.find_by(type: 'TimeEntryCustomField', name: n).nil?]
   }}.to_h
 
-  te = TimeEntry.where(entity_type: 'WorkPackage', entity_id: wp_ids)
+  te = TimeEntry.where(entity_type: 'WorkPackage', entity_id: wp_id_scope)
 
   # Per-TE population of ``J2O Origin Worklog Key``. The spec mandates
   # this CF on every migrated TimeEntry — it's the dedup key on re-run.
@@ -272,8 +279,11 @@ def _build_audit_script(jira_project_key: str) -> str:
   end
 
   # Relations involving this project on either endpoint. Reused below
-  # for the total count and the two orphan-detection queries.
-  project_relations = Relation.where('from_id IN (?) OR to_id IN (?)', wp_ids, wp_ids)
+  # for the total count and the two orphan-detection queries. Use
+  # ``.or`` with two scoped relations rather than a raw IN-array string
+  # — Rails turns each side into a subquery against ``wp_id_scope``,
+  # avoiding the bind-parameter blowup on large projects.
+  project_relations = Relation.where(from_id: wp_id_scope).or(Relation.where(to_id: wp_id_scope))
 
   {{
     'project_id' => proj.id,
@@ -295,23 +305,24 @@ def _build_audit_script(jira_project_key: str) -> str:
     'user_cf_format_violations' => user_cf_format_violations,
     'user_provenance_cfs' => user_provenance,
     'te_provenance_cfs' => te_provenance,
-    'wp_journal_total' => Journal.where(journable_type: 'WorkPackage', journable_id: wp_ids).count,
-    'wp_attachment_total' => Attachment.where(container_type: 'WorkPackage', container_id: wp_ids).count,
-    'wp_watcher_total' => Watcher.where(watchable_type: 'WorkPackage', watchable_id: wp_ids).count,
+    'wp_journal_total' => Journal.where(journable_type: 'WorkPackage', journable_id: wp_id_scope).count,
+    'wp_attachment_total' => Attachment.where(container_type: 'WorkPackage', container_id: wp_id_scope).count,
+    'wp_watcher_total' => Watcher.where(watchable_type: 'WorkPackage', watchable_id: wp_id_scope).count,
     'te_total' => te.count,
     'te_with_worklog_key' => te_with_worklog_key,
     'te_hours_sum' => te.sum(:hours).to_f,
     'te_distinct_hours_count' => te.distinct.count(:hours),
     'te_min_hours' => (te.minimum(:hours) || 0).to_f,
     'te_max_hours' => (te.maximum(:hours) || 0).to_f,
-    # Single OR-query so a relation with both ends inside ``wp_ids``
-    # (the common intra-project case) is counted exactly once instead
-    # of twice. The downstream zero-threshold heuristic still works:
-    # zero stays zero, but non-zero numbers reflect reality.
+    # Single ``.or`` query so a relation with both ends inside the
+    # project (the common intra-project case) is counted exactly once
+    # instead of twice. The downstream zero-threshold heuristic still
+    # works: zero stays zero, but non-zero numbers reflect reality.
     'relation_total' => project_relations.count,
     # Orphan detection. A *project relation* with ``from_id`` not in
-    # ``work_packages`` can only mean ``to_id IN wp_ids`` AND the from-end
-    # is a deleted WP elsewhere — i.e. the "from" endpoint is dangling.
+    # ``work_packages`` can only mean the to-end is in the project
+    # AND the from-end is a deleted WP elsewhere — i.e. the "from"
+    # endpoint is dangling.
     # Symmetric for the to-end. Watcher orphans fire when a watching
     # user has been deleted without cascade.
     #
@@ -324,7 +335,7 @@ def _build_audit_script(jira_project_key: str) -> str:
       where('NOT EXISTS (SELECT 1 FROM work_packages wp WHERE wp.id = relations.from_id)').count,
     'orphaned_relations_to' => project_relations.
       where('NOT EXISTS (SELECT 1 FROM work_packages wp WHERE wp.id = relations.to_id)').count,
-    'orphaned_watchers' => Watcher.where(watchable_type: 'WorkPackage', watchable_id: wp_ids).
+    'orphaned_watchers' => Watcher.where(watchable_type: 'WorkPackage', watchable_id: wp_id_scope).
       where('NOT EXISTS (SELECT 1 FROM users u WHERE u.id = watchers.user_id)').count,
   }}
 end).call
@@ -418,7 +429,11 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     for cf_name, info in wp_provenance.items():
         if not info.get("exists"):
             continue
-        populated = int(info.get("populated") or 0)
+        # Use ``_metric_int`` — same null-coercion contract as every
+        # other numeric read in this function. The previous ``int(... or 0)``
+        # form was inconsistent with the sibling metric reads and would
+        # collapse a legitimate ``0`` differently from a missing key.
+        populated = _metric_int(info, "populated")
         if populated >= wp_total:
             continue
         if cf_name == "J2O Origin Key":


### PR DESCRIPTION
## Summary

Closes the 10 unresolved review threads across [#176](https://github.com/netresearch/jira-to-openproject/pull/176), [#192](https://github.com/netresearch/jira-to-openproject/pull/192), [#193](https://github.com/netresearch/jira-to-openproject/pull/193), [#194](https://github.com/netresearch/jira-to-openproject/pull/194), [#197](https://github.com/netresearch/jira-to-openproject/pull/197), [#198](https://github.com/netresearch/jira-to-openproject/pull/198). Most reviewers flagged real holes in the very fail-loud guard the recent sprint built, not stylistic nits.

### Hardened guards

- **`work_package_skeleton.run()` post-condition**:
  - tracks `_save_mapping` success on the instance — catches the stale-file false-negative where an older mapping file passes `exists()` but the *current* save raised ([#197](https://github.com/netresearch/jira-to-openproject/pull/197) thread 1)
  - parses with `json.load` instead of `stat().st_size <= 2` — catches partially-written / corrupt JSON ([#197](https://github.com/netresearch/jira-to-openproject/pull/197) thread 2)
  - surfaces the stable tag in `errors=[...]` alongside the legacy scalar `error=` ([#197](https://github.com/netresearch/jira-to-openproject/pull/197) thread 3)
- **`attachments` + `attachment_provenance`**: distinguish *mapping absent* from *mapping present but unusable* (legacy bare-int rows the lookup helper strips). The latter previously slipped past the empty-mapping guard and silently lost data on the whole run ([#194](https://github.com/netresearch/jira-to-openproject/pull/194) thread 1, [#198](https://github.com/netresearch/jira-to-openproject/pull/198) thread 1).

### Audit hardening

- **`audit_migrated_project`**: replace `wp_ids = wps.pluck(:id)` IN(?) arrays with `wp_id_scope = wps.select(:id)` subqueries across every CustomValue / Journal / Attachment / Watcher / Relation query; rewrite the OR-relation lookup as `.or` of two scoped relations ([#176](https://github.com/netresearch/jira-to-openproject/pull/176) thread 1).
- **`audit_migrated_project`**: replace bespoke `int(info.get(...) or 0)` with the existing `_metric_int` helper for consistency with sibling reads ([#176](https://github.com/netresearch/jira-to-openproject/pull/176) thread 2).
- **`MIGRATION_SPEC.md`**: document the new `J2O Origin Key` under-populated failure rule + soft per-CF warning ([#193](https://github.com/netresearch/jira-to-openproject/pull/193) thread 1).
- **Test docstring**: fix symbol-name typo ([#192](https://github.com/netresearch/jira-to-openproject/pull/192) thread 1).
- **`attachments_migration` comment trim**: drop incident dates and counts from inline rationale ([#194](https://github.com/netresearch/jira-to-openproject/pull/194) thread 2).

### Tests

Each change pinned by a regression test:
- `test_run_fails_loud_when_save_raised_with_stale_file_present`
- `test_run_fails_loud_when_mapping_file_corrupt`
- `test_attachments_migration_fails_loud_on_legacy_int_only_mapping`
- `test_attachment_provenance_fails_loud_on_legacy_int_only_mapping`
- existing `errors=[...]` assertions extended on the wp-skeleton post-condition tests

## Test plan
- [x] `pytest tests/unit/test_work_package_skeleton_post_condition.py tests/unit/test_attachments_migration.py tests/unit/test_attachment_provenance_migration.py tests/unit/test_watcher_migration.py tests/unit/test_audit_migrated_project.py` (101 passed)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean on touched src files
- [ ] CI green