### PR TITLE
fix(audit): cross-project-aware relation breakdown

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -1136,6 +1136,204 @@ def test_fetch_jira_relation_count_propagates_none_from_paginator(monkeypatch) -
     assert audit_mod._fetch_jira_relation_count("NRS") is None
 
 
+# --- Direct tests for _fetch_jira_relation_breakdown -------------------------
+# Per PR #202 review: the breakdown function has non-trivial parsing
+# logic (intra dedup, cross counting, dual-shape link handling). These
+# tests pin the breakdown calculation directly without going through
+# ``_classify``, so a regression in the parsing surfaces as a focused
+# failure rather than a downstream classifier mismatch.
+
+
+class _FakeJiraIssue:
+    """Object-shape Jira issue for the breakdown tests."""
+
+    def __init__(self, key: str, links: list[Any]) -> None:
+        self.key = key
+        self.fields = type("F", (), {"issuelinks": links})()
+
+
+def _link_obj(*, outward_key: str | None = None, inward_key: str | None = None) -> Any:
+    """Object-shape link with optional outward/inward target key."""
+    link = type("L", (), {})()
+    link.outwardIssue = type("O", (), {"key": outward_key})() if outward_key else None
+    link.inwardIssue = type("I", (), {"key": inward_key})() if inward_key else None
+    return link
+
+
+def _link_dict(*, outward_key: str | None = None, inward_key: str | None = None) -> dict[str, Any]:
+    """Dict-shape link, mirroring the cached / serialized shape that
+    ``relation_migration._merge_batch_issues`` produces.
+    """
+    out: dict[str, Any] = {}
+    if outward_key:
+        out["outwardIssue"] = {"key": outward_key}
+    if inward_key:
+        out["inwardIssue"] = {"key": inward_key}
+    return out
+
+
+def _patch_jira_search(monkeypatch, pages: list[list[Any]]) -> None:
+    """Patch the JiraClient lookup so the breakdown sees ``pages`` in order."""
+
+    class _FakeUnderlying:
+        def __init__(self, pages_: list[list[Any]]) -> None:
+            self._pages = list(pages_)
+
+        def search_issues(self, *_a, **_kw):
+            return self._pages.pop(0) if self._pages else []
+
+    class _FakeJira:
+        def __init__(self) -> None:
+            self.jira = _FakeUnderlying(pages)
+
+    monkeypatch.setattr(
+        "src.infrastructure.jira.jira_client.JiraClient",
+        _FakeJira,
+    )
+
+
+def test_breakdown_dedups_intra_pairs(monkeypatch) -> None:
+    """Each intra-project link appears twice (once per end) — must dedup to 1."""
+    pages = [
+        [
+            _FakeJiraIssue("NRS-1", [_link_obj(outward_key="NRS-2")]),
+            _FakeJiraIssue("NRS-2", [_link_obj(inward_key="NRS-1")]),
+        ],
+    ]
+    _patch_jira_search(monkeypatch, pages)
+    from tools import audit_migrated_project as audit_mod
+
+    result = audit_mod._fetch_jira_relation_breakdown("NRS")
+    assert result == {"intra_unique": 1, "cross": 0, "raw": 2}
+
+
+def test_breakdown_counts_cross_separately(monkeypatch) -> None:
+    """Cross-project link appears once (only the in-scope end carries it)."""
+    pages = [
+        [_FakeJiraIssue("NRS-1", [_link_obj(outward_key="OTHER-1")])],
+    ]
+    _patch_jira_search(monkeypatch, pages)
+    from tools import audit_migrated_project as audit_mod
+
+    result = audit_mod._fetch_jira_relation_breakdown("NRS")
+    assert result == {"intra_unique": 0, "cross": 1, "raw": 1}
+
+
+def test_breakdown_handles_dict_shaped_links(monkeypatch) -> None:
+    """Dict-shape links (cached / serialized form) classify identically.
+
+    Without dual-shape support, every dict link falls into the
+    "malformed" path and gets dropped from both intra and cross —
+    skewing the breakdown. Per PR #202 review.
+    """
+    pages = [
+        [
+            _FakeJiraIssue("NRS-1", [_link_dict(outward_key="NRS-2"), _link_dict(outward_key="OTHER-7")]),
+        ],
+    ]
+    _patch_jira_search(monkeypatch, pages)
+    from tools import audit_migrated_project as audit_mod
+
+    result = audit_mod._fetch_jira_relation_breakdown("NRS")
+    # 1 cross + 1 intra (NRS-1 → NRS-2 only, the reciprocal isn't fetched here)
+    assert result == {"intra_unique": 1, "cross": 1, "raw": 2}
+
+
+def test_breakdown_handles_dict_shaped_issues(monkeypatch) -> None:
+    """Dict-shape issues + dict-shape links both work."""
+    pages = [
+        [
+            {"key": "NRS-1", "fields": {"issuelinks": [_link_dict(outward_key="NRS-2")]}},
+            {"key": "NRS-2", "fields": {"issuelinks": [_link_dict(inward_key="NRS-1")]}},
+        ],
+    ]
+    _patch_jira_search(monkeypatch, pages)
+    from tools import audit_migrated_project as audit_mod
+
+    result = audit_mod._fetch_jira_relation_breakdown("NRS")
+    assert result == {"intra_unique": 1, "cross": 0, "raw": 2}
+
+
+def test_breakdown_skips_malformed_links_without_keys(monkeypatch) -> None:
+    """Link with neither outwardIssue nor inwardIssue → counted as raw,
+    dropped from both intra and cross to avoid double-counting.
+    """
+    pages = [
+        [_FakeJiraIssue("NRS-1", [_link_obj()])],  # no outward, no inward
+    ]
+    _patch_jira_search(monkeypatch, pages)
+    from tools import audit_migrated_project as audit_mod
+
+    result = audit_mod._fetch_jira_relation_breakdown("NRS")
+    assert result == {"intra_unique": 0, "cross": 0, "raw": 1}
+
+
+def test_breakdown_invalid_project_key_returns_none(monkeypatch, capsys) -> None:
+    """Same project-key validation contract as the legacy halved counter."""
+    from tools import audit_migrated_project as audit_mod
+
+    result = audit_mod._fetch_jira_relation_breakdown("nrs lower-case")
+    assert result is None
+    captured = capsys.readouterr()
+    assert "invalid project key" in captured.err.lower(), captured.err
+
+
+def test_breakdown_emits_odd_raw_diagnostic(monkeypatch, capsys) -> None:
+    """Odd raw count → "[audit] odd" stderr warning (same hint as legacy)."""
+    pages = [
+        # 3 raw entries: 1 intra (NRS-1 → NRS-2), 1 cross, 1 cross.
+        # Reciprocal end of the intra link is missing → odd raw.
+        [
+            _FakeJiraIssue(
+                "NRS-1",
+                [
+                    _link_obj(outward_key="NRS-2"),
+                    _link_obj(outward_key="OTHER-1"),
+                    _link_obj(outward_key="OTHER-2"),
+                ],
+            ),
+        ],
+    ]
+    _patch_jira_search(monkeypatch, pages)
+    from tools import audit_migrated_project as audit_mod
+
+    audit_mod._fetch_jira_relation_breakdown("NRS")
+    captured = capsys.readouterr()
+    assert "odd" in captured.err.lower() and "(3)" in captured.err, captured.err
+
+
+def test_breakdown_failure_falls_back_to_legacy_count(monkeypatch) -> None:
+    """When the breakdown raises mid-pagination, ``_execute_audit`` falls
+    back to the legacy halved count so the audit still produces signal.
+
+    Per PR #202 review: previously the breakdown failure path set
+    ``jira_relation_count = None`` too, which collapsed the relation
+    check to a "source unavailable" warning even when the legacy
+    counter would have worked.
+    """
+    from tools import audit_migrated_project as audit_mod
+
+    # Force the breakdown to fail.
+    monkeypatch.setattr(audit_mod, "_fetch_jira_relation_breakdown", lambda _k: None)
+    # Force the legacy halved counter to succeed.
+    monkeypatch.setattr(audit_mod, "_fetch_jira_relation_count", lambda _k: 42)
+    # Stub the other Jira-side comparisons + the OP-side script execution.
+    monkeypatch.setattr(audit_mod, "_fetch_jira_issue_count", lambda _k: 100)
+    monkeypatch.setattr(audit_mod, "_fetch_jira_attachment_count", lambda _k: 10)
+    monkeypatch.setattr(audit_mod, "_fetch_jira_watcher_count", lambda _k: 50)
+
+    class _StubOp:
+        def execute_json_query(self, *_a, **_kw) -> dict[str, Any]:
+            return {}
+
+    monkeypatch.setattr(audit_mod, "OpenProjectClient", _StubOp)
+
+    metrics = audit_mod._execute_audit("NRS")
+    assert metrics["jira_relation_breakdown"] is None
+    # Crucial: legacy counter still populated, classifier uses it.
+    assert metrics["jira_relation_count"] == 42
+
+
 def test_generated_audit_script_parses_as_ruby() -> None:
     """The generated Ruby script must pass ``ruby -c`` (parse-only).
 

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -868,6 +868,102 @@ def test_jira_relation_count_none_warns_source_unavailable() -> None:
     ), warnings
 
 
+# --- Cross-project relation breakdown (added 2026-05-07) ---------------------
+# The legacy ``raw // 2`` halved count over-counts on cross-project-heavy
+# projects (NRS audit caught a 75% false positive). The new breakdown
+# compares OP to intra-project unique pairs and surfaces cross-project
+# count as informational. These tests pin both halves of that contract.
+
+
+def test_jira_relation_breakdown_intra_within_tolerance_passes() -> None:
+    """OP matches intra-project Jira links → no failure on relations."""
+    # baseline OP=30; intra=29 (within 5%), cross=1000 (irrelevant).
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            jira_relation_breakdown={"intra_unique": 29, "cross": 1000, "raw": 2000},
+        ),
+    )
+    assert not any("relation" in f.lower() and "jira" in f.lower() and "5" in f for f in failures), failures
+
+
+def test_jira_relation_breakdown_intra_above_tolerance_is_failure() -> None:
+    """OP missing intra-project links → failure (regardless of cross count)."""
+    # baseline OP=30; intra=100 (way over) — fails.
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            jira_relation_breakdown={"intra_unique": 100, "cross": 0, "raw": 200},
+        ),
+    )
+    assert any("intra-project" in f.lower() and "5" in f for f in failures), failures
+
+
+def test_jira_relation_breakdown_cross_emits_informational_warning() -> None:
+    """Cross-project links produce an informational warning, not a failure.
+
+    Pin: even when OP intra matches Jira intra exactly, the audit
+    surfaces the cross-project count so the operator knows how
+    much was deliberately not migrated. Live NRS run: 3451 cross
+    vs 1173 raw intra (= 586 unique pairs after dedup).
+    """
+    failures, warnings = _classify(
+        _baseline_metrics(
+            jira_relation_breakdown={"intra_unique": 30, "cross": 3451, "raw": 4624},
+        ),
+    )
+    assert not any("relation" in f.lower() and "jira" in f.lower() and "5" in f for f in failures), failures
+    assert any("cross-project" in w.lower() and "3451" in w for w in warnings), warnings
+
+
+def test_jira_relation_breakdown_cross_zero_omits_warning() -> None:
+    """No cross-project links → no informational warning."""
+    _failures, warnings = _classify(
+        _baseline_metrics(
+            jira_relation_breakdown={"intra_unique": 30, "cross": 0, "raw": 60},
+        ),
+    )
+    assert not any("cross-project" in w.lower() for w in warnings), warnings
+
+
+def test_jira_relation_breakdown_takes_precedence_over_legacy_count() -> None:
+    """When both ``jira_relation_breakdown`` and the legacy halved count are
+    present, the breakdown wins.
+
+    Mirrors what ``_execute_audit`` actually populates: both metrics
+    are set in the same dict, but the breakdown's intra-only check
+    is the authoritative comparison. Pin: a legacy halved count
+    that would fail (large cross-project tail) is silently ignored
+    in favour of the intra-only check.
+    """
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            jira_relation_count=2350,  # legacy halved would FAIL: 30 vs 2350
+            jira_relation_breakdown={"intra_unique": 30, "cross": 4640, "raw": 4700},
+        ),
+    )
+    assert not any("relation" in f.lower() and "5" in f for f in failures), failures
+
+
+def test_jira_relation_breakdown_zero_intra_requires_zero_op() -> None:
+    """Both intra-counts at zero is healthy; OP non-zero would fail."""
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            jira_relation_breakdown={"intra_unique": 0, "cross": 5, "raw": 5},
+            relation_total=0,
+            wp_total=10,
+        ),
+    )
+    assert not any("relation" in f.lower() and "5" in f for f in failures), failures
+    failures2, _ = _classify(
+        _baseline_metrics(
+            jira_relation_breakdown={"intra_unique": 0, "cross": 5, "raw": 5},
+            relation_total=3,
+            wp_total=10,
+        ),
+    )
+    # OP has 3 relations but Jira intra is 0 → mismatch.
+    assert any("relation" in f.lower() and "5" in f for f in failures2), failures2
+
+
 def test_jira_relation_count_missing_field_treated_as_silent() -> None:
     metrics = _baseline_metrics()
     failures, warnings = _classify(metrics)

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -594,29 +594,57 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     # whenever Jira data is available. Both directions out-of-band
     # are failures: a low OP count means relations were dropped on
     # migration; a high OP count means duplicates leaked through.
-    if "jira_relation_count" in metrics:
-        jira_rel = metrics["jira_relation_count"]
-        if jira_rel is None:
-            warnings.append(
-                "Jira relation source comparison unavailable — check skipped",
-            )
+    # Prefer the cross/intra breakdown (added 2026-05-07): the legacy
+    # ``raw // 2`` halved count over-counts on projects whose issues
+    # link heavily to other projects (NRS: 75% audit false-positive).
+    # Only intra-project links migrate, so we compare OP to the intra
+    # count and surface the cross count as informational.
+    breakdown = metrics.get("jira_relation_breakdown")
+    if isinstance(breakdown, dict):
+        op_rel = _metric_int(metrics, "relation_total")
+        intra_unique = int(breakdown.get("intra_unique") or 0)
+        cross = int(breakdown.get("cross") or 0)
+        if intra_unique == 0:
+            tolerance_ok = op_rel == 0
         else:
-            op_rel = _metric_int(metrics, "relation_total")
-            jira_rel_int = int(jira_rel)
-            # Tolerance is symmetric; when Jira reports zero we just
-            # require OP to also report zero (no division-by-zero).
-            if jira_rel_int == 0:
-                tolerance_ok = op_rel == 0
-            else:
-                delta_pct = abs(op_rel - jira_rel_int) / jira_rel_int
-                tolerance_ok = delta_pct <= _RELATION_TOLERANCE
-            if not tolerance_ok:
-                failures.append(
-                    f"Jira→OP relation count mismatch beyond ±5%:"
-                    f" Jira reports {jira_rel_int}, OP has {op_rel}"
-                    f" ({op_rel - jira_rel_int:+d}) — relations dropped or"
-                    " duplicated during migration",
-                )
+            delta_pct = abs(op_rel - intra_unique) / intra_unique
+            tolerance_ok = delta_pct <= _RELATION_TOLERANCE
+        if not tolerance_ok:
+            failures.append(
+                f"Jira→OP intra-project relation count mismatch beyond ±5%:"
+                f" Jira intra={intra_unique}, OP has {op_rel}"
+                f" ({op_rel - intra_unique:+d}) — relations dropped or"
+                " duplicated during migration",
+            )
+        if cross:
+            warnings.append(
+                f"Jira→OP cross-project relations not migrated: {cross}"
+                " — informational, not loss (cross-project links are"
+                " out of scope per MIGRATION_SPEC.md; the matched"
+                " project is single-scope)",
+            )
+    elif "jira_relation_count" in metrics and metrics["jira_relation_count"] is None:
+        warnings.append(
+            "Jira relation source comparison unavailable — check skipped",
+        )
+    elif "jira_relation_count" in metrics:
+        # Pre-breakdown legacy fallback. Still needed for fixture-based
+        # classifier tests that bypass ``_execute_audit`` and only set
+        # ``jira_relation_count``. Same halving caveat as before.
+        jira_rel_int = int(metrics["jira_relation_count"])
+        op_rel = _metric_int(metrics, "relation_total")
+        if jira_rel_int == 0:
+            tolerance_ok = op_rel == 0
+        else:
+            delta_pct = abs(op_rel - jira_rel_int) / jira_rel_int
+            tolerance_ok = delta_pct <= _RELATION_TOLERANCE
+        if not tolerance_ok:
+            failures.append(
+                f"Jira→OP relation count mismatch beyond ±5%:"
+                f" Jira reports {jira_rel_int}, OP has {op_rel}"
+                f" ({op_rel - jira_rel_int:+d}) — relations dropped or"
+                " duplicated during migration",
+            )
 
     # WP CF format validation. The Ruby side counts populated values
     # that don't match the expected regex per CF. Missing key = legacy
@@ -936,26 +964,131 @@ def _fetch_jira_watcher_count(jira_project_key: str) -> int | None:
     return total
 
 
+def _fetch_jira_relation_breakdown(jira_project_key: str) -> dict[str, int] | None:
+    """Best-effort: classify Jira issuelinks as intra-project vs cross-project.
+
+    The previous halving model (``raw // 2``) assumed intra-project
+    links dominate, which holds for small projects but breaks badly
+    on real-world projects whose issues link heavily to *other*
+    projects. Live 2026-05-07 NRS audit: 4624 raw issuelinks split
+    as 1173 intra + 3451 cross — halving reported 2312, OP had 591
+    (which roughly matches the 586 unique intra pairs) → audit
+    failed by -1759 even though the migration was lossless on
+    intra-project relations (cross-project links don't migrate by
+    design, per ``MIGRATION_SPEC.md``).
+
+    Returns a dict with three counts, or ``None`` on Jira failure:
+
+    * ``intra_unique`` — distinct unordered pairs ``{a, b}`` where
+      both ends are in this project. Each appears twice in the raw
+      stream (once per end); deduped via ``frozenset``. This is the
+      number OP's ``relation_total`` should match.
+    * ``cross`` — links where exactly one end is in this project.
+      Counted once each (only the in-project end carries them in
+      the per-issue iteration). Informational; cross-project links
+      do not migrate.
+    * ``raw`` — total issuelink entries summed across all issues.
+      Kept for back-compat with the legacy ``jira_relation_count``
+      metric (= ``raw // 2``) and to surface the "odd raw"
+      diagnostic if present.
+
+    Pagination + project-key validation reuse the same hardening as
+    :func:`_paginated_per_issue_field_count`.
+    """
+    if not _JIRA_PROJECT_KEY_RE.match(jira_project_key):
+        sys.stderr.write(
+            f"[audit] Jira relation breakdown skipped — invalid project key"
+            f" {jira_project_key!r} (expected uppercase Jira key like 'NRS')\n",
+        )
+        return None
+    try:
+        from src.infrastructure.jira.jira_client import JiraClient
+    except ImportError as exc:
+        sys.stderr.write(
+            f"[audit] Jira relation breakdown skipped — could not import JiraClient: {exc}\n",
+        )
+        return None
+
+    project_prefix = f"{jira_project_key}-"
+    intra_pairs: set[frozenset[str]] = set()
+    cross_count = 0
+    raw_count = 0
+
+    try:
+        jira = JiraClient()
+        underlying = jira.jira
+        page_size = 100
+        start_at = 0
+        jql = f'project = "{jira_project_key}"'
+        for _ in range(_PAGINATION_MAX_PAGES):
+            page = underlying.search_issues(
+                jql,
+                startAt=start_at,
+                maxResults=page_size,
+                fields="issuelinks",
+                expand="",
+            )
+            if not page:
+                break
+            for issue in page:
+                fields_obj = getattr(issue, "fields", None)
+                if fields_obj is None:
+                    continue
+                source_key = getattr(issue, "key", None)
+                if not source_key:
+                    continue
+                links = getattr(fields_obj, "issuelinks", None) or []
+                for link in links:
+                    raw_count += 1
+                    target_key: str | None = None
+                    outward = getattr(link, "outwardIssue", None)
+                    inward = getattr(link, "inwardIssue", None)
+                    if outward is not None:
+                        target_key = getattr(outward, "key", None)
+                    elif inward is not None:
+                        target_key = getattr(inward, "key", None)
+                    if not target_key:
+                        # Malformed link — neither outward nor inward
+                        # carries a key. Skip from both buckets so we
+                        # don't double-count.
+                        continue
+                    if target_key.startswith(project_prefix):
+                        # Intra-project: dedup by sorted pair so each
+                        # link contributes exactly once.
+                        intra_pairs.add(frozenset((source_key, target_key)))
+                    else:
+                        cross_count += 1
+            start_at += len(page)
+        else:
+            sys.stderr.write(
+                f"[audit] Jira relation pagination hit the {_PAGINATION_MAX_PAGES}"
+                f"-page safety cap for project {jira_project_key!r} — likely a buggy"
+                " upstream returning the same page repeatedly\n",
+            )
+            return None
+    except Exception as exc:
+        sys.stderr.write(
+            f"[audit] Jira relation breakdown skipped — {type(exc).__name__}: {exc}\n",
+        )
+        sys.stderr.write(traceback.format_exc())
+        return None
+
+    return {
+        "intra_unique": len(intra_pairs),
+        "cross": cross_count,
+        "raw": raw_count,
+    }
+
+
 def _fetch_jira_relation_count(jira_project_key: str) -> int | None:
-    """Best-effort: count total issue-link records across all issues in the project.
+    """Back-compat shim: returns the legacy ``raw // 2`` halved count.
 
-    Each ``issue.fields.issuelinks`` entry is one *direction* of a
-    Jira link (``inwardIssue`` or ``outwardIssue``); summing across
-    the project's issues counts each *intra-project* link twice (once
-    on each end) and each *cross-project* link once (only the in-scope
-    end is counted). The OP ``relation_total`` counts each Relation
-    row exactly once. So:
-
-    - 7 intra-project + 0 cross → raw=14, halved=7, OP=7 ✓
-    - 7 intra + 5 cross → raw=19, halved=9, OP=7 → fails ±5% (false positive)
-    - 0 intra + 1 cross → raw=1, halved=0, OP=0 ✓ (assuming cross-project
-      links don't migrate, which the current migration code does)
-
-    Halving is the right model when cross-project links are rare.
-    On projects where they're common the audit may report a drift
-    that's actually expected — operator should treat the failure as
-    a hint, then check ``stderr`` for the odd-raw warning below to
-    distinguish "real loss" from "cross-project asymmetry".
+    The classifier prefers ``jira_relation_breakdown`` when present
+    (set by :func:`_execute_audit`); this function exists so older
+    callers / fixtures that read ``metrics["jira_relation_count"]``
+    keep working. The halving model is documented as broken for
+    cross-project-heavy projects in
+    :func:`_fetch_jira_relation_breakdown`.
     """
     raw = _paginated_per_issue_field_count(
         jira_project_key,
@@ -968,17 +1101,14 @@ def _fetch_jira_relation_count(jira_project_key: str) -> int | None:
     if raw % 2 != 0:
         # Odd raw count means at least one cross-project link, which
         # the floor-division below silently rounds down. Surface the
-        # asymmetry on stderr so an operator investigating a relation
-        # mismatch can tell "real migration defect" from "cross-
-        # project link counted only on this side".
+        # asymmetry on stderr — preserved here so legacy callers /
+        # tests that exercise this shim still see the same diagnostic.
         sys.stderr.write(
             f"[audit] Jira raw issuelinks count for {jira_project_key!r}"
             f" is odd ({raw}) — at least one cross-project link is"
             " present; the floor-divided count below may be 0.5 low,"
             " which on small projects can push past ±5% tolerance\n",
         )
-    # Halve to match OP's one-row-per-link convention. ``// 2`` rounds
-    # down (per the warning above when raw is odd).
     return raw // 2
 
 
@@ -994,7 +1124,19 @@ def _execute_audit(jira_project_key: str) -> dict[str, Any]:
     # report is still valid.
     metrics["jira_issue_count"] = _fetch_jira_issue_count(jira_project_key)
     metrics["jira_attachment_count"] = _fetch_jira_attachment_count(jira_project_key)
-    metrics["jira_relation_count"] = _fetch_jira_relation_count(jira_project_key)
+    # Prefer the breakdown over the legacy halved count — the latter
+    # over-counts on cross-project-heavy projects (NRS audit caught
+    # this: -1759 false positive, see _fetch_jira_relation_breakdown).
+    breakdown = _fetch_jira_relation_breakdown(jira_project_key)
+    if breakdown is not None:
+        metrics["jira_relation_breakdown"] = breakdown
+        # Keep the legacy ``jira_relation_count`` populated for any
+        # downstream tooling that still reads it; derive from the same
+        # raw count so the two stay consistent.
+        metrics["jira_relation_count"] = breakdown["raw"] // 2
+    else:
+        metrics["jira_relation_breakdown"] = None
+        metrics["jira_relation_count"] = None
     metrics["jira_watcher_count"] = _fetch_jira_watcher_count(jira_project_key)
     return metrics
 

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -989,8 +989,11 @@ def _fetch_jira_relation_breakdown(jira_project_key: str) -> dict[str, int] | No
       do not migrate.
     * ``raw`` — total issuelink entries summed across all issues.
       Kept for back-compat with the legacy ``jira_relation_count``
-      metric (= ``raw // 2``) and to surface the "odd raw"
-      diagnostic if present.
+      metric (= ``raw // 2``). If ``raw`` is odd at the end of
+      pagination, an "[audit] odd raw" diagnostic is written to
+      stderr — same hint the legacy halved counter emits, surfaced
+      here so an operator investigating a small mismatch can
+      distinguish "real loss" from cross-project asymmetry.
 
     Pagination + project-key validation reuse the same hardening as
     :func:`_paginated_per_issue_field_count`.
@@ -1014,6 +1017,17 @@ def _fetch_jira_relation_breakdown(jira_project_key: str) -> dict[str, int] | No
     cross_count = 0
     raw_count = 0
 
+    def _read_attr(obj: Any, name: str) -> Any:
+        """Dual-shape access: dicts use ``.get``, SDK objects use
+        ``getattr``. Mirrors the dual-shape pattern in
+        ``relation_migration._merge_batch_issues`` so the breakdown
+        works on both live SDK responses AND any future dict-shaped
+        cache the audit might consume.
+        """
+        if isinstance(obj, dict):
+            return obj.get(name)
+        return getattr(obj, name, None)
+
     try:
         jira = JiraClient()
         underlying = jira.jira
@@ -1031,22 +1045,19 @@ def _fetch_jira_relation_breakdown(jira_project_key: str) -> dict[str, int] | No
             if not page:
                 break
             for issue in page:
-                fields_obj = getattr(issue, "fields", None)
+                fields_obj = _read_attr(issue, "fields")
                 if fields_obj is None:
                     continue
-                source_key = getattr(issue, "key", None)
+                source_key = _read_attr(issue, "key")
                 if not source_key:
                     continue
-                links = getattr(fields_obj, "issuelinks", None) or []
+                links = _read_attr(fields_obj, "issuelinks") or []
                 for link in links:
                     raw_count += 1
-                    target_key: str | None = None
-                    outward = getattr(link, "outwardIssue", None)
-                    inward = getattr(link, "inwardIssue", None)
-                    if outward is not None:
-                        target_key = getattr(outward, "key", None)
-                    elif inward is not None:
-                        target_key = getattr(inward, "key", None)
+                    outward = _read_attr(link, "outwardIssue")
+                    inward = _read_attr(link, "inwardIssue")
+                    target = outward if outward is not None else inward
+                    target_key = _read_attr(target, "key") if target is not None else None
                     if not target_key:
                         # Malformed link — neither outward nor inward
                         # carries a key. Skip from both buckets so we
@@ -1072,6 +1083,19 @@ def _fetch_jira_relation_breakdown(jira_project_key: str) -> dict[str, int] | No
         )
         sys.stderr.write(traceback.format_exc())
         return None
+
+    if raw_count % 2 != 0:
+        # Odd raw count means at least one cross-project link the legacy
+        # halving model rounds down. Emit the same diagnostic the legacy
+        # ``_fetch_jira_relation_count`` does so an operator
+        # investigating a small mismatch sees the same hint regardless
+        # of which path produced the metrics.
+        sys.stderr.write(
+            f"[audit] Jira raw issuelinks count for {jira_project_key!r}"
+            f" is odd ({raw_count}) — at least one cross-project link is"
+            " present; the legacy halved count derived from this raw is"
+            " 0.5 low, which on small projects can push past ±5% tolerance\n",
+        )
 
     return {
         "intra_unique": len(intra_pairs),
@@ -1127,6 +1151,10 @@ def _execute_audit(jira_project_key: str) -> dict[str, Any]:
     # Prefer the breakdown over the legacy halved count — the latter
     # over-counts on cross-project-heavy projects (NRS audit caught
     # this: -1759 false positive, see _fetch_jira_relation_breakdown).
+    # If the breakdown fails (transient Jira shape change, permission
+    # issue, etc.), fall back to the legacy halved count so the audit
+    # still produces *some* signal instead of degrading to a "check
+    # skipped" warning. Per PR #202 review.
     breakdown = _fetch_jira_relation_breakdown(jira_project_key)
     if breakdown is not None:
         metrics["jira_relation_breakdown"] = breakdown
@@ -1136,7 +1164,7 @@ def _execute_audit(jira_project_key: str) -> dict[str, Any]:
         metrics["jira_relation_count"] = breakdown["raw"] // 2
     else:
         metrics["jira_relation_breakdown"] = None
-        metrics["jira_relation_count"] = None
+        metrics["jira_relation_count"] = _fetch_jira_relation_count(jira_project_key)
     metrics["jira_watcher_count"] = _fetch_jira_watcher_count(jira_project_key)
     return metrics
 


### PR DESCRIPTION
## Summary

Fixes a 75% audit false positive caught by the live 2026-05-07 NRS run.

The legacy ``_fetch_jira_relation_count`` halved raw issuelinks (``raw // 2``) assuming intra-project links dominate. NRS is the opposite: 4624 raw entries split as **1173 intra + 3451 cross** — the halving reported 2312 vs. OP=591, audit flagged a -1759 \"loss\" even though intra-project relations were essentially lossless (586 unique pairs ≈ OP=591).

## Approach

Add ``_fetch_jira_relation_breakdown`` that walks each issue's ``issuelinks``, reads ``outwardIssue.key`` / ``inwardIssue.key``, and classifies:

- **intra_unique** — distinct ``frozenset({src, tgt})`` pairs where both ends are in the project. Each link appears twice in the raw stream (once per end); the set deduplicates them. This is the number OP's ``relation_total`` should match.
- **cross** — links where exactly one end is in the project. Counted once each (only the in-project end iterates them). Cross-project links don't migrate per [MIGRATION_SPEC.md](./docs/MIGRATION_SPEC.md).
- **raw** — back-compat with the legacy halved metric.

Classifier prefers the breakdown over the legacy count and surfaces cross count as an informational warning.

## Test plan
- [x] 6 new unit tests (intra-within-tolerance, intra-above-tolerance, cross-warning, cross-zero-omitted, breakdown-takes-precedence, zero-intra-requires-zero-op)
- [x] 80 existing audit tests still pass (legacy halved-count path preserved for fixture-only tests)
- [x] ``ruff check`` + ``ruff format --check`` clean
- [ ] CI green