### PR TITLE
feat(users): user_mapping_backfill component

### DIFF
--- a/src/application/components/user_mapping_backfill_migration.py
+++ b/src/application/components/user_mapping_backfill_migration.py
@@ -1,0 +1,377 @@
+"""Backfill ``user_mapping`` for Jira identities not in ``/rest/api/2/users``.
+
+The ``users`` component populates ``user_mapping.json`` by iterating
+``/rest/api/2/users``, which excludes locked / inactive accounts.
+Anyone who watched an issue / authored a comment / was assigned a
+worklog under one of those locked accounts then drops out as
+``user_unmapped`` in :class:`WatcherMigration`,
+:class:`TimeEntryMigration`, etc. — silent loss on every run.
+
+This is a **backfill** in the literal sense the operator described:
+on a follow-up run, retroactively fold *new* identities (new in Jira
+*or* newly-discovered via richer issue data) into the existing
+mapping so the rest of the run can resolve them.
+
+Sources of candidate identities, in priority order:
+
+1. **Previous run's ``unmapped_users`` lists** — the watcher and TE
+   migrations record every distinct identity they couldn't resolve
+   in ``ComponentResult.details["unmapped_users"]``. The latest
+   ``migration_results_*.json`` carries that breadcrumb forward.
+2. **Cached Jira issues** — when ``jira_issues_cache.json`` is
+   present, discover identities from ``fields.assignee``,
+   ``fields.reporter``, ``fields.watches.watchers`` and
+   ``fields.comment.comments[*].author``. (This is the same
+   discovery PR #196 added to ``user_migration``; running it in a
+   dedicated component ensures it executes regardless of whether
+   ``users`` was skipped by change-detection.)
+
+For each candidate:
+
+* Skip if already in the mapping under any identifier.
+* Query Jira for the full profile.
+* Probe OP via ``get_user(login)`` → ``get_user_by_email(email)``.
+* If found → write to ``user_mapping`` under every identifier
+  (name / key / accountId / emailAddress) so the multi-probe
+  resolver in the consumers can reach it from any of them.
+* If not found in OP → record under ``not_found_in_op`` for
+  operator triage.
+
+Idempotent: re-runs leave already-mapped names untouched and never
+clobber operator-set entries on an alternate identifier.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+from typing import Any
+
+from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.models import ComponentResult
+
+
+@register_entity_types("user_mapping_backfill")
+class UserMappingBackfillMigration(BaseMigration):
+    """Phase: pull missing Jira identities into ``user_mapping``."""
+
+    def __init__(self, jira_client: JiraClient, op_client: OpenProjectClient) -> None:
+        super().__init__(jira_client=jira_client, op_client=op_client)
+
+    def _get_current_entities_for_type(self, entity_type: str) -> list[dict[str, Any]]:
+        msg = (
+            "UserMappingBackfillMigration is a transformation-only migration"
+            " and does not support idempotent workflow. It operates on the"
+            " persisted user_mapping + previous migration_results / cached issues."
+        )
+        raise ValueError(msg)
+
+    @staticmethod
+    def _names_from_previous_results(results_dir: Path) -> set[str]:
+        """Walk every ``migration_results_*.json`` in ``results_dir`` and
+        union the ``unmapped_users`` from every component's details.
+
+        Reading every file (not just the latest) is intentional: a
+        backfill might span several runs in which different sets of
+        users showed up unmapped, and there's no guarantee the
+        latest file has the union — only the most recent run's
+        breadcrumb. Each run's file is small (≪1 MB), so the cost is
+        negligible.
+        """
+        out: set[str] = set()
+        if not results_dir.exists():
+            return out
+        for path in sorted(results_dir.glob("migration_results_*.json")):
+            try:
+                with path.open() as f:
+                    d = json.load(f)
+            except OSError, json.JSONDecodeError:
+                continue
+            comps = d.get("components") or d.get("component_results") or {}
+            if not isinstance(comps, dict):
+                continue
+            for comp in comps.values():
+                if not isinstance(comp, dict):
+                    continue
+                details = comp.get("details") or {}
+                if not isinstance(details, dict):
+                    continue
+                names = details.get("unmapped_users") or []
+                if isinstance(names, list):
+                    for name in names:
+                        if isinstance(name, str) and name.strip():
+                            out.add(name.strip())
+        return out
+
+    @staticmethod
+    def _names_from_issue_cache(data_dir: Path) -> set[str]:
+        """Discover identities from cached Jira issues.
+
+        Same shape :meth:`UserMigration._discover_users_from_cached_issues`
+        consumes — we read from any of these locations:
+
+        * ``jira_issues_cache.json`` (unified)
+        * ``jira_issues_*.json`` (per-project dumps from
+          ``work_package_migration._extract_jira_issues``)
+
+        Per-issue probes: ``fields.assignee``, ``fields.reporter``,
+        ``fields.watches.watchers[*]``,
+        ``fields.comment.comments[*].author``. Each user object's
+        ``name`` / ``key`` / ``accountId`` is candidate-keyed (whichever
+        identifier the issue carries).
+        """
+        out: set[str] = set()
+        candidates: list[Path] = []
+        unified = data_dir / "jira_issues_cache.json"
+        if unified.exists():
+            candidates.append(unified)
+        for hit in data_dir.glob("jira_issues_*.json"):
+            if hit.name == "jira_issues_cache.json":
+                continue
+            candidates.append(hit)
+        if not candidates:
+            return out
+
+        for path in candidates:
+            try:
+                with path.open() as f:
+                    raw = json.load(f)
+            except OSError, json.JSONDecodeError:
+                continue
+            issues_iter: list[Any] = []
+            if isinstance(raw, dict):
+                issues_iter = list(raw.values())
+            elif isinstance(raw, list):
+                issues_iter = list(raw)
+            for issue in issues_iter:
+                _harvest_users_from_issue(issue, out)
+        return out
+
+    def _candidate_keys(self, jira_user: dict[str, Any]) -> list[str]:
+        """Identifier ladder mirroring the consumer migrations' resolvers
+        (:meth:`AttachmentProvenanceMigration._resolve_user_id`).
+        """
+        out: list[str] = []
+        for k in ("name", "key", "accountId", "emailAddress"):
+            v = jira_user.get(k)
+            if isinstance(v, str) and v.strip():
+                out.append(v.strip())
+        return out
+
+    def _find_op_user(self, jira_user: dict[str, Any]) -> dict[str, Any] | None:
+        """Best-effort: locate an OP user matching the Jira user.
+
+        ``get_user`` and ``get_user_by_email`` raise on miss; catch and
+        continue so one missing probe doesn't cancel the next.
+        """
+        name = jira_user.get("name") or jira_user.get("key")
+        if isinstance(name, str) and name:
+            with contextlib.suppress(Exception):
+                user = self.op_client.get_user(name)
+                if user:
+                    return user
+        email = jira_user.get("emailAddress")
+        if isinstance(email, str) and email:
+            with contextlib.suppress(Exception):
+                user = self.op_client.get_user_by_email(email)
+                if user:
+                    return user
+        return None
+
+    def _build_entry(self, op_user: dict[str, Any], jira_user: dict[str, Any]) -> dict[str, Any] | None:
+        """Build the user_mapping entry, returning ``None`` if the OP user
+        has no usable id.
+        """
+        op_id = op_user.get("id")
+        if not isinstance(op_id, int):
+            try:
+                op_id = int(op_id) if op_id is not None else None
+            except TypeError, ValueError:
+                op_id = None
+        if op_id is None:
+            return None
+        return {
+            "openproject_id": op_id,
+            "jira_name": jira_user.get("name"),
+            "jira_email": jira_user.get("emailAddress"),
+            "jira_display_name": jira_user.get("displayName"),
+            "jira_key": jira_user.get("key"),
+            "matched_by": "user_mapping_backfill",
+        }
+
+    def run(self) -> ComponentResult:  # type: ignore[override]
+        self.logger.info("Starting user_mapping backfill")
+
+        user_map: dict[str, Any] = dict(self.mappings.get_mapping("user") or {})
+        before = len(user_map)
+
+        results_dir = self.data_dir.parent / "results"
+        from_results = self._names_from_previous_results(results_dir)
+        from_cache = self._names_from_issue_cache(self.data_dir)
+        all_names = from_results | from_cache
+        self.logger.info(
+            "Backfill candidates: %d from previous migration_results, %d from issue cache (%d unique)",
+            len(from_results),
+            len(from_cache),
+            len(all_names),
+        )
+
+        if not all_names:
+            return ComponentResult(
+                success=True,
+                updated=0,
+                message="No backfill candidates from previous results / issue cache.",
+                details={
+                    "from_previous_results": 0,
+                    "from_issue_cache": 0,
+                    "added": 0,
+                    "already_mapped": 0,
+                    "not_found_in_jira": 0,
+                    "not_found_in_op": 0,
+                },
+            )
+
+        # Filter out identities already reachable by any probe key in
+        # the existing mapping. We don't know yet which identifier
+        # form each name takes (login vs accountId vs email), so the
+        # cheap path is "is this string already a key?". A second
+        # check after the Jira lookup catches the case where Jira
+        # reports an alternate identifier we already have.
+        unresolved: list[str] = []
+        already_mapped: list[str] = []
+        for name in sorted(all_names):
+            if name in user_map:
+                already_mapped.append(name)
+            else:
+                unresolved.append(name)
+
+        added: list[dict[str, Any]] = []
+        not_found_in_jira: list[str] = []
+        not_found_in_op: list[dict[str, Any]] = []
+
+        for name in unresolved:
+            try:
+                jira_user = self.jira_client.get_user_info(name)
+            except Exception:
+                jira_user = None
+            if not isinstance(jira_user, dict):
+                not_found_in_jira.append(name)
+                continue
+
+            # Second-chance dedup: if Jira reports an alternate
+            # identifier we already have mapped, skip.
+            cand_keys = self._candidate_keys(jira_user)
+            if any(k in user_map for k in cand_keys):
+                already_mapped.append(name)
+                continue
+
+            op_user = self._find_op_user(jira_user)
+            if op_user is None:
+                not_found_in_op.append(
+                    {
+                        "jira_name": name,
+                        "jira_email": jira_user.get("emailAddress"),
+                        "jira_display": jira_user.get("displayName"),
+                        "active": jira_user.get("active"),
+                    },
+                )
+                continue
+
+            entry = self._build_entry(op_user, jira_user)
+            if entry is None:
+                not_found_in_op.append(
+                    {
+                        "jira_name": name,
+                        "reason": "op_user_id_missing_or_non_integer",
+                    },
+                )
+                continue
+            for k in cand_keys:
+                if k not in user_map:
+                    user_map[k] = entry
+            added.append({"name": name, "openproject_id": entry["openproject_id"]})
+
+        # Persist only when something actually changed. Avoids re-writing
+        # the file every run when no candidates were resolved.
+        if added:
+            self.mappings.set_mapping("user", user_map)
+            self.logger.info(
+                "Backfilled %d Jira identities into user_mapping (was %d → %d entries).",
+                len(added),
+                before,
+                len(user_map),
+            )
+        if not_found_in_op:
+            sample = [u.get("jira_name") for u in not_found_in_op[:20]]
+            self.logger.warning(
+                "%d Jira identities have no matching OP user (sample: %s)."
+                " Operator must create these in OP or accept the loss as"
+                " expected for fully-deleted accounts.",
+                len(not_found_in_op),
+                sample,
+            )
+
+        return ComponentResult(
+            success=True,
+            updated=len(added),
+            message=(
+                f"User mapping backfill: added={len(added)},"
+                f" already_mapped={len(already_mapped)},"
+                f" not_found_in_jira={len(not_found_in_jira)},"
+                f" not_found_in_op={len(not_found_in_op)}"
+            ),
+            details={
+                "from_previous_results": len(from_results),
+                "from_issue_cache": len(from_cache),
+                "added": len(added),
+                "already_mapped": len(already_mapped),
+                "not_found_in_jira": len(not_found_in_jira),
+                "not_found_in_op_count": len(not_found_in_op),
+                "not_found_in_op_sample": not_found_in_op[:20],
+                "added_sample": added[:20],
+            },
+        )
+
+
+def _harvest_users_from_issue(issue: Any, into: set[str]) -> None:
+    """Walk an issue (dict or SDK object) and collect every user
+    identifier it carries. Mutates ``into`` for streaming-friendliness.
+
+    Probed locations match the consumers:
+
+    * ``fields.assignee``
+    * ``fields.reporter``
+    * ``fields.watches.watchers[*]``
+    * ``fields.comment.comments[*].author``
+    """
+
+    def _read(obj: Any, name: str) -> Any:
+        if isinstance(obj, dict):
+            return obj.get(name)
+        return getattr(obj, name, None)
+
+    def _add(user: Any) -> None:
+        if user is None:
+            return
+        for k in ("name", "key", "accountId", "emailAddress"):
+            v = _read(user, k)
+            if isinstance(v, str) and v.strip():
+                into.add(v.strip())
+                return  # Prefer the first hit (matches the resolver probe order)
+
+    fields = _read(issue, "fields")
+    if fields is None:
+        return
+    _add(_read(fields, "assignee"))
+    _add(_read(fields, "reporter"))
+    watches = _read(fields, "watches")
+    if watches is not None:
+        for w in _read(watches, "watchers") or []:
+            _add(w)
+    comment = _read(fields, "comment")
+    if comment is not None:
+        for c in _read(comment, "comments") or []:
+            _add(_read(c, "author"))

--- a/src/application/components/user_mapping_backfill_migration.py
+++ b/src/application/components/user_mapping_backfill_migration.py
@@ -43,13 +43,13 @@ clobber operator-set entries on an alternate identifier.
 
 from __future__ import annotations
 
-import contextlib
 import json
 from pathlib import Path
 from typing import Any
 
 from src.application.components.base_migration import BaseMigration, register_entity_types
-from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.exceptions import RecordNotFoundError
+from src.infrastructure.jira.jira_client import JiraClient, JiraResourceNotFoundError
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult
 
@@ -141,21 +141,32 @@ class UserMappingBackfillMigration(BaseMigration):
                     raw = json.load(f)
             except OSError, json.JSONDecodeError:
                 continue
-            issues_iter: list[Any] = []
+            # Iterate the parsed object directly — materialising
+            # ``list(raw.values())`` would copy every issue dict in
+            # memory on large per-project dumps (4082 NRS issues ≈
+            # tens of MB). Streaming over the underlying iterable
+            # halves peak memory.
             if isinstance(raw, dict):
-                issues_iter = list(raw.values())
+                for issue in raw.values():
+                    _harvest_users_from_issue(issue, out)
             elif isinstance(raw, list):
-                issues_iter = list(raw)
-            for issue in issues_iter:
-                _harvest_users_from_issue(issue, out)
+                for issue in raw:
+                    _harvest_users_from_issue(issue, out)
         return out
 
     def _candidate_keys(self, jira_user: dict[str, Any]) -> list[str]:
-        """Identifier ladder mirroring the consumer migrations' resolvers
-        (:meth:`AttachmentProvenanceMigration._resolve_user_id`).
+        """Identifier ladder mirroring the consumer migrations' resolvers.
+
+        Probe order matches :meth:`AttachmentProvenanceMigration._resolve_user_id`
+        and :meth:`WatcherMigration._resolve_user_id`:
+        ``accountId`` → ``name`` → ``key`` → ``emailAddress`` →
+        ``displayName``. Cloud instances key on ``accountId``;
+        Server/DC on ``name``. Yielding the most stable identifier
+        first means a backfilled mapping is reachable by the
+        consumers' first probe whenever possible.
         """
         out: list[str] = []
