### PR TITLE
fix(watchers,tests): unblock watcher migration + stop test pollution

### DIFF
--- a/src/application/components/watcher_migration.py
+++ b/src/application/components/watcher_migration.py
@@ -163,7 +163,15 @@ class WatcherMigration(BaseMigration):
         # as a set so a user watching N issues only logs once.
         unmapped_users: set[str] = set()
 
-        # Use cached issues if available, otherwise iterate through keys directly
+        # Use cached issues if available, otherwise iterate through keys directly.
+        # The ``issue`` value is only used by the field-fallback path
+        # below when the explicit watchers API call fails — when there's
+        # no cache we still iterate the keys and rely on the API. The
+        # previous fallback ``{k: {} for k in jira_keys}`` combined with
+        # an early ``if not issue: skip`` was a self-inflicted bug:
+        # every empty placeholder failed the truthiness check and got
+        # categorised as ``empty_issue``, dropping all 4204 watchers
+        # silently on the live TEST run (2026-05-07).
         issues: dict[str, Any] = {}
         cache_file = self.data_dir / "jira_issues_cache.json"
         if cache_file.exists():
@@ -176,15 +184,15 @@ class WatcherMigration(BaseMigration):
             except Exception:
                 issues = {}
 
-        # If no cache, create a minimal dict from jira_keys for iteration
+        # If no cache, create a minimal dict from jira_keys for iteration.
+        # The empty placeholder values are intentional — the explicit
+        # watchers API call below doesn't need any issue body, and the
+        # field-fallback handles the empty case gracefully.
         if not issues:
             logger.info("No cached issues, will iterate through %d Jira keys", len(jira_keys))
             issues = {k: {} for k in jira_keys}
 
         for key, issue in issues.items():
-            if not issue:
-                skip_reasons["empty_issue"] += 1
-                continue
             wp_id = self._resolve_wp_id(str(key))
             if not wp_id:
                 skip_reasons["wp_unmapped"] += 1

--- a/tests/end_to_end/test_complete_migration_workflow.py
+++ b/tests/end_to_end/test_complete_migration_workflow.py
@@ -4,17 +4,53 @@ These tests validate the entire migration process from start to finish,
 ensuring all components work together correctly.
 """
 
+from __future__ import annotations
+
+import contextlib
 import json
 import time
 from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src import config
+from src.mappings.mappings import Mappings
 from src.migration import create_backup, run_migration
 from src.models.component_results import ComponentResult
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@contextlib.contextmanager
+def _isolated_global_mappings(data_dir: Path) -> Iterator[Mappings]:
+    """Swap ``config.mappings`` for a tmp-scoped instance and restore on exit.
+
+    ``Mappings.set_mapping`` writes through to ``data_dir`` on disk —
+    when tests call it against the global ``config.mappings`` (which
+    initialises against the real ``var/data/``), they overwrite the
+    developer's working data. Caught by the live 2026-05-07 run: the
+    pre-existing seed-mapping calls below were wiping the 438-entry
+    ``user_mapping.json`` mid-migration, replacing it with the test
+    fixture ``{"alice": {"openproject_id": 1}}`` and dropping every
+    real worklog as ``user_unmapped`` downstream.
+
+    Usage:
+
+        with _isolated_global_mappings(data_dir) as tmp_mappings:
+            tmp_mappings.set_mapping(...)
+            ...  # rest of test body
+    """
+    original = config.mappings
+    tmp = Mappings(data_dir=data_dir)
+    config.mappings = tmp
+    try:
+        yield tmp
+    finally:
+        config.mappings = original
 
 
 def configure_comprehensive_mocks(mock_jira, mock_op):
@@ -1030,7 +1066,9 @@ class TestCompleteMigrationWorkflow:
         3. All items are processed correctly
         """
         # Set up test environment
