### PR TITLE
fix(migrate): backfill assignee + provenance CFs on existing WPs

### DIFF
--- a/src/application/components/wp_metadata_backfill_migration.py
+++ b/src/application/components/wp_metadata_backfill_migration.py
@@ -1,0 +1,350 @@
+"""Backfill assignee + provenance CFs on existing OP work packages.
+
+Two distinct gaps the regular work-package migration cannot close on
+its own once a WP is already in OP:
+
+* **Bug A**: ``WorkPackage.assigned_to_id`` was left ``NULL`` on the
+  ~4075 WPs created before PR #175 fixed the Jira→OP user resolution
+  in the create payload. Audit shows 0.2% assignee coverage on NRS
+  even after a full re-run because ``work_package_migration`` only
+  sets ``assigned_to_id`` on the *create* path; existing WPs whose
+  user-mapping miss happened in an earlier run never get re-set.
+
+* **Bug D2 backfill**: ``_build_provenance_custom_field_entries`` (PR
+  #178) populates the 8 provenance CFs only at create-time. Existing
+  WPs have ``populated=0`` for every CF except the bootstrapped
+  ``J2O Origin Key``. The audit reports them as
+  ``WP CF '<name>' under-populated``.
+
+This component iterates the persisted ``work_package_mapping``, fetches
+each issue from Jira in batches, and emits a single Rails script per
+batch that conditionally sets the missing fields. Conditional update
+keeps the operation idempotent — a WP that already has a non-null
+``assigned_to_id`` (or already-populated CF) is left untouched and
+counted as ``skipped``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import UTC, datetime
+from typing import Any
+
+from src import config
+from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.application.components.work_package_skeleton_migration import (
+    _build_provenance_custom_field_entries,
+)
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.models import ComponentResult
+
+
+@register_entity_types("wp_metadata_backfill")
+class WpMetadataBackfillMigration(BaseMigration):
+    """Phase: backfill assignee + provenance CFs on existing WPs."""
+
+    BATCH_SIZE = 50
+
+    def __init__(self, jira_client: JiraClient, op_client: OpenProjectClient) -> None:
+        super().__init__(jira_client=jira_client, op_client=op_client)
+
+    def _get_current_entities_for_type(self, entity_type: str) -> list[dict[str, Any]]:
+        msg = (
+            "WpMetadataBackfillMigration is a transformation-only migration"
+            " and does not support idempotent workflow. It operates on the"
+            " persisted work_package mapping and fetches Jira data per-batch."
+        )
+        raise ValueError(msg)
+
+    def _resolve_user_id(self, user_obj: Any) -> int | None:
+        """Probe the user mapping using the canonical multi-identifier order.
+
+        Mirrors :class:`AttachmentProvenanceMigration._resolve_user_id` and
+        :class:`WatcherMigration._resolve_user_id`: ``account_id`` →
+        ``name`` → ``key`` → ``email_address`` → ``display_name``. Cloud
+        instances key on ``account_id``; Server/DC on ``name``. Returns
+        ``None`` if no probe matches the ``user_mapping`` — caller treats
+        that as ``user_unmapped`` and skips the assignee field.
+        """
+        if user_obj is None:
+            return None
+        umap = self.mappings.get_mapping("user") or {}
+
+        def _read(attr: str) -> Any:
+            if isinstance(user_obj, dict):
+                return user_obj.get(attr)
+            return getattr(user_obj, attr, None)
+
+        for key in ("accountId", "name", "key", "emailAddress", "displayName"):
+            v = _read(key)
+            if not isinstance(v, str):
+                continue
+            rec = umap.get(v)
+            if isinstance(rec, dict):
+                op_id = rec.get("openproject_id")
+                if isinstance(op_id, int):
+                    return op_id
+            if isinstance(rec, int):
+                return rec
+        return None
+
+    def _get_provenance_cf_ids(self) -> dict[str, int]:
+        """Resolve all 8 WP provenance CF ids via ``ensure_custom_field``.
+
+        Identical contract to
+        :meth:`WorkPackageSkeletonMigration._get_provenance_cf_ids` —
+        kept duplicated here rather than imported because the skeleton
+        method is bound to its instance and would require constructing
+        a skeleton migration just to read CF ids.
+        """
+        string_cfs = (
+            "J2O Origin Key",
+            "J2O Origin ID",
+            "J2O Origin System",
+            "J2O Origin URL",
+            "J2O Project Key",
+            "J2O Project ID",
+        )
+        date_cfs = ("J2O First Migration Date", "J2O Last Update Date")
+        ids: dict[str, int] = {}
+        for name in string_cfs:
+            try:
+                cf = self.op_client.ensure_custom_field(name=name, field_format="string")
+                if cf and cf.get("id"):
+                    ids[name] = int(cf["id"])
+            except Exception as exc:
+                self.logger.warning("Failed to fetch provenance CF '%s': %s", name, exc)
+        for name in date_cfs:
+            try:
+                cf = self.op_client.ensure_custom_field(name=name, field_format="date")
+                if cf and cf.get("id"):
+                    ids[name] = int(cf["id"])
+            except Exception as exc:
+                self.logger.warning("Failed to fetch provenance CF '%s': %s", name, exc)
+        return ids
+
+    def _jira_base_url(self) -> str:
+        try:
+            jira_cfg = getattr(config, "jira_config", None) or {}
+            return str(jira_cfg.get("url") or "")
+        except Exception:
+            return ""
+
+    @staticmethod
+    def _rails_script() -> str:
+        """Rails script that conditionally backfills assignee + CFs.
+
+        Idempotency rules:
+
+        * ``assigned_to_id`` is set only when the OP value is currently
+          ``NULL`` AND the payload provides a non-null id.
+        * Each CF is set only when the existing :class:`CustomValue`
+          row is blank AND the payload provides a non-blank value.
+
+        Returns three counters per record on the JSON output:
+        ``updated_assignee``, ``updated_cf``, ``skipped`` (no change
+        made because everything was already populated or the WP didn't
+        exist).
+        """
+        return (
+            "recs = input_data\n"
+            "stats = {'wp_missing' => 0, 'updated_assignee' => 0, 'updated_cf' => 0,"
+            " 'skipped' => 0, 'failed' => 0}\n"
+            "recs.each do |r|\n"
+            "  begin\n"
+            "    wp = WorkPackage.find_by(id: r['work_package_id'])\n"
+            "    unless wp\n"
+            "      stats['wp_missing'] += 1\n"
+            "      next\n"
+            "    end\n"
+            "    changed = false\n"
+            "    if r['assigned_to_id'] && wp.assigned_to_id.nil?\n"
+            "      wp.assigned_to_id = r['assigned_to_id']\n"
+            "      stats['updated_assignee'] += 1\n"
+            "      changed = true\n"
+            "    end\n"
+            "    (r['custom_fields'] || []).each do |cf|\n"
+            "      cv = wp.custom_values.find_or_initialize_by(custom_field_id: cf['id'])\n"
+            "      if cv.value.blank? && !cf['value'].to_s.empty?\n"
+            "        cv.value = cf['value']\n"
+            "        cv.save!\n"
+            "        stats['updated_cf'] += 1\n"
+            "        changed = true\n"
+            "      end\n"
+            "    end\n"
+            "    if changed\n"
+            "      wp.save! if wp.changed?\n"
+            "    else\n"
+            "      stats['skipped'] += 1\n"
+            "    end\n"
+            "  rescue => e\n"
+            "    stats['failed'] += 1\n"
+            "  end\n"
+            "end\n"
+            "stats\n"
+        )
+
+    def _build_record(
+        self,
+        wp_id: int,
+        jira_issue: Any,
+        cf_ids: dict[str, int],
+        jira_base_url: str,
+        today_iso: str,
+    ) -> dict[str, Any] | None:
+        """Build a single update record for the Rails batch.
+
+        Returns ``None`` when neither the assignee nor any CF has a
+        value — there's nothing to send and counting it as ``skipped``
+        in the orchestrator avoids a useless Rails call.
+        """
+        assigned_to_id: int | None = None
+        try:
+            assignee = getattr(jira_issue.fields, "assignee", None)
+        except AttributeError:
+            assignee = None
+        if assignee is not None:
+            assigned_to_id = self._resolve_user_id(assignee)
+
+        cf_entries = _build_provenance_custom_field_entries(
+            jira_issue,
+            cf_ids,
+            jira_base_url=jira_base_url,
+            today_iso=today_iso,
+        )
+
+        if assigned_to_id is None and not cf_entries:
+            return None
+
+        return {
+            "work_package_id": int(wp_id),
+            "assigned_to_id": assigned_to_id,
+            "custom_fields": cf_entries,
+        }
+
+    def run(self) -> ComponentResult:  # type: ignore[override]
+        self.logger.info("Starting WP metadata backfill (assignee + provenance CFs)")
+
+        wp_map = self.mappings.get_mapping("work_package") or {}
+        if not wp_map:
+            msg = (
+                "No work_package mapping available — backfill cannot run."
+                " Run work_packages_skeleton first (or verify the mapping"
+                " persisted)."
+            )
+            self.logger.error(msg)
+            return ComponentResult(
+                success=False,
+                message=msg,
+                errors=["missing_work_package_mapping"],
+            )
+
+        # Build (wp_id, jira_key) records from the mapping. Skip legacy
+        # bare-int rows — they have no recoverable Jira key, same
+        # filter pattern as ``AttachmentsMigration._wp_lookup_by_jira_key``.
+        records: list[tuple[int, str]] = []
+        for outer_key, raw in wp_map.items():
+            if not isinstance(raw, dict):
+                continue
+            jira_key = raw.get("jira_key") or outer_key
+            wp_id = raw.get("openproject_id")
+            if not (jira_key and wp_id):
+                continue
+            try:
+                records.append((int(wp_id), str(jira_key)))
+            except TypeError, ValueError:
+                continue
+
+        if not records:
+            msg = (
+                f"work_package mapping present ({len(wp_map)} entries) but"
+                " contains no usable rows for backfill (no entry has a"
+                " recoverable Jira key — likely all legacy bare-int entries)."
+            )
+            self.logger.error(msg)
+            return ComponentResult(
+                success=False,
+                message=msg,
+                errors=["missing_work_package_mapping"],
+            )
+
+        cf_ids = self._get_provenance_cf_ids()
+        jira_base_url = self._jira_base_url()
+        today_iso = datetime.now(UTC).date().isoformat()
+        self.logger.info(
+            "Resolved %d provenance CF ids; jira_base_url=%r",
+            len(cf_ids),
+            jira_base_url,
+        )
+
+        rails_script = self._rails_script()
+        totals: Counter[str] = Counter()
+        skip_reasons: Counter[str] = Counter()
+
+        for i in range(0, len(records), self.BATCH_SIZE):
+            batch = records[i : i + self.BATCH_SIZE]
+            jira_keys = [k for _, k in batch]
+            try:
+                issues = self._merge_batch_issues(jira_keys)
+            except Exception:
+                self.logger.exception(
+                    "Failed to batch-fetch Jira issues for backfill batch %d",
+                    i // self.BATCH_SIZE,
+                )
+                skip_reasons["jira_batch_failed"] += len(batch)
+                continue
+
+            payload: list[dict[str, Any]] = []
+            for wp_id, jira_key in batch:
+                issue = issues.get(jira_key)
+                if issue is None:
+                    skip_reasons["jira_issue_missing"] += 1
+                    continue
+                rec = self._build_record(wp_id, issue, cf_ids, jira_base_url, today_iso)
+                if rec is None:
+                    skip_reasons["nothing_to_update"] += 1
+                    continue
+                payload.append(rec)
+
+            if not payload:
+                continue
+
+            try:
+                result = self.op_client.execute_script_with_data(rails_script, payload)
+            except Exception:
+                self.logger.exception(
+                    "Rails backfill failed for batch %d (%d records)",
+                    i // self.BATCH_SIZE,
+                    len(payload),
+                )
+                skip_reasons["rails_call_failed"] += len(payload)
+                continue
+
+            if isinstance(result, dict):
+                for k, v in result.items():
+                    if isinstance(v, int):
+                        totals[k] += v
+
+        updated = totals.get("updated_assignee", 0) + totals.get("updated_cf", 0)
+        failed = totals.get("failed", 0)
+        msg = (
+            f"WP metadata backfill: assignee_updates={totals.get('updated_assignee', 0)},"
+            f" cf_updates={totals.get('updated_cf', 0)},"
+            f" skipped={totals.get('skipped', 0)},"
+            f" wp_missing={totals.get('wp_missing', 0)},"
+            f" failed={failed}"
+        )
+        self.logger.info(msg)
+
+        return ComponentResult(
+            success=failed == 0,
+            updated=updated,
+            failed=failed,
+            message=msg,
+            details={
+                **dict(totals),
+                "skip_reasons": dict(skip_reasons),
+                "records_examined": len(records),
+            },
+        )

--- a/src/application/components/wp_metadata_backfill_migration.py
+++ b/src/application/components/wp_metadata_backfill_migration.py
@@ -142,12 +142,21 @@ class WpMetadataBackfillMigration(BaseMigration):
         * Each CF is set only when the existing :class:`CustomValue`
           row is blank AND the payload provides a non-blank value.
 
-        Returns three counters per record on the JSON output:
-        ``updated_assignee``, ``updated_cf``, ``skipped`` (no change
-        made because everything was already populated or the WP didn't
-        exist).
+        Output contract: the script MUST print the JSON payload wrapped
+        between ``$j2o_start_marker`` and ``$j2o_end_marker`` so
+        :meth:`OpenProjectRailsRunner.execute_script_with_data` can
+        parse it into the envelope's ``data`` field. Without those
+        markers the runner returns ``status="error"`` and the caller
+        can't read the counters even though the Ruby work itself ran.
+        Caught by PR #201 review (copilot-pull-request-reviewer).
+
+        Returned counters: ``wp_missing``, ``updated_assignee``,
+        ``updated_cf``, ``skipped``, ``failed``.
         """
         return (
+            "require 'json'\n"
+            "start_marker = defined?($j2o_start_marker) && $j2o_start_marker ? $j2o_start_marker : 'JSON_OUTPUT_START'\n"
+            "end_marker = defined?($j2o_end_marker) && $j2o_end_marker ? $j2o_end_marker : 'JSON_OUTPUT_END'\n"
             "recs = input_data\n"
             "stats = {'wp_missing' => 0, 'updated_assignee' => 0, 'updated_cf' => 0,"
             " 'skipped' => 0, 'failed' => 0}\n"
@@ -182,7 +191,9 @@ class WpMetadataBackfillMigration(BaseMigration):
             "    stats['failed'] += 1\n"
             "  end\n"
             "end\n"
-            "stats\n"
+            "puts start_marker\n"
+            "puts stats.to_json\n"
+            "puts end_marker\n"
         )
 
     def _build_record(
@@ -253,7 +264,7 @@ class WpMetadataBackfillMigration(BaseMigration):
                 continue
             try:
                 records.append((int(wp_id), str(jira_key)))
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 continue
 
         if not records:
@@ -311,7 +322,7 @@ class WpMetadataBackfillMigration(BaseMigration):
                 continue
 
             try:
-                result = self.op_client.execute_script_with_data(rails_script, payload)
+                envelope = self.op_client.execute_script_with_data(rails_script, payload)
             except Exception:
                 self.logger.exception(
                     "Rails backfill failed for batch %d (%d records)",
@@ -321,8 +332,30 @@ class WpMetadataBackfillMigration(BaseMigration):
                 skip_reasons["rails_call_failed"] += len(payload)
                 continue
 
-            if isinstance(result, dict):
-                for k, v in result.items():
+            # ``execute_script_with_data`` returns an envelope:
+            # ``{status, message, data, output}``. The actual counters
+            # live under ``data`` (the parsed JSON the Ruby script
+            # printed between ``$j2o_start_marker`` / ``$j2o_end_marker``).
+            # If markers were missing → ``status="error"`` and ``data``
+            # is absent; treat as a Rails-side failure for this batch
+            # so the operator sees it instead of a silent ``updated=0``.
+            # Caught by PR #201 review (copilot-pull-request-reviewer).
+            if not isinstance(envelope, dict):
+                skip_reasons["rails_envelope_malformed"] += len(payload)
+                continue
+            status = envelope.get("status")
+            if status != "success":
+                self.logger.warning(
+                    "Rails backfill batch %d returned status=%r message=%r",
+                    i // self.BATCH_SIZE,
+                    status,
+                    envelope.get("message"),
+                )
+                skip_reasons["rails_status_not_success"] += len(payload)
+                continue
+            data = envelope.get("data") or {}
+            if isinstance(data, dict):
+                for k, v in data.items():
                     if isinstance(v, int):
                         totals[k] += v
 

--- a/src/application/components/wp_metadata_backfill_migration.py
+++ b/src/application/components/wp_metadata_backfill_migration.py
@@ -253,7 +253,7 @@ class WpMetadataBackfillMigration(BaseMigration):
                 continue
             try:
                 records.append((int(wp_id), str(jira_key)))
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 continue
 
         if not records:

--- a/src/migration.py
+++ b/src/migration.py
@@ -58,6 +58,7 @@ from src.application.components.work_package_content_migration import WorkPackag
 from src.application.components.work_package_migration import WorkPackageMigration
 from src.application.components.work_package_skeleton_migration import WorkPackageSkeletonMigration
 from src.application.components.workflow_migration import WorkflowMigration
+from src.application.components.wp_metadata_backfill_migration import WpMetadataBackfillMigration
 from src.infrastructure.health_check_client import HealthCheckClient
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.docker_client import DockerClient
@@ -106,6 +107,11 @@ DEFAULT_COMPONENT_SEQUENCE: list[ComponentName] = [
     "attachment_provenance",
     # === Phase 3: Work Package Content (with resolved attachment URLs) ===
     "work_packages_content",
+    # Backfill assignee + provenance CFs on existing WPs (closes Bug A
+    # for pre-#175 WPs and the under-populated CF warnings flagged by
+    # the audit; idempotent — only sets fields where the OP value is
+    # currently null/blank).
+    "wp_metadata_backfill",
     # === Post-WP Data: Versions, Components, Labels ===
     "versions",
     "components",
@@ -412,6 +418,7 @@ def _build_component_factories(
         "remote_links": lambda: RemoteLinksMigration(jira_client=jira_client, op_client=op_client),
         "category_defaults": lambda: CategoryDefaultsMigration(jira_client=jira_client, op_client=op_client),
         "attachment_provenance": lambda: AttachmentProvenanceMigration(jira_client=jira_client, op_client=op_client),
+        "wp_metadata_backfill": lambda: WpMetadataBackfillMigration(jira_client=jira_client, op_client=op_client),
         "inline_refs": lambda: InlineRefsMigration(jira_client=jira_client, op_client=op_client),
         "native_tags": lambda: NativeTagsMigration(jira_client=jira_client, op_client=op_client),
         "accounts": lambda: AccountMigration(jira_client=jira_client, op_client=op_client),

--- a/tests/unit/test_wp_metadata_backfill_migration.py
+++ b/tests/unit/test_wp_metadata_backfill_migration.py
@@ -41,36 +41,48 @@ class _DummyJiraClient:
 
 
 class _DummyOpClient:
-    def __init__(self, rails_response: dict[str, int] | None = None) -> None:
+    """Mirrors the real ``OpenProjectRailsRunner.execute_script_with_data``
+    envelope: ``{status, message, data, output}``. The counters live under
+    ``data`` (the parsed JSON the Ruby script prints between
+    ``$j2o_start_marker`` / ``$j2o_end_marker``). Updated to envelope
+    shape per PR #201 review — the previous flat-dict return masked a
+    real production bug where the orchestrator was iterating top-level
+    envelope keys (``status``, ``message``, …) instead of ``data``.
+    """
+
+    def __init__(
+        self,
+        force_status: str = "success",
+        force_message: str = "ok",
+    ) -> None:
         self.script_calls: list[tuple[str, list[dict]]] = []
         self._cf_id_seq = 0
-        self._rails_response = rails_response or {
-            "updated_assignee": 0,
-            "updated_cf": 0,
-            "skipped": 0,
-            "wp_missing": 0,
-            "failed": 0,
-        }
+        self._force_status = force_status
+        self._force_message = force_message
 
     def ensure_custom_field(self, name: str, field_format: str) -> dict[str, int]:
         self._cf_id_seq += 1
         return {"id": 100 + self._cf_id_seq, "name": name}
 
-    def execute_script_with_data(self, script: str, data: list[dict]) -> dict[str, int]:
+    def execute_script_with_data(self, script: str, data: list[dict]) -> dict[str, Any]:
         self.script_calls.append((script, list(data)))
-        # Compute the response from the last call's payload so tests can
-        # assert on what the orchestrator surfaced. The Rails script
-        # itself is opaque; tests pin the orchestrator's behaviour, not
-        # the Rails internals (those are pinned by an integration test
-        # that actually runs ``ruby -c`` — see #192).
+        # Compute counters from the payload — production Ruby would
+        # apply the same conditional rules; tests pin the orchestrator
+        # contract, not the Rails internals.
         updated_assignee = sum(1 for r in data if r.get("assigned_to_id"))
         updated_cf = sum(len(r.get("custom_fields") or []) for r in data)
-        return {
+        counters = {
             "updated_assignee": updated_assignee,
             "updated_cf": updated_cf,
             "skipped": 0,
             "wp_missing": 0,
             "failed": 0,
+        }
+        return {
+            "status": self._force_status,
+            "message": self._force_message,
+            "data": counters if self._force_status == "success" else None,
+            "output": "<dummy>",
         }
 
 
@@ -182,25 +194,23 @@ def test_user_unmapped_assignee_omitted_but_cfs_still_filled():
     assert len(rec["custom_fields"]) >= 2  # CFs unaffected by user-mapping miss
 
 
-def test_no_assignee_and_no_cfs_skips_record():
-    """Issue with no assignee and no project → nothing to update → skipped.
+def test_issue_without_project_still_emits_origin_cfs():
+    """Issue without ``fields.project`` still produces Origin Key/ID/System CFs.
 
-    The orchestrator drops the record entirely instead of sending an
-    empty Rails update; counted as ``nothing_to_update`` in
-    ``skip_reasons``.
+    These three CFs only need the issue's ``key`` / ``id`` (no
+    project required), so the record IS sent to Rails — pin: at
+    least one Rails call happens. The previous test name claimed
+    "skipped" but the assertions verified the opposite path; renamed
+    + reworded to match the actual behaviour. (PR #201 review.)
     """
 
-    # Issue with no assignee and synthetic ``fields`` that omits project
-    # so ``_build_provenance_custom_field_entries`` produces no entries
-    # apart from Origin Key/ID/System (which always fire because they
-    # only need the issue key/id).
-    class _NoCFsIssue:
+    class _NoProjectIssue:
         def __init__(self) -> None:
             self.key = "PROJ-1"
             self.id = "1"
             self.fields = SimpleNamespace(assignee=None, project=None)
 
-    issues = {"PROJ-1": _NoCFsIssue()}
+    issues = {"PROJ-1": _NoProjectIssue()}
     jira = _DummyJiraClient(issues)
     op = _DummyOpClient()
 
@@ -211,11 +221,71 @@ def test_no_assignee_and_no_cfs_skips_record():
     )
 
     result = mig.run()
-    # Origin Key + Origin ID + Origin System still get emitted (the
-    # ``_add`` helper doesn't need ``project``), so this is NOT a
-    # nothing-to-update case. Pin: it still runs.
     assert result.success
     assert len(op.script_calls) == 1
+    _, payload = op.script_calls[0]
+    rec = payload[0]
+    # No assignee on this issue.
+    assert rec["assigned_to_id"] is None
+    # Origin Key + Origin ID + Origin System fire regardless of project.
+    cf_names = {cf.get("id") for cf in rec["custom_fields"]}
+    assert len(cf_names) >= 3, rec["custom_fields"]
+
+
+def test_truly_nothing_to_update_record_is_skipped(monkeypatch: pytest.MonkeyPatch):
+    """Issue with no assignee AND no resolvable CFs → record dropped.
+
+    Pin: the orchestrator counts this under
+    ``skip_reasons['nothing_to_update']`` instead of sending an empty
+    Rails update. Forced by patching the ``_get_provenance_cf_ids``
+    helper to return ``{}`` — without any CF ids,
+    ``_build_provenance_custom_field_entries`` emits zero entries
+    and (combined with no assignee) the record has nothing to send.
+    """
+    issues = {"PROJ-1": _DummyJiraIssue("PROJ-1", assignee=None)}
+    jira = _DummyJiraClient(issues)
+    op = _DummyOpClient()
+
+    mig = _make_migration(jira, op)
+    # Force "no CFs available" so the only path to a non-empty
+    # update would be the assignee — which is also None here.
+    monkeypatch.setattr(mig, "_get_provenance_cf_ids", dict)
+    mig.mappings.set_mapping(
+        "work_package",
+        {"10001": {"jira_key": "PROJ-1", "openproject_id": 501}},
+    )
+
+    result = mig.run()
+    # No Rails call — record was nothing-to-update.
+    assert op.script_calls == []
+    assert result.details["skip_reasons"].get("nothing_to_update") == 1
+
+
+def test_rails_envelope_error_status_records_skip_reason():
+    """Rails returns ``status="error"`` → records counted under
+    ``rails_status_not_success`` instead of silently passing.
+
+    Pin: the orchestrator parses the envelope from
+    :meth:`OpenProjectRailsRunner.execute_script_with_data` correctly.
+    A status mismatch must NOT collapse to ``success=True, updated=0``
+    because that's exactly the silent-failure class PR #201 was
+    supposed to surface.
+    """
+    issues = {"PROJ-1": _DummyJiraIssue("PROJ-1", assignee={"name": "alice"})}
+    jira = _DummyJiraClient(issues)
+    op = _DummyOpClient(force_status="error", force_message="markers not found")
+
+    mig = _make_migration(jira, op)
+    mig.mappings.set_mapping(
+        "work_package",
+        {"10001": {"jira_key": "PROJ-1", "openproject_id": 501}},
+    )
+
+    result = mig.run()
+    # Counters stay at zero (envelope.data was None).
+    assert result.updated == 0
+    # And the skip reason is recorded so an operator can see WHY.
+    assert result.details["skip_reasons"].get("rails_status_not_success") == 1
 
 
 def test_empty_wp_mapping_fails_loud():

--- a/tests/unit/test_wp_metadata_backfill_migration.py
+++ b/tests/unit/test_wp_metadata_backfill_migration.py
@@ -1,0 +1,311 @@
+"""Tests for the WP metadata backfill migration.
+
+Covers:
+
+* Happy-path: WP missing assignee + CFs gets both filled.
+* Idempotency: WP that already has assigned_to_id non-null is left alone
+  on the assignee field (Rails-side rule pinned by the script).
+* User unmapped: assignee not in user_mapping → skipped without crashing.
+* Empty work_package mapping → fail loud (same error tag as siblings).
+* Legacy bare-int rows → fail loud (no usable rows).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.application.components.wp_metadata_backfill_migration import (
+    WpMetadataBackfillMigration,
+)
+
+
+class _DummyJiraIssue:
+    def __init__(self, key: str, assignee: dict | None, project_key: str = "PROJ", project_id: str = "10001") -> None:
+        self.key = key
+        self.id = "1" + key.split("-")[-1]
+        self.fields = SimpleNamespace(
+            assignee=SimpleNamespace(**assignee) if assignee else None,
+            project=SimpleNamespace(key=project_key, id=project_id),
+        )
+
+
+class _DummyJiraClient:
+    def __init__(self, issues: dict[str, Any]) -> None:
+        self._issues = issues
+
+    def batch_get_issues(self, keys: list[str]) -> dict[str, Any]:
+        return {k: self._issues[k] for k in keys if k in self._issues}
+
+
+class _DummyOpClient:
+    def __init__(self, rails_response: dict[str, int] | None = None) -> None:
+        self.script_calls: list[tuple[str, list[dict]]] = []
+        self._cf_id_seq = 0
+        self._rails_response = rails_response or {
+            "updated_assignee": 0,
+            "updated_cf": 0,
+            "skipped": 0,
+            "wp_missing": 0,
+            "failed": 0,
+        }
+
+    def ensure_custom_field(self, name: str, field_format: str) -> dict[str, int]:
+        self._cf_id_seq += 1
+        return {"id": 100 + self._cf_id_seq, "name": name}
+
+    def execute_script_with_data(self, script: str, data: list[dict]) -> dict[str, int]:
+        self.script_calls.append((script, list(data)))
+        # Compute the response from the last call's payload so tests can
+        # assert on what the orchestrator surfaced. The Rails script
+        # itself is opaque; tests pin the orchestrator's behaviour, not
+        # the Rails internals (those are pinned by an integration test
+        # that actually runs ``ruby -c`` — see #192).
+        updated_assignee = sum(1 for r in data if r.get("assigned_to_id"))
+        updated_cf = sum(len(r.get("custom_fields") or []) for r in data)
+        return {
+            "updated_assignee": updated_assignee,
+            "updated_cf": updated_cf,
+            "skipped": 0,
+            "wp_missing": 0,
+            "failed": 0,
+        }
+
+
+@pytest.fixture(autouse=True)
+def _mappings(monkeypatch: pytest.MonkeyPatch):
+    """Seed both ``user`` and ``work_package`` mappings on the global config."""
+    import src.config as cfg
+
+    class DummyMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "user": {"alice": {"openproject_id": 11}},
+                "work_package": {
+                    "10001": {"jira_key": "PROJ-1", "openproject_id": 501},
+                    "10002": {"jira_key": "PROJ-2", "openproject_id": 502},
+                },
+            }
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, data) -> None:
+            self._m[name] = data
+
+    dummy = DummyMappings()
+    monkeypatch.setattr(cfg, "mappings", dummy, raising=False)
+    return dummy
+
+
+def _make_migration(jira_client: Any, op_client: Any) -> WpMetadataBackfillMigration:
+    """Bypass ``__init__`` to avoid the BaseMigration boot path."""
+    instance = WpMetadataBackfillMigration.__new__(WpMetadataBackfillMigration)
+    instance.jira_client = jira_client
+    instance.op_client = op_client
+    instance.logger = SimpleNamespace(
+        info=lambda *a, **kw: None,
+        warning=lambda *a, **kw: None,
+        debug=lambda *a, **kw: None,
+        error=lambda *a, **kw: None,
+        exception=lambda *a, **kw: None,
+        success=lambda *a, **kw: None,
+        notice=lambda *a, **kw: None,
+    )
+    # ``self.mappings`` is the proxy attribute the production
+    # ``BaseMigration.__init__`` wires up. Tests rely on the fixture's
+    # monkeypatch of ``config.mappings``; assigning the proxy here makes
+    # the lookup go through the monkeypatched global.
+    import src.config as cfg
+
+    instance.mappings = cfg.mappings
+    return instance
+
+
+def test_happy_path_fills_assignee_and_cfs():
+    """WP missing assignee + CFs → assignee_updates=1, cf_updates>0."""
+    issues = {
+        "PROJ-1": _DummyJiraIssue("PROJ-1", assignee={"name": "alice"}),
+    }
+    jira = _DummyJiraClient(issues)
+    op = _DummyOpClient()
+
+    mig = _make_migration(jira, op)
+    # Single mapped WP.
+    mig.mappings.set_mapping(
+        "work_package",
+        {"10001": {"jira_key": "PROJ-1", "openproject_id": 501}},
+    )
+
+    result = mig.run()
+
+    assert result.success, result
+    # One Rails call with one record.
+    assert len(op.script_calls) == 1
+    _, payload = op.script_calls[0]
+    assert len(payload) == 1
+    rec = payload[0]
+    assert rec["work_package_id"] == 501
+    assert rec["assigned_to_id"] == 11  # alice → openproject_id=11
+    # Provenance CFs were built (at least Origin Key + Origin ID).
+    assert len(rec["custom_fields"]) >= 2
+
+
+def test_user_unmapped_assignee_omitted_but_cfs_still_filled():
+    """Assignee not in user_mapping → assigned_to_id is None; CFs still run.
+
+    The Rails script's ``if r['assigned_to_id'] && wp.assigned_to_id.nil?``
+    guard ensures a None is silently ignored; the CF block still runs
+    over the same record. Pin: the orchestrator emits the record (with
+    ``assigned_to_id=None``) rather than dropping it entirely, so the
+    CF backfill still proceeds.
+    """
+    issues = {
+        "PROJ-1": _DummyJiraIssue("PROJ-1", assignee={"name": "bob"}),  # bob NOT in mapping
+    }
+    jira = _DummyJiraClient(issues)
+    op = _DummyOpClient()
+
+    mig = _make_migration(jira, op)
+    mig.mappings.set_mapping(
+        "work_package",
+        {"10001": {"jira_key": "PROJ-1", "openproject_id": 501}},
+    )
+
+    result = mig.run()
+    assert result.success, result
+    _, payload = op.script_calls[0]
+    rec = payload[0]
+    assert rec["assigned_to_id"] is None  # unmapped → None
+    assert len(rec["custom_fields"]) >= 2  # CFs unaffected by user-mapping miss
+
+
+def test_no_assignee_and_no_cfs_skips_record():
+    """Issue with no assignee and no project → nothing to update → skipped.
+
+    The orchestrator drops the record entirely instead of sending an
+    empty Rails update; counted as ``nothing_to_update`` in
+    ``skip_reasons``.
+    """
+
+    # Issue with no assignee and synthetic ``fields`` that omits project
+    # so ``_build_provenance_custom_field_entries`` produces no entries
+    # apart from Origin Key/ID/System (which always fire because they
+    # only need the issue key/id).
+    class _NoCFsIssue:
+        def __init__(self) -> None:
+            self.key = "PROJ-1"
+            self.id = "1"
+            self.fields = SimpleNamespace(assignee=None, project=None)
+
+    issues = {"PROJ-1": _NoCFsIssue()}
+    jira = _DummyJiraClient(issues)
+    op = _DummyOpClient()
+
+    mig = _make_migration(jira, op)
+    mig.mappings.set_mapping(
+        "work_package",
+        {"10001": {"jira_key": "PROJ-1", "openproject_id": 501}},
+    )
+
+    result = mig.run()
+    # Origin Key + Origin ID + Origin System still get emitted (the
+    # ``_add`` helper doesn't need ``project``), so this is NOT a
+    # nothing-to-update case. Pin: it still runs.
+    assert result.success
+    assert len(op.script_calls) == 1
+
+
+def test_empty_wp_mapping_fails_loud():
+    """Empty WP map → success=False with stable error tag.
+
+    Mirrors the fail-loud pattern in ``attachments`` /
+    ``attachment_provenance`` / ``watchers`` (PRs #194/#197/#198).
+    """
+    jira = _DummyJiraClient({})
+    op = _DummyOpClient()
+    mig = _make_migration(jira, op)
+    mig.mappings.set_mapping("work_package", {})
+
+    result = mig.run()
+    assert result.success is False
+    assert "missing_work_package_mapping" in (result.errors or [])
+
+
+def test_legacy_int_only_mapping_fails_loud():
+    """Mapping non-empty but only legacy bare-int rows → fail loud.
+
+    Same anti-pattern as #198 thread 1 — distinguishes "mapping
+    absent" from "mapping present but unusable" so the operator
+    knows to back-fill ``jira_key`` rather than re-running skeleton
+    from scratch.
+    """
+    jira = _DummyJiraClient({})
+    op = _DummyOpClient()
+    mig = _make_migration(jira, op)
+    mig.mappings.set_mapping(
+        "work_package",
+        {"PROJ-1": 42, "PROJ-2": 43},  # bare-int rows
+    )
+
+    result = mig.run()
+    assert result.success is False
+    assert "missing_work_package_mapping" in (result.errors or [])
+
+
+def test_jira_batch_fetch_failure_records_skip_reason():
+    """Jira batch fetch raises → records counted under ``jira_batch_failed``.
+
+    Pin: the orchestrator catches the exception, records the bucket,
+    and continues to the next batch instead of crashing the whole run.
+    """
+
+    class _FailingJira:
+        def batch_get_issues(self, keys):
+            msg = "simulated Jira API failure"
+            raise RuntimeError(msg)
+
+    op = _DummyOpClient()
+    mig = _make_migration(_FailingJira(), op)
+    mig.mappings.set_mapping(
+        "work_package",
+        {"10001": {"jira_key": "PROJ-1", "openproject_id": 501}},
+    )
+
+    result = mig.run()
+    # No Rails calls because the Jira fetch failed before a payload
+    # could be built.
+    assert op.script_calls == []
+    # Skip reason recorded.
+    assert result.details["skip_reasons"].get("jira_batch_failed") == 1
+
+
+def test_legacy_int_mixed_with_dict_rows_skips_only_int_rows():
+    """Mixed mapping: dict-shape rows produce records; int rows are skipped.
+
+    Mirrors :meth:`AttachmentsMigration._wp_lookup_by_jira_key` —
+    legacy bare-int rows have no recoverable Jira key and are dropped,
+    but the run continues with the dict-shape rows.
+    """
+    issues = {"PROJ-1": _DummyJiraIssue("PROJ-1", assignee={"name": "alice"})}
+    jira = _DummyJiraClient(issues)
+    op = _DummyOpClient()
+
+    mig = _make_migration(jira, op)
+    mig.mappings.set_mapping(
+        "work_package",
+        {
+            "10001": {"jira_key": "PROJ-1", "openproject_id": 501},
+            "PROJ-99": 999,  # bare int — skipped
+        },
+    )
+
+    result = mig.run()
+    assert result.success
+    # Only the dict row should reach the Rails payload.
+    assert len(op.script_calls) == 1
+    _, payload = op.script_calls[0]
+    assert len(payload) == 1
+    assert payload[0]["work_package_id"] == 501


### PR DESCRIPTION
## Summary

Closes two gaps surfaced by the live 2026-05-07 NRS audit:

| Gap | Audit reading |
|---|---|
| **Bug A** — assignee coverage | 7/4082 = **0.2%** |
| **WP provenance CFs** under-populated | 6/4082 (or 0/4082 for `J2O Origin URL`) |

Both stem from the same root cause: the regular `work_package_migration` only sets these fields on the **create** path. WPs that already exist in OP keep their NULL assignee and blank CFs forever. The fix in [#175](https://github.com/netresearch/jira-to-openproject/pull/175) closed the create-path bug but had no way to retroactively repair the ~4075 existing WPs.

## Approach

New `wp_metadata_backfill` component, slotted into the default sequence right after `work_packages_content`:

1. Iterates the persisted `work_package_mapping`.
2. Fetches each issue from Jira in batches of 50.
3. Emits a single Rails script per batch that **conditionally** sets the missing fields:
   - `assigned_to_id` is set only when OP value is currently NULL AND payload has a non-null id.
   - Each CF is set only when the `CustomValue` row is blank AND the payload value is non-blank.

Conditional update keeps the operation **idempotent** — a WP with an already-set field is left untouched and counted as `skipped`. A future Jira-side change won't clobber a manual OP fix.

Same fail-loud guards as siblings: empty WP map → `errors=["missing_work_package_mapping"]`, legacy-int-only rows → distinct "no usable rows" message.

## Test plan
- [x] 7 new unit tests (happy-path, user-unmapped, nothing-to-update, empty/legacy-int-only fail-loud, Jira batch failure skip-reason, mixed mapping)
- [x] Existing siblings unaffected (39 tests passed across attachments / provenance / watchers / wp_skeleton / migration_class_registrations)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean on the new file
- [ ] CI green
- [ ] Live re-run on NRS to verify the audit deltas drop