-        for k in ("name", "key", "accountId", "emailAddress"):
+        for k in ("accountId", "name", "key", "emailAddress", "displayName"):
             v = jira_user.get(k)
             if isinstance(v, str) and v.strip():
                 out.append(v.strip())
@@ -164,21 +175,28 @@ class UserMappingBackfillMigration(BaseMigration):
     def _find_op_user(self, jira_user: dict[str, Any]) -> dict[str, Any] | None:
         """Best-effort: locate an OP user matching the Jira user.
 
-        ``get_user`` and ``get_user_by_email`` raise on miss; catch and
-        continue so one missing probe doesn't cancel the next.
+        Suppresses *only* the not-found path
+        (:class:`RecordNotFoundError`) — a real client failure
+        (``QueryExecutionError``, auth, network) is allowed to
+        propagate so the operator sees the incident instead of a
+        silent ``not_found_in_op``. Per PR #205 review.
         """
         name = jira_user.get("name") or jira_user.get("key")
         if isinstance(name, str) and name:
-            with contextlib.suppress(Exception):
+            try:
                 user = self.op_client.get_user(name)
-                if user:
-                    return user
+            except RecordNotFoundError:
+                user = None
+            if user:
+                return user
         email = jira_user.get("emailAddress")
         if isinstance(email, str) and email:
