### PR TITLE
feat(audit): per-issue attachment loss diagnostic

### DIFF
--- a/tests/unit/test_diagnose_attachment_loss.py
+++ b/tests/unit/test_diagnose_attachment_loss.py
@@ -1,0 +1,305 @@
+"""Unit tests for ``tools.diagnose_attachment_loss``.
+
+The tool fans out to live Jira + OP, so the tests stub both paths
+through small fakes. Pinned behaviours:
+
+* WP-mapping load: dict-shape rows, legacy-int rows skipped, inner
+  ``jira_key`` preferred over outer numeric key.
+* Per-issue diff: clean match, missing-in-op, extra-in-op, duplicate
+  filenames (multiset semantics), unmapped Jira issue.
+* Aggregate summary counts agree with per-issue results.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _write_mapping(path: Path, data: dict[str, Any]) -> None:
+    with path.open("w") as f:
+        json.dump(data, f)
+
+
+def test_load_wp_mapping_prefers_inner_jira_key(tmp_path: Path) -> None:
+    """Outer key is numeric, inner ``jira_key`` is the human-readable one.
+
+    The diagnostic must use the inner key so it matches what
+    ``AttachmentsMigration._wp_lookup_by_jira_key`` produces — any
+    divergence here would silently miscount.
+    """
+    from tools.diagnose_attachment_loss import _load_wp_mapping
+
+    f = tmp_path / "wpm.json"
+    _write_mapping(
+        f,
+        {
+            "10001": {"jira_key": "PROJ-1", "openproject_id": 501},
+            "10002": {"jira_key": "PROJ-2", "openproject_id": 502},
+        },
+    )
+    out = _load_wp_mapping(f)
+    assert out == {"PROJ-1": 501, "PROJ-2": 502}
+
+
+def test_load_wp_mapping_skips_legacy_int_rows(tmp_path: Path) -> None:
+    """Bare-int rows have no recoverable ``jira_key`` — skipped silently."""
+    from tools.diagnose_attachment_loss import _load_wp_mapping
+
+    f = tmp_path / "wpm.json"
+    _write_mapping(
+        f,
+        {
+            "10001": {"jira_key": "PROJ-1", "openproject_id": 501},
+            "PROJ-99": 999,  # legacy int — skip
+        },
+    )
+    out = _load_wp_mapping(f)
+    assert out == {"PROJ-1": 501}
+
+
+def test_load_wp_mapping_falls_back_to_outer_when_inner_missing(tmp_path: Path) -> None:
+    """If inner ``jira_key`` is absent, the outer key is taken as the human-readable form.
+
+    Mirrors the legacy/test fixture shape some prior runs left on
+    disk; matches the fallback in
+    ``AttachmentsMigration._wp_lookup_by_jira_key``.
+    """
+    from tools.diagnose_attachment_loss import _load_wp_mapping
+
+    f = tmp_path / "wpm.json"
+    _write_mapping(f, {"PROJ-1": {"openproject_id": 501}})
+    out = _load_wp_mapping(f)
+    assert out == {"PROJ-1": 501}
+
+
+def test_load_wp_mapping_missing_file_raises(tmp_path: Path) -> None:
+    from tools.diagnose_attachment_loss import _load_wp_mapping
+
+    with pytest.raises(FileNotFoundError, match="not found"):
+        _load_wp_mapping(tmp_path / "nope.json")
+
+
+def test_diagnose_clean_match(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Per-issue Jira+OP filenames match → ``clean`` count incremented."""
+    from tools import diagnose_attachment_loss as mod
+
+    f = tmp_path / "wpm.json"
+    _write_mapping(f, {"10001": {"jira_key": "NRS-1", "openproject_id": 501}})
+
+    monkeypatch.setattr(
+        mod,
+        "_iter_jira_issues_with_attachments",
+        lambda _k: {"NRS-1": [{"filename": "a.txt", "size": 10, "id": "1"}]},
+    )
+
+    class _StubOp:
+        def execute_json_query(self, *_a, **_kw) -> dict[str, list[dict[str, Any]]]:
+            return {"501": [{"filename": "a.txt", "id": 100, "size": 10}]}
+
+    monkeypatch.setattr(mod, "OpenProjectClient", _StubOp)
+
+    report = mod.diagnose("NRS", f)
+    assert report["summary"]["clean"] == 1
+    assert report["summary"]["missing_attachments_total"] == 0
+    assert "NRS-1" not in report["per_issue_diffs"]
+
+
+def test_diagnose_missing_in_op(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """File present in Jira but absent from OP → counted as missing."""
+    from tools import diagnose_attachment_loss as mod
+
+    f = tmp_path / "wpm.json"
+    _write_mapping(f, {"10001": {"jira_key": "NRS-1", "openproject_id": 501}})
+
+    monkeypatch.setattr(
+        mod,
+        "_iter_jira_issues_with_attachments",
+        lambda _k: {
+            "NRS-1": [{"filename": "a.txt", "size": 10, "id": "1"}, {"filename": "b.txt", "size": 5, "id": "2"}]
+        },
+    )
+
+    class _StubOp:
+        def execute_json_query(self, *_a, **_kw) -> dict[str, list[dict[str, Any]]]:
+            return {"501": [{"filename": "a.txt", "id": 100, "size": 10}]}
+
+    monkeypatch.setattr(mod, "OpenProjectClient", _StubOp)
+
+    report = mod.diagnose("NRS", f)
+    assert report["summary"]["missing_attachments_total"] == 1
+    diff = report["per_issue_diffs"]["NRS-1"]
+    assert diff["missing_in_op"] == ["b.txt"]
+    assert diff["extra_in_op"] == []
+
+
+def test_diagnose_extra_in_op(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """File present in OP but absent from Jira → counted as extra (phantom)."""
+    from tools import diagnose_attachment_loss as mod
+
+    f = tmp_path / "wpm.json"
+    _write_mapping(f, {"10001": {"jira_key": "NRS-1", "openproject_id": 501}})
+
+    monkeypatch.setattr(
+        mod,
+        "_iter_jira_issues_with_attachments",
+        lambda _k: {"NRS-1": [{"filename": "a.txt", "size": 10, "id": "1"}]},
+    )
+
+    class _StubOp:
+        def execute_json_query(self, *_a, **_kw) -> dict[str, list[dict[str, Any]]]:
+            return {
+                "501": [
+                    {"filename": "a.txt", "id": 100, "size": 10},
+                    {"filename": "phantom.bin", "id": 101, "size": 99},
+                ],
+            }
+
+    monkeypatch.setattr(mod, "OpenProjectClient", _StubOp)
+
+    report = mod.diagnose("NRS", f)
+    assert report["summary"]["extra_attachments_total"] == 1
+    diff = report["per_issue_diffs"]["NRS-1"]
+    assert diff["missing_in_op"] == []
+    assert diff["extra_in_op"] == ["phantom.bin"]
+
+
+def test_diagnose_handles_duplicate_filenames(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Duplicate filenames are matched as a multiset.
+
+    Pin: 2 ``screenshot.png`` in Jira and 1 in OP → 1 missing
+    (NOT 0 — set-based dedup would have masked the loss).
+    """
+    from tools import diagnose_attachment_loss as mod
+
+    f = tmp_path / "wpm.json"
+    _write_mapping(f, {"10001": {"jira_key": "NRS-1", "openproject_id": 501}})
+
+    monkeypatch.setattr(
+        mod,
+        "_iter_jira_issues_with_attachments",
+        lambda _k: {
+            "NRS-1": [
+                {"filename": "screenshot.png", "size": 10, "id": "1"},
+                {"filename": "screenshot.png", "size": 11, "id": "2"},
+            ],
+        },
+    )
+
+    class _StubOp:
+        def execute_json_query(self, *_a, **_kw) -> dict[str, list[dict[str, Any]]]:
+            return {"501": [{"filename": "screenshot.png", "id": 100, "size": 10}]}
+
+    monkeypatch.setattr(mod, "OpenProjectClient", _StubOp)
+
+    report = mod.diagnose("NRS", f)
+    assert report["summary"]["missing_attachments_total"] == 1
+    assert report["per_issue_diffs"]["NRS-1"]["missing_in_op"] == ["screenshot.png"]
+
+
+def test_diagnose_unmapped_jira_issue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Jira issue has attachments but no entry in WP mapping → ``wp_unmapped``."""
+    from tools import diagnose_attachment_loss as mod
+
+    f = tmp_path / "wpm.json"
+    _write_mapping(f, {"10001": {"jira_key": "NRS-1", "openproject_id": 501}})
+
+    monkeypatch.setattr(
+        mod,
+        "_iter_jira_issues_with_attachments",
+        lambda _k: {
+            "NRS-1": [{"filename": "a.txt", "size": 10, "id": "1"}],
+            "NRS-99": [{"filename": "ghost.bin", "size": 5, "id": "2"}],  # not in mapping
+        },
+    )
+
+    class _StubOp:
+        def execute_json_query(self, *_a, **_kw) -> dict[str, list[dict[str, Any]]]:
+            return {"501": [{"filename": "a.txt", "id": 100, "size": 10}]}
+
+    monkeypatch.setattr(mod, "OpenProjectClient", _StubOp)
+
+    report = mod.diagnose("NRS", f)
+    assert report["summary"]["wp_unmapped"] == 1
+    assert report["per_issue_diffs"]["NRS-99"]["status"] == "wp_unmapped"
+    assert report["per_issue_diffs"]["NRS-99"]["wp_id"] is None
+    # The ghost file shows up under missing_in_op for the unmapped issue.
+    assert report["per_issue_diffs"]["NRS-99"]["missing_in_op"] == ["ghost.bin"]
+
+
+def test_diagnose_invalid_project_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same project-key validation contract as the audit tool."""
+    from tools import diagnose_attachment_loss as mod
+
+    f = tmp_path / "wpm.json"
+    _write_mapping(f, {})
+
+    # Stub OpenProjectClient so the test doesn't try to connect.
+    def _no_op_client() -> SimpleNamespace:
+        return SimpleNamespace()
+
+    monkeypatch.setattr(mod, "OpenProjectClient", _no_op_client)
+
+    with pytest.raises(ValueError, match="invalid project key"):
+        mod.diagnose("nrs lower-case", f)
+
+
+def test_diagnose_summary_counts_agree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Aggregate counts must equal the per-issue diff sums.
+
+    Pin: a future regression that double-counts (or under-counts)
+    one of the buckets shows up here as a sum mismatch.
+    """
+    from tools import diagnose_attachment_loss as mod
+
+    f = tmp_path / "wpm.json"
+    _write_mapping(
+        f,
+        {
+            "10001": {"jira_key": "NRS-1", "openproject_id": 501},
+            "10002": {"jira_key": "NRS-2", "openproject_id": 502},
+            "10003": {"jira_key": "NRS-3", "openproject_id": 503},
+        },
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "_iter_jira_issues_with_attachments",
+        lambda _k: {
+            # Clean
+            "NRS-1": [{"filename": "ok.txt", "size": 1, "id": "1"}],
+            # Missing
+            "NRS-2": [
+                {"filename": "lost.txt", "size": 1, "id": "2"},
+                {"filename": "also_lost.txt", "size": 1, "id": "3"},
+            ],
+            # Extra
+            "NRS-3": [{"filename": "kept.txt", "size": 1, "id": "4"}],
+        },
+    )
+
+    class _StubOp:
+        def execute_json_query(self, *_a, **_kw) -> dict[str, list[dict[str, Any]]]:
+            return {
+                "501": [{"filename": "ok.txt", "id": 100, "size": 1}],
+                "502": [],
+                "503": [
+                    {"filename": "kept.txt", "id": 102, "size": 1},
+                    {"filename": "phantom.txt", "id": 103, "size": 7},
+                ],
+            }
+
+    monkeypatch.setattr(mod, "OpenProjectClient", _StubOp)
+
+    report = mod.diagnose("NRS", f)
+    s = report["summary"]
+    assert s["clean"] == 1, s
+    assert s["issues_with_missing"] == 1, s
+    assert s["issues_with_extra"] == 1, s
+    assert s["missing_attachments_total"] == 2, s
+    assert s["extra_attachments_total"] == 1, s
+    assert s["issues_examined"] == 3, s

--- a/tools/diagnose_attachment_loss.py
+++ b/tools/diagnose_attachment_loss.py
@@ -1,0 +1,323 @@
+"""Diagnose per-issue attachment loss between Jira and OpenProject.
+
+The :mod:`tools.audit_migrated_project` script reports an aggregate
+``Jira reports N, OP has M`` for attachments. When they differ (live
+2026-05-07 NRS audit: -131), that summary doesn't say *which* issues
+or *which* filenames are missing — operators are left to grep the
+migration log or trial-and-error.
+
+This tool enumerates the gap directly:
+
+1. Iterate every Jira issue in the project (paginated).
+2. For each issue, list Jira's attachments (filename + size).
+3. Look up the matching OP work package via the persisted
+   ``work_package_mapping``.
+4. List OP's attachments on that work package.
+5. Diff by filename and emit per-issue + aggregate counts:
+
+   * ``missing_in_op`` — present in Jira, not in OP (real loss).
+   * ``extra_in_op`` — present in OP, not in Jira (phantom /
+     duplicate / pre-existing).
+
+Usage::
+
+    .venv/bin/python -m tools.diagnose_attachment_loss NRS
+
+Output: structured JSON to stdout. The intended downstream is a
+follow-up backfill (re-attach the missing files) or a remediation
+runbook entry (Jira-side 404s — confirmed deleted source).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import traceback
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+
+# Validated against argv before being interpolated into JQL — same
+# guard as the audit tool to prevent quote injection from a malformed
+# project key.
+_JIRA_PROJECT_KEY_RE = re.compile(r"\A[A-Z][A-Z0-9_]+\z")
+
+# Hard cap on pagination — same defence the audit tool uses against
+# a buggy upstream returning the same page repeatedly.
+_PAGINATION_MAX_PAGES = 1000
+
+# Default location of the persisted WP mapping. Override via CLI if
+# the operator runs against an alternate data dir.
+_DEFAULT_WP_MAPPING_FILE = Path("var/data/work_package_mapping.json")
+
+
+def _read_attr(obj: Any, name: str) -> Any:
+    """Dual-shape access (dict / SDK object)."""
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def _iter_jira_issues_with_attachments(jira_project_key: str) -> dict[str, list[dict[str, Any]]]:
+    """Return ``{jira_key: [{filename, size, id}, ...]}`` for the project.
+
+    Issues with no attachments are omitted from the result so the
+    diagnostic output stays focused on actionable rows.
+    """
+    if not _JIRA_PROJECT_KEY_RE.match(jira_project_key):
+        msg = f"invalid project key {jira_project_key!r} (expected uppercase Jira key)"
+        raise ValueError(msg)
+
+    from src.infrastructure.jira.jira_client import JiraClient
+
+    out: dict[str, list[dict[str, Any]]] = {}
+    jira = JiraClient()
+    underlying = jira.jira
+    if underlying is None:
+        msg = "Jira client is not initialized — check J2O_JIRA_* env vars"
+        raise RuntimeError(msg)
+    page_size = 100
+    start_at = 0
+    jql = f'project = "{jira_project_key}"'
+    for _ in range(_PAGINATION_MAX_PAGES):
+        page = underlying.search_issues(
+            jql,
+            startAt=start_at,
+            maxResults=page_size,
+            fields="attachment",
+            expand="",
+        )
+        if not page:
+            break
+        for issue in page:
+            key = _read_attr(issue, "key")
+            fields_obj = _read_attr(issue, "fields")
+            if not key or fields_obj is None:
+                continue
+            atts = _read_attr(fields_obj, "attachment") or []
+            entries: list[dict[str, Any]] = []
+            for a in atts:
+                filename = _read_attr(a, "filename")
+                if not isinstance(filename, str) or not filename.strip():
+                    continue
+                entries.append(
+                    {
+                        "filename": filename,
+                        "size": _read_attr(a, "size"),
+                        "id": _read_attr(a, "id"),
+                    },
+                )
+            if entries:
+                out[str(key)] = entries
+        start_at += len(page)
+    else:
+        sys.stderr.write(
+            f"[diagnose] Jira pagination hit the {_PAGINATION_MAX_PAGES}"
+            f"-page cap for project {jira_project_key!r} — likely a buggy"
+            " upstream returning the same page repeatedly\n",
+        )
+    return out
+
+
+def _load_wp_mapping(path: Path) -> dict[str, int]:
+    """Return ``{jira_key: op_wp_id}`` from the persisted mapping file.
+
+    Mirrors :meth:`AttachmentsMigration._wp_lookup_by_jira_key` so the
+    diagnostic uses the same lookup the migration uses — any divergence
+    here would silently miscount.
+    """
+    if not path.exists():
+        msg = f"work_package mapping file not found at {path} (run work_packages_skeleton first)"
+        raise FileNotFoundError(msg)
+    with path.open() as f:
+        raw = json.load(f)
+    if not isinstance(raw, dict):
+        msg = f"work_package mapping at {path} is not a dict (got {type(raw).__name__})"
+        raise TypeError(msg)
+    out: dict[str, int] = {}
+    for outer_key, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        inner_jira_key = entry.get("jira_key")
+        jira_key = str(inner_jira_key or outer_key)
+        op_id = entry.get("openproject_id")
+        if op_id is None:
+            continue
+        if not isinstance(op_id, int):
+            try:
+                op_id = int(op_id)
+            except TypeError, ValueError:
+                continue
+        out[jira_key] = op_id
+    return out
+
+
+def _build_op_query(wp_ids: list[int]) -> str:
+    """Ruby that returns ``{wp_id: [{filename, id, size}]}`` for the WPs."""
+    return f"""
+(lambda do
+  ids = {wp_ids!r}
+  out = {{}}
+  Attachment.where(container_type: 'WorkPackage', container_id: ids).
+    pluck(:container_id, :filename, :id, :file_size).each do |cid, fn, id, sz|
+      out[cid] ||= []
+      out[cid] << {{ 'filename' => fn, 'id' => id, 'size' => sz }}
+    end
+  out
+end).call
+"""
+
+
+def _fetch_op_attachments(op_client: OpenProjectClient, wp_ids: list[int]) -> dict[int, list[dict[str, Any]]]:
+    """Return ``{op_wp_id: [{filename, id, size}]}`` for the given WPs.
+
+    Batches large id lists to keep the Ruby script under the
+    bind-parameter limits the audit tool also defends against.
+    """
+    batch_size = 500
+    merged: dict[int, list[dict[str, Any]]] = {}
+    for i in range(0, len(wp_ids), batch_size):
+        batch = wp_ids[i : i + batch_size]
+        script = _build_op_query(batch)
+        result = op_client.execute_json_query(script, timeout=120)
+        if not isinstance(result, dict):
+            continue
+        for k, v in result.items():
+            try:
+                wid = int(k)
+            except TypeError, ValueError:
+                continue
+            if isinstance(v, list):
+                merged[wid] = v
+    return merged
+
+
+def diagnose(jira_project_key: str, mapping_path: Path) -> dict[str, Any]:
+    """Run the per-issue Jira ↔ OP attachment diff."""
+    sys.stderr.write(f"[diagnose] reading WP mapping from {mapping_path}\n")
+    wp_map = _load_wp_mapping(mapping_path)
+    project_keys_in_mapping = {k for k in wp_map if k.startswith(f"{jira_project_key}-")}
+    sys.stderr.write(
+        f"[diagnose] {len(wp_map)} total WP entries; {len(project_keys_in_mapping)}"
+        f" belong to project {jira_project_key!r}\n",
+    )
+
+    sys.stderr.write(f"[diagnose] enumerating Jira issues with attachments for {jira_project_key!r}…\n")
+    jira_atts = _iter_jira_issues_with_attachments(jira_project_key)
+    sys.stderr.write(
+        f"[diagnose] found {len(jira_atts)} Jira issues with attachments;"
+        f" {sum(len(v) for v in jira_atts.values())} attachments total\n",
+    )
+
+    # Resolve the WPs we'll look up on the OP side.
+    relevant_wp_ids = sorted({wp_map[k] for k in jira_atts if k in wp_map})
+    sys.stderr.write(f"[diagnose] fetching OP attachments for {len(relevant_wp_ids)} matching WPs…\n")
+    op_client = OpenProjectClient()
+    op_atts_by_wp = _fetch_op_attachments(op_client, relevant_wp_ids)
+
+    per_issue: dict[str, dict[str, Any]] = {}
+    summary: Counter[str] = Counter()
+    missing_filenames_total: list[tuple[str, str]] = []
+    extra_filenames_total: list[tuple[str, str]] = []
+
+    for jira_key, jira_list in jira_atts.items():
+        wp_id = wp_map.get(jira_key)
+        jira_filenames = [a["filename"] for a in jira_list]
+        if wp_id is None:
+            per_issue[jira_key] = {
+                "wp_id": None,
+                "jira_count": len(jira_filenames),
+                "op_count": 0,
+                "missing_in_op": jira_filenames,
+                "extra_in_op": [],
+                "status": "wp_unmapped",
+            }
+            summary["wp_unmapped"] += 1
+            for fn in jira_filenames:
+                missing_filenames_total.append((jira_key, fn))
+            continue
+
+        op_list = op_atts_by_wp.get(wp_id, [])
+        op_filenames = [a["filename"] for a in op_list]
+        # Multiset diff so duplicate filenames (a real Jira pattern)
+        # match correctly instead of collapsing to a set.
+        jira_counter = Counter(jira_filenames)
+        op_counter = Counter(op_filenames)
+        missing_in_op_counter = jira_counter - op_counter
+        extra_in_op_counter = op_counter - jira_counter
+        missing_in_op = sorted(missing_in_op_counter.elements())
+        extra_in_op = sorted(extra_in_op_counter.elements())
+
+        if missing_in_op or extra_in_op:
+            per_issue[jira_key] = {
+                "wp_id": wp_id,
+                "jira_count": len(jira_filenames),
+                "op_count": len(op_filenames),
+                "missing_in_op": missing_in_op,
+                "extra_in_op": extra_in_op,
+                "status": "diff",
+            }
+            if missing_in_op:
+                summary["issues_with_missing"] += 1
+            if extra_in_op:
+                summary["issues_with_extra"] += 1
+            for fn in missing_in_op:
+                missing_filenames_total.append((jira_key, fn))
+            for fn in extra_in_op:
+                extra_filenames_total.append((jira_key, fn))
+        else:
+            summary["clean"] += 1
+
+    return {
+        "project_key": jira_project_key,
+        "mapping_path": str(mapping_path),
+        "summary": {
+            "issues_examined": len(jira_atts),
+            **dict(summary),
+            "missing_attachments_total": len(missing_filenames_total),
+            "extra_attachments_total": len(extra_filenames_total),
+        },
+        "per_issue_diffs": per_issue,
+        "missing_filenames_sample": missing_filenames_total[:50],
+        "extra_filenames_sample": extra_filenames_total[:50],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: write the per-issue attachment diff JSON to stdout."""
+    parser = argparse.ArgumentParser(description="Diagnose per-issue attachment loss for a migrated Jira project")
+    parser.add_argument("jira_key", help="Jira project key (e.g. NRS)")
+    parser.add_argument(
+        "--mapping",
+        type=Path,
+        default=_DEFAULT_WP_MAPPING_FILE,
+        help=f"Path to the work_package_mapping.json (default: {_DEFAULT_WP_MAPPING_FILE})",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = diagnose(args.jira_key, args.mapping)
+    except Exception as exc:
+        sys.stderr.write(f"[diagnose] failed: {type(exc).__name__}: {exc}\n")
+        sys.stderr.write(traceback.format_exc())
+        return 2
+
+    sys.stdout.write(json.dumps(report, indent=2) + "\n")
+    summary = report["summary"]
+    sys.stderr.write(
+        f"[diagnose] PASS={summary.get('clean', 0)},"
+        f" MISSING_ISSUES={summary.get('issues_with_missing', 0)},"
+        f" EXTRA_ISSUES={summary.get('issues_with_extra', 0)},"
+        f" MISSING_FILES={summary['missing_attachments_total']},"
+        f" EXTRA_FILES={summary['extra_attachments_total']}\n",
+    )
+    # Non-zero exit if any real loss is detected so CI / wrappers see it.
+    return 1 if summary.get("missing_attachments_total", 0) > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The audit tool reports an aggregate ``Jira reports 4572, OP has 4441 (-131)`` for attachments. The summary doesn't say *which* issues or *which* filenames are missing — operators are left grepping migration logs.

This adds ``tools/diagnose_attachment_loss.py NRS`` which enumerates the gap per-issue:

1. Iterate every Jira issue in the project (paginated)
2. List Jira's attachments per issue (filename + size + id)
3. Look up matching OP work package via the persisted ``work_package_mapping`` (same lookup ``AttachmentsMigration._wp_lookup_by_jira_key`` uses)
4. Pull OP's attachments for those WPs in batched Rails calls
5. Emit a per-issue diff (multiset semantics for duplicate filenames) and aggregate counters

## Output

Structured JSON to stdout, summary to stderr, non-zero exit when ``missing_attachments_total > 0``. Sample structure:

```json
{
  "project_key": "NRS",
  "summary": {
    "issues_examined": 1234,
    "clean": 1100,
    "issues_with_missing": 50,
    "missing_attachments_total": 131,
    "extra_attachments_total": 0
  },
  "per_issue_diffs": {
    "NRS-42": { "wp_id": 503, "missing_in_op": ["screenshot.png"], "extra_in_op": [], ... }
  }
}
```

Intended downstream: a focused backfill (re-attach the missing files) or a remediation runbook entry (Jira-side 404s — confirmed deleted source).

## Test plan
- [x] 11 unit tests covering inner/outer key fallback, legacy bare-int row skip, multiset duplicate handling, unmapped Jira issue, invalid project key, aggregate-vs-per-issue count agreement
- [x] ``ruff check`` + ``ruff format --check`` clean
- [ ] CI green
- [ ] Live run on NRS to enumerate the 131 missing files