-        test_env["J2O_DATA_DIR"] = str(temp_dir / "data")
+        data_dir = temp_dir / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        test_env["J2O_DATA_DIR"] = str(data_dir)
 
         # Create larger test dataset
         large_user_dataset = [
@@ -1120,53 +1158,54 @@ class TestCompleteMigrationWorkflow:
 
             start_time = time.time()
 
-            # Seed the mappings the work_packages preflight requires so the
-            # test runs the same way regardless of whatever happens to live
-            # in var/data on the developer host. (CI starts with an empty
-            # var/data, so the preflight aborts the run unless these are
-            # populated up-front.)
-            from src import config as _cfg
+            # Seed the mappings the work_packages preflight requires so
+            # the test runs the same way regardless of whatever happens
+            # to live in var/data on the developer host. Use the
+            # tmp-scoped helper so the writes go to ``data_dir`` instead
+            # of polluting the developer's real ``var/data/`` (the
+            # global ``config.mappings`` initialises against the real
+            # data dir at import time).
+            with _isolated_global_mappings(data_dir) as tmp_mappings:
+                tmp_mappings.set_mapping("project", {"TEST": {"openproject_id": 1}})
+                tmp_mappings.set_mapping("user", {"alice": {"openproject_id": 1}})
+                tmp_mappings.set_mapping("issue_type", {"Task": {"openproject_id": 1}})
+                tmp_mappings.set_mapping("issue_type_id", {"1": 1})
+                tmp_mappings.set_mapping("status", {"To Do": {"openproject_id": 1}})
 
-            _cfg.mappings.set_mapping("project", {"TEST": {"openproject_id": 1}})
-            _cfg.mappings.set_mapping("user", {"alice": {"openproject_id": 1}})
-            _cfg.mappings.set_mapping("issue_type", {"Task": {"openproject_id": 1}})
-            _cfg.mappings.set_mapping("issue_type_id", {"1": 1})
-            _cfg.mappings.set_mapping("status", {"To Do": {"openproject_id": 1}})
-
-            with (
-                patch(
-                    "src.config.migration_config",
-                    {
-                        "dry_run": False,
-                        "no_backup": True,
-                    },
-                ),
-                # User/work-package migrations rely on many downstream
-                # subsystems (custom fields, provenance, association
-                # migrators) that are out of scope for this performance test.
-                # Short-circuit them to a success result so the test can
-                # exercise the end-to-end orchestration timing assertion.
-                patch(
-                    "src.application.components.user_migration.UserMigration.run",
-                    return_value=ComponentResult(
-                        success=True,
-                        message="stubbed user migration",
-                        success_count=0,
+                with (
+                    patch(
+                        "src.config.migration_config",
+                        {
+                            "dry_run": False,
+                            "no_backup": True,
+                        },
                     ),
-                ),
-                patch(
-                    "src.application.components.work_package_migration.WorkPackageMigration.run",
-                    return_value=ComponentResult(
-                        success=True,
-                        message="stubbed work package migration",
-                        success_count=0,
+                    # User/work-package migrations rely on many downstream
+                    # subsystems (custom fields, provenance, association
+                    # migrators) that are out of scope for this performance test.
+                    # Short-circuit them to a success result so the test can
+                    # exercise the end-to-end orchestration timing assertion.
+                    patch(
+                        "src.application.components.user_migration.UserMigration.run",
+                        return_value=ComponentResult(
+                            success=True,
+                            message="stubbed user migration",
+                            success_count=0,
+                        ),
                     ),
-                ),
-            ):
-                result = await run_migration(
-                    components=["users", "work_packages"],
-                    no_confirm=True,
-                )
+                    patch(
+                        "src.application.components.work_package_migration.WorkPackageMigration.run",
+                        return_value=ComponentResult(
+                            success=True,
+                            message="stubbed work package migration",
+                            success_count=0,
+                        ),
+                    ),
+                ):
+                    result = await run_migration(
+                        components=["users", "work_packages"],
+                        no_confirm=True,
+                    )
 
             end_time = time.time()
             migration_time = end_time - start_time
@@ -1193,7 +1232,9 @@ class TestCompleteMigrationWorkflow:
         3. Custom fields are created before work packages (work packages may use custom fields)
         """
         # Set up test environment
-        test_env["J2O_DATA_DIR"] = str(temp_dir / "data")
+        data_dir = temp_dir / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        test_env["J2O_DATA_DIR"] = str(data_dir)
 
         call_order = []
 
@@ -1267,46 +1308,47 @@ class TestCompleteMigrationWorkflow:
 
             # See note in test_large_dataset_migration: seed the preflight
             # mappings so this test runs identically locally and in CI.
-            from src import config as _cfg
+            # Use the tmp-scoped helper so the writes don't pollute the
+            # developer's real ``var/data/``.
+            with _isolated_global_mappings(data_dir) as tmp_mappings:
+                tmp_mappings.set_mapping("project", {"TEST": {"openproject_id": 1}})
+                tmp_mappings.set_mapping("user", {"alice": {"openproject_id": 1}})
+                tmp_mappings.set_mapping("issue_type", {"Task": {"openproject_id": 1}})
+                tmp_mappings.set_mapping("issue_type_id", {"1": 1})
+                tmp_mappings.set_mapping("status", {"To Do": {"openproject_id": 1}})
 
-            _cfg.mappings.set_mapping("project", {"TEST": {"openproject_id": 1}})
-            _cfg.mappings.set_mapping("user", {"alice": {"openproject_id": 1}})
-            _cfg.mappings.set_mapping("issue_type", {"Task": {"openproject_id": 1}})
-            _cfg.mappings.set_mapping("issue_type_id", {"1": 1})
-            _cfg.mappings.set_mapping("status", {"To Do": {"openproject_id": 1}})
-
-            with (
-                patch(
-                    "src.config.migration_config",
-                    {
-                        "dry_run": False,
-                        "no_backup": True,
-                    },
-                ),
-                # See note in test_large_dataset_migration about stubbing the
-                # heavy migrations; the dependency-order assertion below only
-                # needs each component to complete successfully.
-                patch(
-                    "src.application.components.user_migration.UserMigration.run",
-                    return_value=ComponentResult(
-                        success=True,
-                        message="stubbed user migration",
-                        success_count=0,
+                with (
+                    patch(
+                        "src.config.migration_config",
+                        {
+                            "dry_run": False,
+                            "no_backup": True,
+                        },
                     ),
-                ),
-                patch(
-                    "src.application.components.work_package_migration.WorkPackageMigration.run",
-                    return_value=ComponentResult(
-                        success=True,
-                        message="stubbed work package migration",
-                        success_count=0,
+                    # See note in test_large_dataset_migration about stubbing the
+                    # heavy migrations; the dependency-order assertion below only
+                    # needs each component to complete successfully.
+                    patch(
+                        "src.application.components.user_migration.UserMigration.run",
+                        return_value=ComponentResult(
+                            success=True,
+                            message="stubbed user migration",
+                            success_count=0,
+                        ),
                     ),
-                ),
-            ):
-                result = await run_migration(
-                    components=["users", "projects", "work_packages"],
-                    no_confirm=True,
-                )
+                    patch(
+                        "src.application.components.work_package_migration.WorkPackageMigration.run",
+                        return_value=ComponentResult(
+                            success=True,
+                            message="stubbed work package migration",
+                            success_count=0,
+                        ),
+                    ),
+                ):
+                    result = await run_migration(
+                        components=["users", "projects", "work_packages"],
+                        no_confirm=True,
+                    )
 
             # Validate migration completed successfully
             assert result.overall["status"] == "success"

--- a/tests/unit/test_watcher_migration.py
+++ b/tests/unit/test_watcher_migration.py
@@ -327,3 +327,44 @@ def test_skip_reasons_empty_when_all_succeed(
     assert breakdown == {}, breakdown
     assert res.details["created"] == 1
     assert res.details["skipped"] == 0
+
+
+def test_watchers_added_without_issue_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    _map_store,
+    tmp_path,
+):
+    """No ``jira_issues_cache.json`` → watchers still get processed.
+
+    Regression: live TEST run (2026-05-07) showed all 4204 watchers
+    skipped as ``empty_issue`` because the no-cache fallback built
+    ``issues = {k: {} for k in jira_keys}`` and the immediate
+    ``if not issue: skip_reasons["empty_issue"]`` rejected every
+    placeholder. The ``issue`` value is only used by the
+    field-fallback path when the explicit ``get_issue_watchers``
+    API call raises — without a cache the API call still works,
+    so we must iterate keys regardless.
+    """
+    op = DummyOpClient()
+
+    class DummyJira:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def get_issue_watchers(self, key: str):
+            self.calls.append(key)
+            return [{"name": "alice"}]
+
+    jira = DummyJira()
+    wm = WatcherMigration(jira_client=jira, op_client=op)  # type: ignore[arg-type]
+    # Empty data_dir — NO cache file present.
+    wm.data_dir = tmp_path
+
+    res = wm.run()
+
+    # The watcher was created via the API path despite no cache.
+    assert res.success
+    assert op.added == [(10, 5)], op.added
+    assert "J1" in jira.calls, jira.calls
+    # No ``empty_issue`` skip reason — that bucket has been removed.
+    assert "empty_issue" not in res.details["skip_reasons"], res.details


### PR DESCRIPTION
## Summary

Two bugs caught by running the migration end-to-end on 2026-05-07:

### 1. Watcher migration silently dropped all 4204 watchers

The live run halted with `watchers: skip_reasons={"empty_issue": 4204}` (created=0, skipped=4204). Root cause: the no-cache fallback in `watcher_migration.run()` built `issues = {k: {} for k in jira_keys}` (placeholder empty dicts) and the very next line `if not issue: skip_reasons["empty_issue"] += 1` rejected every one as falsy.

The `issue` value is only used on the field-fallback path when the explicit `get_issue_watchers` API call raises — it has no purpose on the happy path. Removing the early-return lets the API call run for every key.

Pinned by `test_watchers_added_without_issue_cache`.

### 2. End-to-end tests polluted the developer's `var/data/`

`test_large_dataset_migration` and `test_component_dependency_order` called `config.mappings.set_mapping(...)` against the **global** `config.mappings` instance — which writes through to the real `var/data/`. Caught when a local pytest run mid-migration overwrote my 438-entry `user_mapping.json` with the test fixture `{"alice": {"openproject_id": 1}}`, dropping every real worklog as `user_unmapped` in the live `time_entries` phase.

Added `_isolated_global_mappings(data_dir)` context manager that creates a tmp-scoped `Mappings(data_dir=...)` and restores the original on exit. Both seed-mapping blocks now use it.

## Test plan
- [x] `pytest tests/unit/test_watcher_migration.py tests/end_to_end/test_complete_migration_workflow.py` (16 passed)
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green