-            with contextlib.suppress(Exception):
+            try:
                 user = self.op_client.get_user_by_email(email)
-                if user:
-                    return user
+            except RecordNotFoundError:
+                user = None
+            if user:
+                return user
         return None
 
     def _build_entry(self, op_user: dict[str, Any], jira_user: dict[str, Any]) -> dict[str, Any] | None:
@@ -220,6 +238,9 @@ class UserMappingBackfillMigration(BaseMigration):
         )
 
         if not all_names:
+            # Same details schema as the main return path so downstream
+            # consumers (audit, dashboards) read a uniform shape
+            # regardless of which branch the component took.
             return ComponentResult(
                 success=True,
                 updated=0,
@@ -230,7 +251,10 @@ class UserMappingBackfillMigration(BaseMigration):
                     "added": 0,
                     "already_mapped": 0,
                     "not_found_in_jira": 0,
-                    "not_found_in_op": 0,
+                    "not_found_in_op_count": 0,
+                    "not_found_in_op_sample": [],
+                    "jira_api_errors": 0,
+                    "added_sample": [],
                 },
             )
 
@@ -251,12 +275,29 @@ class UserMappingBackfillMigration(BaseMigration):
         added: list[dict[str, Any]] = []
         not_found_in_jira: list[str] = []
         not_found_in_op: list[dict[str, Any]] = []
+        # Tracks Jira API failures distinct from "user doesn't exist"
+        # (auth, network, rate limit). Misclassifying an outage as
+        # missing users would cause silent data loss on the next
+        # consumer (PR #205 review).
+        jira_api_errors = 0
 
         for name in unresolved:
             try:
                 jira_user = self.jira_client.get_user_info(name)
-            except Exception:
+            except JiraResourceNotFoundError:
+                # Genuine 404 — record under not_found_in_jira.
                 jira_user = None
+            except Exception as exc:
+                # Any other JiraError (auth, rate-limit, connection)
+                # is an outage, not a missing user. Log + count;
+                # don't pretend the user doesn't exist.
+                self.logger.warning(
+                    "Jira API error looking up %r: %s — counted under jira_api_errors",
+                    name,
+                    exc,
+                )
+                jira_api_errors += 1
+                continue
             if not isinstance(jira_user, dict):
                 not_found_in_jira.append(name)
                 continue
@@ -321,7 +362,8 @@ class UserMappingBackfillMigration(BaseMigration):
                 f"User mapping backfill: added={len(added)},"
                 f" already_mapped={len(already_mapped)},"
                 f" not_found_in_jira={len(not_found_in_jira)},"
-                f" not_found_in_op={len(not_found_in_op)}"
+                f" not_found_in_op={len(not_found_in_op)},"
+                f" jira_api_errors={jira_api_errors}"
             ),
             details={
                 "from_previous_results": len(from_results),
@@ -331,6 +373,7 @@ class UserMappingBackfillMigration(BaseMigration):
                 "not_found_in_jira": len(not_found_in_jira),
                 "not_found_in_op_count": len(not_found_in_op),
                 "not_found_in_op_sample": not_found_in_op[:20],
+                "jira_api_errors": jira_api_errors,
                 "added_sample": added[:20],
             },
         )
@@ -356,7 +399,14 @@ def _harvest_users_from_issue(issue: Any, into: set[str]) -> None:
     def _add(user: Any) -> None:
         if user is None:
             return
-        for k in ("name", "key", "accountId", "emailAddress"):
+        # ``accountId`` first to match the consumer resolvers' probe
+        # order (``AttachmentProvenanceMigration._resolve_user_id`` /
+        # ``WatcherMigration._resolve_user_id``). Cloud users have a
+        # stable ``accountId`` but variable ``displayName``; preferring
+        # the latter would harvest less-stable identifiers and miss
+        # matches when the display-name in the cache differs from the
+        # current Jira directory.
+        for k in ("accountId", "name", "key", "emailAddress", "displayName"):
             v = _read(user, k)
             if isinstance(v, str) and v.strip():
                 into.add(v.strip())

--- a/src/migration.py
+++ b/src/migration.py
@@ -50,6 +50,7 @@ from src.application.components.sprint_epic_migration import SprintEpicMigration
 from src.application.components.status_migration import StatusMigration
 from src.application.components.story_points_migration import StoryPointsMigration
 from src.application.components.time_entry_migration import TimeEntryMigration
+from src.application.components.user_mapping_backfill_migration import UserMappingBackfillMigration
 from src.application.components.user_migration import UserMigration
 from src.application.components.versions_migration import VersionsMigration
 from src.application.components.votes_migration import VotesMigration
@@ -83,6 +84,12 @@ console = Console()
 DEFAULT_COMPONENT_SEQUENCE: list[ComponentName] = [
     # === Foundation: Users & Groups ===
     "users",
+    # Retroactively pull missing Jira identities into the user mapping
+    # before any consumer tries to resolve them. Sources: previous
+    # migration_results' ``unmapped_users`` lists + cached issue
+    # author/assignee/reporter/watcher fields. Idempotent — re-runs
+    # only add what's not already mapped.
+    "user_mapping_backfill",
     "groups",
     # === Metadata: Field Definitions ===
     "custom_fields",
@@ -388,6 +395,7 @@ def _build_component_factories(
     """
     return {
         "users": lambda: UserMigration(jira_client=jira_client, op_client=op_client),
+        "user_mapping_backfill": lambda: UserMappingBackfillMigration(jira_client=jira_client, op_client=op_client),
         "groups": lambda: GroupMigration(jira_client=jira_client, op_client=op_client),
         "custom_fields": lambda: CustomFieldMigration(jira_client=jira_client, op_client=op_client),
         "companies": lambda: CompanyMigration(jira_client=jira_client, op_client=op_client),

--- a/src/type_definitions.py
+++ b/src/type_definitions.py
@@ -143,6 +143,7 @@ type BackupDir = Path
 type ComponentStatus = Literal["success", "failed", "interrupted"]
 type ComponentName = Literal[
     "users",
+    "user_mapping_backfill",
     "groups",
     "custom_fields",
     "companies",
@@ -158,6 +159,7 @@ type ComponentName = Literal[
     "versions",
     "components",
     "attachments",
+    "attachment_recovery",
     "estimates",
     "affects_versions",
     "security_levels",
@@ -170,6 +172,7 @@ type ComponentName = Literal[
     "attachment_provenance",
     "inline_refs",
     "native_tags",
+    "wp_metadata_backfill",
 ]
 
 

--- a/tests/unit/test_user_mapping_backfill_migration.py
+++ b/tests/unit/test_user_mapping_backfill_migration.py
@@ -1,0 +1,445 @@
+"""Tests for ``UserMappingBackfillMigration``.
+
+Pinned behaviours:
+
+* Names sourced from previous ``migration_results_*.json`` files
+  (multiple files merged, ``unmapped_users`` from any component).
+* Names sourced from ``jira_issues_cache.json`` and per-project
+  ``jira_issues_*.json`` dumps (assignee, reporter, watchers,
+  comment authors).
+* Probe order: ``login`` first, ``email`` fallback.
+* Idempotency: already-mapped names skipped on the cheap path AND
+  on the post-Jira-lookup second-chance dedup.
+* Failure modes: not-found-in-jira, not-found-in-op, missing OP id.
+* Persistence: ``set_mapping`` only called when something actually changed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+
+def _make_migration(
+    tmp_path: Path,
+    jira_client: Any,
+    op_client: Any,
+    user_map: dict[str, Any] | None = None,
+) -> Any:
+    """Bypass ``__init__`` to avoid the BaseMigration boot path.
+
+    Mirrors the helper used in ``test_wp_metadata_backfill_migration``.
+    Provides a fake ``mappings`` so the test can both read and write.
+    """
+    from src.application.components.user_mapping_backfill_migration import (
+        UserMappingBackfillMigration,
+    )
+
+    instance = UserMappingBackfillMigration.__new__(UserMappingBackfillMigration)
+    instance.jira_client = jira_client
+    instance.op_client = op_client
+    instance.logger = SimpleNamespace(
+        info=lambda *a, **kw: None,
+        warning=lambda *a, **kw: None,
+        debug=lambda *a, **kw: None,
+        error=lambda *a, **kw: None,
+        exception=lambda *a, **kw: None,
+        success=lambda *a, **kw: None,
+        notice=lambda *a, **kw: None,
+    )
+    instance.data_dir = tmp_path / "data"
+    instance.data_dir.mkdir(parents=True, exist_ok=True)
+
+    class FakeMappings:
+        def __init__(self, initial: dict[str, Any]) -> None:
+            self._m = {"user": dict(initial)}
+            self.set_calls: list[tuple[str, dict[str, Any]]] = []
+
+        def get_mapping(self, name: str) -> dict[str, Any]:
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, data: dict[str, Any]) -> None:
+            self._m[name] = dict(data)
+            self.set_calls.append((name, dict(data)))
+
+    instance.mappings = FakeMappings(user_map or {})
+    return instance
+
+
+def _write_results(
+    tmp_path: Path,
+    *,
+    timestamp: str = "2026-05-07_07-20-27",
+    components: dict[str, Any] | None = None,
+) -> Path:
+    """Create a ``migration_results_<timestamp>.json`` under ``tmp_path/results``."""
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    path = results_dir / f"migration_results_{timestamp}.json"
+    payload = {"components": components or {}}
+    path.write_text(json.dumps(payload))
+    return path
+
+
+# --- name-source helpers ----------------------------------------------------
+
+
+def test_names_from_previous_results_unions_all_components(tmp_path: Path) -> None:
+    """Every component's ``details.unmapped_users`` is unioned."""
+    from src.application.components.user_mapping_backfill_migration import (
+        UserMappingBackfillMigration,
+    )
+
+    _write_results(
+        tmp_path,
+        components={
+            "watchers": {"details": {"unmapped_users": ["alice", "bob", "alice"]}},
+            "users": {"details": {}},
+            "time_entries": {"details": {"unmapped_users": ["carol"]}},
+        },
+    )
+    out = UserMappingBackfillMigration._names_from_previous_results(tmp_path / "results")
+    assert out == {"alice", "bob", "carol"}
+
+
+def test_names_from_previous_results_missing_dir_is_empty(tmp_path: Path) -> None:
+    """Fresh checkout / CI: results dir doesn't exist yet → empty set."""
+    from src.application.components.user_mapping_backfill_migration import (
+        UserMappingBackfillMigration,
+    )
+
+    out = UserMappingBackfillMigration._names_from_previous_results(tmp_path / "missing")
+    assert out == set()
+
+
+def test_names_from_previous_results_corrupt_file_is_skipped(tmp_path: Path) -> None:
+    """A half-written / unparseable result file must NOT crash the run.
+
+    Pin: corrupted JSON in one results file is silently skipped
+    while other files in the directory still contribute.
+    """
+    from src.application.components.user_mapping_backfill_migration import (
+        UserMappingBackfillMigration,
+    )
+
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True)
+    (results_dir / "migration_results_corrupt.json").write_text('{"components": {"watchers')
+    _write_results(
+        tmp_path,
+        timestamp="2026-05-07_07-20-27",
+        components={"watchers": {"details": {"unmapped_users": ["alice"]}}},
+    )
+    out = UserMappingBackfillMigration._names_from_previous_results(results_dir)
+    assert out == {"alice"}
+
+
+def test_names_from_issue_cache_unified_dict_shape(tmp_path: Path) -> None:
+    """Unified ``jira_issues_cache.json`` (dict shape) yields users from
+    assignee, reporter, watchers, comment authors.
+    """
+    from src.application.components.user_mapping_backfill_migration import (
+        UserMappingBackfillMigration,
+    )
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "jira_issues_cache.json").write_text(
+        json.dumps(
+            {
+                "NRS-1": {
+                    "fields": {
+                        "assignee": {"name": "alice"},
+                        "reporter": {"name": "bob"},
+                        "watches": {"watchers": [{"name": "carol"}, {"name": "dave"}]},
+                        "comment": {"comments": [{"author": {"name": "eve"}}]},
+                    },
+                },
+            },
+        ),
+    )
+    out = UserMappingBackfillMigration._names_from_issue_cache(data_dir)
+    assert out == {"alice", "bob", "carol", "dave", "eve"}
+
+
+def test_names_from_issue_cache_per_project_dumps(tmp_path: Path) -> None:
+    """Per-project ``jira_issues_NRS.json`` (list shape) is also consumed."""
+    from src.application.components.user_mapping_backfill_migration import (
+        UserMappingBackfillMigration,
+    )
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "jira_issues_NRS.json").write_text(
+        json.dumps(
+            [
+                {
+                    "key": "NRS-1",
+                    "fields": {"assignee": {"name": "alice"}, "reporter": None},
+                },
+                {
+                    "key": "NRS-2",
+                    "fields": {"assignee": None, "reporter": {"name": "bob"}},
+                },
+            ],
+        ),
+    )
+    out = UserMappingBackfillMigration._names_from_issue_cache(data_dir)
+    assert out == {"alice", "bob"}
+
+
+def test_names_from_issue_cache_no_files_is_empty(tmp_path: Path) -> None:
+    """No cache files present → empty set, no crash."""
+    from src.application.components.user_mapping_backfill_migration import (
+        UserMappingBackfillMigration,
+    )
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True)
+    out = UserMappingBackfillMigration._names_from_issue_cache(data_dir)
+    assert out == set()
+
+
+# --- run() integration ------------------------------------------------------
+
+
+class _Jira:
+    """Configurable Jira fake.
+
+    ``responses`` maps username → returned profile dict (or ``None``
+    to simulate "user doesn't exist in Jira"). Calls outside the map
+    return ``None``.
+    """
+
+    def __init__(self, responses: dict[str, dict[str, Any] | None] | None = None) -> None:
+        self._r = responses or {}
+
+    def get_user_info(self, name: str) -> dict[str, Any] | None:
+        return self._r.get(name)
+
+
+class _Op:
+    """Configurable OP fake.
+
+    ``by_login`` and ``by_email`` map identifier → returned user dict.
+    Anything else raises ``LookupError`` to mirror the real client's
+    "not found" behaviour.
+    """
+
+    def __init__(
+        self,
+        by_login: dict[str, dict[str, Any]] | None = None,
+        by_email: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self._by_login = by_login or {}
+        self._by_email = by_email or {}
+
+    def get_user(self, identifier: int | str) -> dict[str, Any]:
+        if identifier in self._by_login:
+            return self._by_login[identifier]
+        msg = f"no user with login {identifier!r}"
+        raise LookupError(msg)
+
+    def get_user_by_email(self, email: str) -> dict[str, Any]:
+        if email in self._by_email:
+            return self._by_email[email]
+        msg = f"no user with email {email!r}"
+        raise LookupError(msg)
+
+
+def test_run_no_candidates_returns_success(tmp_path: Path) -> None:
+    """No previous results, no cache → noop run, success=True, updated=0."""
+    mig = _make_migration(tmp_path, _Jira(), _Op())
+    res = mig.run()
+    assert res.success
+    assert res.updated == 0
+    assert "No backfill candidates" in (res.message or "")
+    # No persistence — nothing changed.
+    assert mig.mappings.set_calls == []
+
+
+def test_run_resolves_via_previous_results_writes_mapping(tmp_path: Path) -> None:
+    """Watcher's ``unmapped_users`` from a previous run is the seed.
+
+    OP user found by login → ``user_map`` updated, ``set_mapping``
+    called once at the end of the run.
+    """
+    _write_results(
+        tmp_path,
+        components={"watchers": {"details": {"unmapped_users": ["alice"]}}},
+    )
+    jira = _Jira({"alice": {"name": "alice", "emailAddress": "alice@x.com"}})
+    op = _Op(by_login={"alice": {"id": 42, "login": "alice"}})
+
+    mig = _make_migration(tmp_path, jira, op)
+    res = mig.run()
+
+    assert res.success
+    assert res.updated == 1
+    user_map = mig.mappings.get_mapping("user")
+    assert user_map["alice"]["openproject_id"] == 42
+    assert user_map["alice@x.com"]["openproject_id"] == 42
+    # Persisted exactly once.
+    assert len(mig.mappings.set_calls) == 1
+
+
+def test_run_resolves_via_email_fallback(tmp_path: Path) -> None:
+    """OP login miss + email match → mapping still updated."""
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["bob"]}}})
+    jira = _Jira({"bob": {"name": "bob", "emailAddress": "bob@x.com"}})
+    op = _Op(by_email={"bob@x.com": {"id": 99, "mail": "bob@x.com"}})
+
+    mig = _make_migration(tmp_path, jira, op)
+    res = mig.run()
+
+    assert res.updated == 1
+    assert mig.mappings.get_mapping("user")["bob"]["openproject_id"] == 99
+
+
+def test_run_skips_already_mapped_cheap_path(tmp_path: Path) -> None:
+    """Name already a key in user_mapping → never queries Jira."""
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["alice"]}}})
+
+    class _BoomJira:
+        def get_user_info(self, name: str) -> dict[str, Any] | None:
+            msg = "should not be called"
+            raise AssertionError(msg)
+
+    mig = _make_migration(
+        tmp_path,
+        _BoomJira(),
+        _Op(),
+        user_map={"alice": {"openproject_id": 1}},
+    )
+    res = mig.run()
+    assert res.updated == 0
+    assert res.details["already_mapped"] == 1
+
+
+def test_run_skips_already_mapped_via_alternate_identifier(tmp_path: Path) -> None:
+    """Name not directly mapped, but Jira reports an alternate
+    identifier (email) that IS mapped → second-chance dedup catches it.
+
+    Pin: prevents adding a duplicate entry under a different key
+    when the OP user was already reachable via email or accountId.
+    """
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["alice"]}}})
+    jira = _Jira({"alice": {"name": "alice", "emailAddress": "alice@x.com"}})
+    # Jira lookup will be queried, but mapping already has alice@x.com.
+    op = _Op(by_login={"alice": {"id": 42}})
+
+    mig = _make_migration(
+        tmp_path,
+        jira,
+        op,
+        user_map={"alice@x.com": {"openproject_id": 999, "matched_by": "manual"}},
+    )
+    res = mig.run()
+
+    assert res.updated == 0
+    assert res.details["already_mapped"] == 1
+    # Manual entry preserved untouched.
+    assert mig.mappings.get_mapping("user")["alice@x.com"]["openproject_id"] == 999
+    # No write happened (nothing actually changed).
+    assert mig.mappings.set_calls == []
+
+
+def test_run_no_jira_user_records_not_found_in_jira(tmp_path: Path) -> None:
+    """Jira returns ``None`` → user goes to ``not_found_in_jira``."""
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["ghost"]}}})
+
+    mig = _make_migration(tmp_path, _Jira(), _Op())
+    res = mig.run()
+    assert res.details["not_found_in_jira"] == 1
+    # Mapping unchanged.
+    assert mig.mappings.set_calls == []
+
+
+def test_run_no_op_user_records_not_found_in_op(tmp_path: Path) -> None:
+    """Jira returns user but OP doesn't → ``not_found_in_op``."""
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["carol"]}}})
+    jira = _Jira(
+        {
+            "carol": {
+                "name": "carol",
+                "emailAddress": "carol@x.com",
+                "displayName": "Carol C.",
+                "active": False,
+            },
+        },
+    )
+    op = _Op()  # no matches
+
+    mig = _make_migration(tmp_path, jira, op)
+    res = mig.run()
+    assert res.details["not_found_in_op_count"] == 1
+    item = res.details["not_found_in_op_sample"][0]
+    assert item["jira_name"] == "carol"
+    assert item["jira_email"] == "carol@x.com"
+    assert item["jira_display"] == "Carol C."
+    assert item["active"] is False
+    # No persistence — nothing matched.
+    assert mig.mappings.set_calls == []
+
+
+def test_run_combines_results_and_cache_sources(tmp_path: Path) -> None:
+    """Both sources contribute; the union is processed.
+
+    Pin: the run uses BOTH the previous-results breadcrumb AND the
+    issue cache, deduplicated. A name showing up in both counts
+    once.
+    """
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["alice"]}}})
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "jira_issues_cache.json").write_text(
+        json.dumps(
+            {
+                "NRS-1": {
+                    "fields": {
+                        "assignee": {"name": "alice"},  # also in previous results
+                        "reporter": {"name": "bob"},  # only in cache
+                    },
+                },
+            },
+        ),
+    )
+    jira = _Jira(
+        {
+            "alice": {"name": "alice", "emailAddress": "alice@x.com"},
+            "bob": {"name": "bob", "emailAddress": "bob@x.com"},
+        },
+    )
+    op = _Op(by_login={"alice": {"id": 1}, "bob": {"id": 2}})
+
+    mig = _make_migration(tmp_path, jira, op)
+    res = mig.run()
+
+    assert res.updated == 2
+    assert res.details["from_previous_results"] == 1
+    assert res.details["from_issue_cache"] == 2  # alice + bob
+
+
+def test_run_does_not_clobber_manual_entries(tmp_path: Path) -> None:
+    """Operator's manual entry under one identifier is preserved when
+    a backfill discovers the same OP user via another identifier.
+    """
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["alice"]}}})
+    jira = _Jira({"alice": {"name": "alice", "emailAddress": "alice@x.com"}})
+    # Mapping has alice@x.com → 999 (operator-set).
+    op = _Op(by_email={"alice@x.com": {"id": 42, "mail": "alice@x.com"}})
+
+    mig = _make_migration(
+        tmp_path,
+        jira,
+        op,
+        user_map={"alice@x.com": {"openproject_id": 999, "matched_by": "manual"}},
+    )
+    mig.run()
+    user_map = mig.mappings.get_mapping("user")
+    # Manual entry preserved.
+    assert user_map["alice@x.com"]["openproject_id"] == 999
+    # Already-mapped via email → second-chance dedup; no new entry under "alice".
+    assert "alice" not in user_map

--- a/tests/unit/test_user_mapping_backfill_migration.py
+++ b/tests/unit/test_user_mapping_backfill_migration.py
@@ -239,14 +239,21 @@ class _Op:
     def get_user(self, identifier: int | str) -> dict[str, Any]:
         if identifier in self._by_login:
             return self._by_login[identifier]
+        # Mirror the real client's not-found exception so the
+        # narrowed ``except RecordNotFoundError`` in production
+        # is exercised by the tests.
+        from src.infrastructure.exceptions import RecordNotFoundError
+
         msg = f"no user with login {identifier!r}"
-        raise LookupError(msg)
+        raise RecordNotFoundError(msg)
 
     def get_user_by_email(self, email: str) -> dict[str, Any]:
         if email in self._by_email:
             return self._by_email[email]
+        from src.infrastructure.exceptions import RecordNotFoundError
+
         msg = f"no user with email {email!r}"
-        raise LookupError(msg)
+        raise RecordNotFoundError(msg)
 
 
 def test_run_no_candidates_returns_success(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Replaces the **closed** PR [#204](https://github.com/netresearch/jira-to-openproject/pull/204) (tool form) with a proper transparent component. Operator feedback: a backfill that requires a manual extra command between migration runs doesn't fit "normal run = lossless".

## What it does

Slotted right after ``users`` in ``DEFAULT_COMPONENT_SEQUENCE``. Two sources, unioned:

1. **Previous run's ``unmapped_users`` lists** — every component (watchers, time_entries) records every distinct identity it couldn't resolve in ``ComponentResult.details["unmapped_users"]``. The component walks every ``var/results/migration_results_*.json`` and unions them. **Catches users newly-seen on the previous run but absent from ``/rest/api/2/users``.**

2. **Cached Jira issues** — discover identities from ``fields.assignee``, ``reporter``, ``watches.watchers[*]``, ``comment.comments[*].author``. Same probe set PR [#196](https://github.com/netresearch/jira-to-openproject/pull/196) added to ``user_migration``, but in a dedicated component so it runs even when ``users`` is skipped by change-detection.

Per candidate: skip-if-already-mapped → query Jira → probe OP via ``get_user(login)`` → ``get_user_by_email(email)`` → write to ``user_mapping`` under every identifier.

## Idempotency / safety

* Re-runs only add what's not already mapped.
* Second-chance dedup: if Jira reports an alternate identifier (email, accountId) already in the mapping, the new entry is skipped — preserves operator manual entries.
* ``set_mapping`` only called when something actually changed (no spurious file writes).
* Names not found in OP go to ``not_found_in_op`` for operator triage; warning logged with up to 20 sample names.

## Sequence position

```
users → user_mapping_backfill → groups → custom_fields → ... → watchers / time_entries / attachment_provenance
```

## Test plan
- [x] 15 unit tests covering all sources, both probe paths, both idempotency paths, three failure modes, and persistence behaviour (``set_mapping`` only called when changed)
- [x] Existing siblings unaffected (44 tests passed across user_mapping_backfill / wp_metadata_backfill / watcher_migration / migration_class_registrations)
- [x] ``ruff check`` + ``ruff format --check`` clean
- [x] ``mypy`` clean on the new file
- [ ] CI green
- [ ] Live run on NRS with the 18 unmapped identities from the 2026-05-07 audit