### PR TITLE
feat(attachments): attachment_recovery component

### DIFF
--- a/src/application/components/attachment_recovery_migration.py
+++ b/src/application/components/attachment_recovery_migration.py
@@ -1,0 +1,428 @@
+"""Recover Jira attachments that didn't make it into OP after the
+``attachments`` component ran.
+
+Live 2026-05-07 NRS audit: ``Jira reports 4572, OP has 4441 (-131)``.
+The ``attachments`` migration is idempotent on the Rails side — a
+file with the same filename already attached to a WP is silently
+skipped — so a re-run can't fill in the missing 131 unless we tell
+it *which* issues are short. Causes of the gap fall into three
+buckets:
+
+1. **Issues skipped mid-batch** — a transient Jira / SSH / Rails
+   error during ``_load`` aborted that batch; the partial-success
+   classifier marked the run green and the skipped files were never
+   re-attempted.
+2. **Files that 404'd on Jira** — the Jira metadata still lists the
+   attachment but the file itself was deleted. No fix; we record it
+   under ``still_missing`` for operator triage.
+3. **Filename collisions** — the Rails idempotency check uses
+   ``LOWER(filename)``; two distinct Jira files with the same
+   filename collapse to one OP attachment.
+
+This component runs after ``attachments`` and ``attachment_provenance``
+in :data:`DEFAULT_COMPONENT_SEQUENCE`. It:
+
+* enumerates Jira's per-issue attachment list (filename + size + id);
+* enumerates OP's per-WP attachment list via a single batched Rails
+  query;
+* builds the per-issue diff with multiset semantics so duplicate
+  filenames match correctly;
+* delegates the actual re-attach to
+  :meth:`AttachmentsMigration._process_batch_end_to_end` for the
+  Jira keys that still have missing files — same path the original
+  attachments migration uses, so any future fix to the transfer /
+  Rails registration code applies here without duplication.
+
+Idempotent: re-runs only re-attempt files genuinely missing in OP.
+On a clean instance this component is a fast no-op.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any
+
+from src.application.components.attachments_migration import AttachmentsMigration
+from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.infrastructure.jira.jira_client import JiraClient
+from src.infrastructure.openproject.openproject_client import OpenProjectClient
+from src.models import ComponentResult
+
+# Validated against jira_project_key before being interpolated into JQL —
+# same regex guard ``audit_migrated_project`` uses to prevent quote
+# injection from a malformed project key.
+_JIRA_PROJECT_KEY_RE = re.compile(r"\A[A-Z][A-Z0-9_]+\z")
+
+# Hard cap on pagination — same defence the audit tool uses against a
+# buggy upstream returning the same page repeatedly.
+_PAGINATION_MAX_PAGES = 1000
+
+
+@register_entity_types("attachment_recovery")
+class AttachmentRecoveryMigration(BaseMigration):
+    """Phase: per-issue diagnose + recover missing OP attachments."""
+
+    def __init__(self, jira_client: JiraClient, op_client: OpenProjectClient) -> None:
+        super().__init__(jira_client=jira_client, op_client=op_client)
+
+    def _get_current_entities_for_type(self, entity_type: str) -> list[dict[str, Any]]:
+        msg = (
+            "AttachmentRecoveryMigration is a transformation-only migration"
+            " and does not support idempotent workflow. It diffs Jira ↔ OP"
+            " state at runtime."
+        )
+        raise ValueError(msg)
+
+    @staticmethod
+    def _read_attr(obj: Any, name: str) -> Any:
+        """Dual-shape access (dict / SDK object). Mirrors the helper in
+        :mod:`relation_migration` and the audit tool.
+        """
+        if isinstance(obj, dict):
+            return obj.get(name)
+        return getattr(obj, name, None)
+
+    def _wp_lookup_by_jira_key(self) -> dict[str, int]:
+        """Reuse :class:`AttachmentsMigration`'s normalised lookup so this
+        component sees exactly the WPs the migration intended to process.
+
+        Avoids a divergence-bug class where the recovery uses a
+        slightly-different WP map than the migration and ends up
+        re-attaching against a different WP than the original load.
+        """
+        # Don't call ``__init__`` — we don't need the helper's
+        # attachment dir / cache; just the method.
+        helper = AttachmentsMigration.__new__(AttachmentsMigration)
+        helper.mappings = self.mappings
+        helper._wp_lookup_cache = None
+        return helper._wp_lookup_by_jira_key()
+
+    def _project_keys_in_scope(self) -> list[str]:
+        """Project keys present in the WP mapping (after the ``inner.jira_key`` /
+        outer-fallback normalisation). Used to scope the Jira-side
+        pagination query without requiring CLI flags.
+        """
+        prefixes: set[str] = set()
+        for k in self._wp_lookup_by_jira_key():
+            head = k.split("-", 1)[0]
+            if _JIRA_PROJECT_KEY_RE.match(head):
+                prefixes.add(head)
+        return sorted(prefixes)
+
+    def _iter_jira_issues_with_attachments(
+        self,
+        jira_project_key: str,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Return ``{jira_key: [{filename, size, id, url}, …]}`` for the
+        project. Issues with zero attachments are omitted.
+
+        Uses the same paginated SDK call the migration's ``_extract_batch``
+        relies on; no separate query path so a future Jira-side change
+        affects both consistently.
+        """
+        if not _JIRA_PROJECT_KEY_RE.match(jira_project_key):
+            self.logger.warning(
+                "Recovery skipping invalid project key %r",
+                jira_project_key,
+            )
+            return {}
+
+        underlying = getattr(self.jira_client, "jira", None)
+        if underlying is None:
+            self.logger.warning(
+                "JiraClient.jira is None — Jira not initialised; recovery for project %r skipped",
+                jira_project_key,
+            )
+            return {}
+
+        out: dict[str, list[dict[str, Any]]] = {}
+        page_size = 100
+        start_at = 0
+        jql = f'project = "{jira_project_key}"'
+        for _ in range(_PAGINATION_MAX_PAGES):
+            try:
+                page = underlying.search_issues(
+                    jql,
+                    startAt=start_at,
+                    maxResults=page_size,
+                    fields="attachment",
+                    expand="",
+                )
+            except Exception:
+                self.logger.exception(
+                    "Recovery aborted enumerating Jira attachments for %r",
+                    jira_project_key,
+                )
+                return out
+            if not page:
+                break
+            for issue in page:
+                key = self._read_attr(issue, "key")
+                fields_obj = self._read_attr(issue, "fields")
+                if not key or fields_obj is None:
+                    continue
+                atts = self._read_attr(fields_obj, "attachment") or []
+                entries: list[dict[str, Any]] = []
+                for a in atts:
+                    filename = self._read_attr(a, "filename")
+                    if not isinstance(filename, str) or not filename.strip():
+                        continue
+                    entries.append(
+                        {
+                            "filename": filename,
+                            "size": self._read_attr(a, "size"),
+                            "id": self._read_attr(a, "id"),
+                            "url": self._read_attr(a, "content"),
+                        },
+                    )
+                if entries:
+                    out[str(key)] = entries
+            start_at += len(page)
+        else:
+            self.logger.warning(
+                "Recovery hit %d-page safety cap on project %r",
+                _PAGINATION_MAX_PAGES,
+                jira_project_key,
+            )
+        return out
+
+    @staticmethod
+    def _build_op_attachment_query(wp_ids: list[int]) -> str:
+        """Ruby that returns ``{wp_id: [filename, ...]}`` for the WPs.
+
+        Output contract: same start/end markers ``execute_script_with_data``
+        consumes. ``puts``-emitted JSON ends up under ``envelope['data']``.
+        """
+        return f"""
+require 'json'
+start_marker = defined?($j2o_start_marker) && $j2o_start_marker ? $j2o_start_marker : 'JSON_OUTPUT_START'
+end_marker = defined?($j2o_end_marker) && $j2o_end_marker ? $j2o_end_marker : 'JSON_OUTPUT_END'
+ids = {wp_ids!r}
+out = {{}}
+Attachment.where(container_type: 'WorkPackage', container_id: ids).
+  pluck(:container_id, :filename).each do |cid, fn|
+    out[cid] ||= []
+    out[cid] << fn
+end
+puts start_marker
+puts out.to_json
+puts end_marker
+"""
+
+    def _fetch_op_attachments_by_wp(self, wp_ids: list[int]) -> dict[int, list[str]]:
+        """Return ``{op_wp_id: [filename, …]}`` for the WPs in ``wp_ids``.
+
+        Batches large id lists to keep the Ruby script under the
+        bind-parameter limits the audit tool also defends against. The
+        Rails envelope is parsed: ``status`` → success/failure, payload
+        from ``envelope['data']`` (NOT the top-level keys — same
+        envelope-bug class PR #201 caught for ``wp_metadata_backfill``).
+        """
+        batch_size = 500
+        merged: dict[int, list[str]] = {}
+        for i in range(0, len(wp_ids), batch_size):
+            batch = wp_ids[i : i + batch_size]
+            script = self._build_op_attachment_query(batch)
+            try:
+                envelope = self.op_client.execute_script_with_data(script, [])
+            except Exception:
+                self.logger.exception(
+                    "Recovery: Rails fetch of OP attachments failed for batch starting at %d",
+                    i,
+                )
+                continue
+            if not isinstance(envelope, dict):
+                continue
+            if envelope.get("status") != "success":
+                self.logger.warning(
+                    "Recovery: Rails returned status=%r message=%r — batch skipped",
+                    envelope.get("status"),
+                    envelope.get("message"),
+                )
+                continue
+            data = envelope.get("data") or {}
+            if not isinstance(data, dict):
+                continue
+            for k, v in data.items():
+                try:
+                    wid = int(k)
+                except TypeError, ValueError:
+                    continue
+                if isinstance(v, list):
+                    merged[wid] = [str(fn) for fn in v if isinstance(fn, str)]
+        return merged
+
+    def run(self) -> ComponentResult:  # type: ignore[override]
+        self.logger.info("Starting attachment recovery (per-issue diff + targeted re-attach)")
+
+        wp_map = self._wp_lookup_by_jira_key()
+        if not wp_map:
+            # Same fail-loud pattern as siblings (#194/#197/#198/#199).
+            msg = (
+                "No usable work_package mapping — recovery cannot run."
+                " Run work_packages_skeleton first (or back-fill the"
+                " jira_key on legacy rows)."
+            )
+            self.logger.error(msg)
+            return ComponentResult(
+                success=False,
+                message=msg,
+                errors=["missing_work_package_mapping"],
+            )
+
+        project_keys = self._project_keys_in_scope()
+        if not project_keys:
+            return ComponentResult(
+                success=True,
+                updated=0,
+                message="No project keys derivable from work_package mapping; nothing to recover.",
+                details={"projects_examined": 0},
+            )
+
+        # Gather Jira side first — paginated per project.
+        jira_atts: dict[str, list[dict[str, Any]]] = {}
+        for proj_key in project_keys:
+            self.logger.info("Recovery: enumerating Jira attachments for %r", proj_key)
+            jira_atts.update(self._iter_jira_issues_with_attachments(proj_key))
+
+        if not jira_atts:
+            return ComponentResult(
+                success=True,
+                updated=0,
+                message="No Jira issues with attachments in scope; nothing to recover.",
+                details={"projects_examined": len(project_keys)},
+            )
+
+        # Resolve only the WPs we need to query.
+        relevant_wp_ids = sorted({wp_map[k] for k in jira_atts if k in wp_map})
+        op_by_wp = self._fetch_op_attachments_by_wp(relevant_wp_ids)
+
+        # Per-issue diff (multiset semantics).
+        per_issue_missing: dict[str, list[str]] = {}
+        per_issue_extra: dict[str, list[str]] = {}
+        clean = 0
+        wp_unmapped = 0
+        missing_total = 0
+        extra_total = 0
+
+        for jira_key, jira_list in jira_atts.items():
+            wp_id = wp_map.get(jira_key)
+            jira_filenames = [a["filename"] for a in jira_list]
+            if wp_id is None:
+                wp_unmapped += 1
+                per_issue_missing[jira_key] = jira_filenames
+                missing_total += len(jira_filenames)
+                continue
+            op_filenames = op_by_wp.get(wp_id, [])
+            jira_counter = Counter(jira_filenames)
+            op_counter = Counter(op_filenames)
+            missing = sorted((jira_counter - op_counter).elements())
+            extra = sorted((op_counter - jira_counter).elements())
+            if missing:
+                per_issue_missing[jira_key] = missing
+                missing_total += len(missing)
+            if extra:
+                per_issue_extra[jira_key] = extra
+                extra_total += len(extra)
+            if not missing and not extra:
+                clean += 1
+
+        recovery_keys = sorted(per_issue_missing)
+        if not recovery_keys:
+            self.logger.info(
+                "Recovery: no missing attachments detected (%d issues clean, %d extras)",
+                clean,
+                extra_total,
+            )
+            # Use the same key names as the recovery branch so callers
+            # can read ``details`` uniformly regardless of which path
+            # the component took.
+            return ComponentResult(
+                success=True,
+                updated=0,
+                message=f"All examined attachments present in OP. clean={clean}, extra={extra_total}",
+                details={
+                    "projects_examined": len(project_keys),
+                    "issues_examined": len(jira_atts),
+                    "clean": clean,
+                    "wp_unmapped": wp_unmapped,
+                    "missing_total_before": 0,
+                    "still_missing_total": 0,
+                    "extra_total": extra_total,
+                    "recovered": 0,
+                },
+            )
+
+        self.logger.info(
+            "Recovery: %d issues with missing attachments (%d files); delegating to attachments_migration",
+            len(recovery_keys),
+            missing_total,
+        )
+
+        # Delegate to the same path the original attachments migration
+        # uses. ``_process_batch_end_to_end`` is idempotent on the
+        # Rails side — files already attached are skipped, so passing
+        # the whole jira_keys list (not just the missing filenames)
+        # is safe AND simpler than re-implementing per-filename
+        # filtering. Rails-side dedup keeps the cost proportional to
+        # the actually-missing count.
+        att_migration = AttachmentsMigration(
+            jira_client=self.jira_client,
+            op_client=self.op_client,
+        )
+        recovered = 0
+        failed = 0
+        batch_size = 50
+        for i in range(0, len(recovery_keys), batch_size):
+            batch = recovery_keys[i : i + batch_size]
+            try:
+                up, fl, _mapping = att_migration._process_batch_end_to_end(batch)
+            except Exception:
+                self.logger.exception(
+                    "Recovery batch %d failed (%d keys)",
+                    i // batch_size,
+                    len(batch),
+                )
+                failed += len(batch)
+                continue
+            recovered += up
+            failed += fl
+
+        # After the recovery pass, recompute the missing tail so we
+        # report what's *still* lost (genuine 404s / collisions /
+        # transfer errors) — not the original count.
+        op_by_wp_after = self._fetch_op_attachments_by_wp(relevant_wp_ids)
+        still_missing_total = 0
+        for jira_key in recovery_keys:
+            wp_id = wp_map.get(jira_key)
+            if wp_id is None:
+                continue
+            jira_counter = Counter(a["filename"] for a in jira_atts[jira_key])
+            op_counter = Counter(op_by_wp_after.get(wp_id, []))
+            still_missing_total += sum((jira_counter - op_counter).values())
+
+        msg = (
+            f"Recovery: recovered={recovered}, still_missing={still_missing_total},"
+            f" failed_batches={failed}, clean={clean}, extra={extra_total},"
+            f" wp_unmapped={wp_unmapped}"
+        )
+        self.logger.info(msg)
+        return ComponentResult(
+            success=still_missing_total == 0,
+            updated=recovered,
+            failed=failed,
+            message=msg,
+            details={
+                "projects_examined": len(project_keys),
+                "issues_examined": len(jira_atts),
+                "clean": clean,
+                "wp_unmapped": wp_unmapped,
+                "missing_total_before": missing_total,
+                "still_missing_total": still_missing_total,
+                "extra_total": extra_total,
+                "recovered": recovered,
+                "still_missing_sample": dict(list(per_issue_missing.items())[:20]),
+                "extra_sample": dict(list(per_issue_extra.items())[:20]),
+            },
+        )

--- a/src/application/components/attachment_recovery_migration.py
+++ b/src/application/components/attachment_recovery_migration.py
@@ -39,11 +39,15 @@ On a clean instance this component is a fast no-op.
 
 from __future__ import annotations
 
+import json
 import re
 from collections import Counter
 from typing import Any
 
-from src.application.components.attachments_migration import AttachmentsMigration
+from src.application.components.attachments_migration import (
+    AttachmentsMigration,
+    compute_wp_lookup_by_jira_key,
+)
 from src.application.components.base_migration import BaseMigration, register_entity_types
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
@@ -83,28 +87,13 @@ class AttachmentRecoveryMigration(BaseMigration):
             return obj.get(name)
         return getattr(obj, name, None)
 
-    def _wp_lookup_by_jira_key(self) -> dict[str, int]:
-        """Reuse :class:`AttachmentsMigration`'s normalised lookup so this
-        component sees exactly the WPs the migration intended to process.
-
-        Avoids a divergence-bug class where the recovery uses a
-        slightly-different WP map than the migration and ends up
-        re-attaching against a different WP than the original load.
-        """
-        # Don't call ``__init__`` — we don't need the helper's
-        # attachment dir / cache; just the method.
-        helper = AttachmentsMigration.__new__(AttachmentsMigration)
-        helper.mappings = self.mappings
-        helper._wp_lookup_cache = None
-        return helper._wp_lookup_by_jira_key()
-
-    def _project_keys_in_scope(self) -> list[str]:
+    def _project_keys_in_scope(self, wp_map: dict[str, int]) -> list[str]:
         """Project keys present in the WP mapping (after the ``inner.jira_key`` /
         outer-fallback normalisation). Used to scope the Jira-side
         pagination query without requiring CLI flags.
         """
         prefixes: set[str] = set()
-        for k in self._wp_lookup_by_jira_key():
+        for k in wp_map:
             head = k.split("-", 1)[0]
             if _JIRA_PROJECT_KEY_RE.match(head):
                 prefixes.add(head)
@@ -256,7 +245,13 @@ puts end_marker
     def run(self) -> ComponentResult:  # type: ignore[override]
         self.logger.info("Starting attachment recovery (per-issue diff + targeted re-attach)")
 
-        wp_map = self._wp_lookup_by_jira_key()
+        # Use the shared ``compute_wp_lookup_by_jira_key`` helper so we
+        # see exactly the same normalisation the original migration
+        # used (no divergence-bug class) without paying the
+        # ``BaseMigration.__init__`` cost up-front. We only construct
+        # an :class:`AttachmentsMigration` once we actually have keys
+        # to delegate — keeps the empty/no-recovery paths fast.
+        wp_map = compute_wp_lookup_by_jira_key(self.mappings)
         if not wp_map:
             # Same fail-loud pattern as siblings (#194/#197/#198/#199).
             msg = (
@@ -271,7 +266,7 @@ puts end_marker
                 errors=["missing_work_package_mapping"],
             )
 
-        project_keys = self._project_keys_in_scope()
+        project_keys = self._project_keys_in_scope(wp_map)
         if not project_keys:
             return ComponentResult(
                 success=True,
@@ -280,40 +275,70 @@ puts end_marker
                 details={"projects_examined": 0},
             )
 
-        # Gather Jira side first — paginated per project.
-        jira_atts: dict[str, list[dict[str, Any]]] = {}
+        # Gather Jira side first — paginated per project. Scope to
+        # the keys present in the WP mapping immediately so unmapped
+        # issues never pollute the recovery accounting (PR #206
+        # review: previously they inflated ``missing_total_before``,
+        # got passed to delegation as wasted API calls, and were
+        # silently skipped from ``still_missing_total`` so a run
+        # could report ``success=True`` with ``wp_unmapped > 0``
+        # masking real loss).
+        jira_atts_all: dict[str, list[dict[str, Any]]] = {}
         for proj_key in project_keys:
             self.logger.info("Recovery: enumerating Jira attachments for %r", proj_key)
-            jira_atts.update(self._iter_jira_issues_with_attachments(proj_key))
+            jira_atts_all.update(self._iter_jira_issues_with_attachments(proj_key))
+
+        # Split into in-scope (mapped) and unmapped buckets.
+        jira_atts: dict[str, list[dict[str, Any]]] = {}
+        unmapped_jira_keys: list[str] = []
+        for k, v in jira_atts_all.items():
+            if k in wp_map:
+                jira_atts[k] = v
+            else:
+                unmapped_jira_keys.append(k)
+
+        if unmapped_jira_keys:
+            # These issues exist in Jira but their WPs aren't in our
+            # mapping — surface as a real warning so an operator
+            # knows attachments on those WPs (if any) cannot be
+            # recovered by this run.
+            self.logger.warning(
+                "Recovery: %d Jira issues have attachments but no WP mapping entry"
+                " (sample: %s) — out of scope for this component;"
+                " run work_packages_skeleton on those projects first.",
+                len(unmapped_jira_keys),
+                unmapped_jira_keys[:10],
+            )
 
         if not jira_atts:
             return ComponentResult(
+                # ``success`` reflects the *in-scope* state. Out-of-scope
+                # unmapped issues are surfaced via the warning above
+                # and the ``wp_unmapped`` count below; they do not
+                # pretend a clean run.
                 success=True,
                 updated=0,
-                message="No Jira issues with attachments in scope; nothing to recover.",
-                details={"projects_examined": len(project_keys)},
+                message=(f"No in-scope Jira issues with attachments to recover. wp_unmapped={len(unmapped_jira_keys)}"),
+                details={
+                    "projects_examined": len(project_keys),
+                    "wp_unmapped": len(unmapped_jira_keys),
+                },
             )
 
         # Resolve only the WPs we need to query.
-        relevant_wp_ids = sorted({wp_map[k] for k in jira_atts if k in wp_map})
+        relevant_wp_ids = sorted({wp_map[k] for k in jira_atts})
         op_by_wp = self._fetch_op_attachments_by_wp(relevant_wp_ids)
 
         # Per-issue diff (multiset semantics).
         per_issue_missing: dict[str, list[str]] = {}
         per_issue_extra: dict[str, list[str]] = {}
         clean = 0
-        wp_unmapped = 0
         missing_total = 0
         extra_total = 0
 
         for jira_key, jira_list in jira_atts.items():
-            wp_id = wp_map.get(jira_key)
+            wp_id = wp_map[jira_key]  # guaranteed by the in-scope filter above
             jira_filenames = [a["filename"] for a in jira_list]
-            if wp_id is None:
-                wp_unmapped += 1
-                per_issue_missing[jira_key] = jira_filenames
-                missing_total += len(jira_filenames)
-                continue
             op_filenames = op_by_wp.get(wp_id, [])
             jira_counter = Counter(jira_filenames)
             op_counter = Counter(op_filenames)
@@ -331,9 +356,10 @@ puts end_marker
         recovery_keys = sorted(per_issue_missing)
         if not recovery_keys:
             self.logger.info(
-                "Recovery: no missing attachments detected (%d issues clean, %d extras)",
+                "Recovery: no missing attachments detected (%d issues clean, %d extras, %d unmapped)",
                 clean,
                 extra_total,
+                len(unmapped_jira_keys),
             )
             # Use the same key names as the recovery branch so callers
             # can read ``details`` uniformly regardless of which path
@@ -341,12 +367,15 @@ puts end_marker
             return ComponentResult(
                 success=True,
                 updated=0,
-                message=f"All examined attachments present in OP. clean={clean}, extra={extra_total}",
+                message=(
+                    f"All in-scope attachments present in OP. clean={clean},"
+                    f" extra={extra_total}, wp_unmapped={len(unmapped_jira_keys)}"
+                ),
                 details={
                     "projects_examined": len(project_keys),
                     "issues_examined": len(jira_atts),
                     "clean": clean,
-                    "wp_unmapped": wp_unmapped,
+                    "wp_unmapped": len(unmapped_jira_keys),
                     "missing_total_before": 0,
                     "still_missing_total": 0,
                     "extra_total": extra_total,
@@ -373,11 +402,12 @@ puts end_marker
         )
         recovered = 0
         failed = 0
+        merged_mapping: dict[str, dict[str, int]] = {}
         batch_size = 50
         for i in range(0, len(recovery_keys), batch_size):
             batch = recovery_keys[i : i + batch_size]
             try:
-                up, fl, _mapping = att_migration._process_batch_end_to_end(batch)
+                up, fl, mapping = att_migration._process_batch_end_to_end(batch)
             except Exception:
                 self.logger.exception(
                     "Recovery batch %d failed (%d keys)",
@@ -388,6 +418,27 @@ puts end_marker
                 continue
             recovered += up
             failed += fl
+            # Accumulate {jira_key: {filename: attachment_id}} for
+            # downstream consumers (work_packages_content uses this
+            # mapping to resolve ``!image.png!`` references to OP API
+            # URLs). Per PR #206 review.
+            if isinstance(mapping, dict):
+                for jk, file_map in mapping.items():
+                    if not isinstance(file_map, dict):
+                        continue
+                    bucket = merged_mapping.setdefault(str(jk), {})
+                    for fn, att_id in file_map.items():
+                        try:
+                            bucket[str(fn)] = int(att_id)
+                        except TypeError, ValueError:
+                            continue
+
+        # Persist the recovered attachment mapping. Merge with any
+        # existing ``attachment_mapping.json`` so the original run's
+        # entries aren't lost. Atomic write (tmp + rename) — same
+        # defence PR #197 added for the WP mapping.
+        if merged_mapping:
+            self._merge_attachment_mapping(merged_mapping)
 
         # After the recovery pass, recompute the missing tail so we
         # report what's *still* lost (genuine 404s / collisions /
@@ -395,9 +446,7 @@ puts end_marker
         op_by_wp_after = self._fetch_op_attachments_by_wp(relevant_wp_ids)
         still_missing_total = 0
         for jira_key in recovery_keys:
-            wp_id = wp_map.get(jira_key)
-            if wp_id is None:
-                continue
+            wp_id = wp_map[jira_key]  # guaranteed by in-scope filter
             jira_counter = Counter(a["filename"] for a in jira_atts[jira_key])
             op_counter = Counter(op_by_wp_after.get(wp_id, []))
             still_missing_total += sum((jira_counter - op_counter).values())
@@ -405,7 +454,7 @@ puts end_marker
         msg = (
             f"Recovery: recovered={recovered}, still_missing={still_missing_total},"
             f" failed_batches={failed}, clean={clean}, extra={extra_total},"
-            f" wp_unmapped={wp_unmapped}"
+            f" wp_unmapped={len(unmapped_jira_keys)}"
         )
         self.logger.info(msg)
         return ComponentResult(
@@ -417,7 +466,7 @@ puts end_marker
                 "projects_examined": len(project_keys),
                 "issues_examined": len(jira_atts),
                 "clean": clean,
-                "wp_unmapped": wp_unmapped,
+                "wp_unmapped": len(unmapped_jira_keys),
                 "missing_total_before": missing_total,
                 "still_missing_total": still_missing_total,
                 "extra_total": extra_total,
@@ -425,4 +474,49 @@ puts end_marker
                 "still_missing_sample": dict(list(per_issue_missing.items())[:20]),
                 "extra_sample": dict(list(per_issue_extra.items())[:20]),
             },
+        )
+
+    def _merge_attachment_mapping(self, new_mapping: dict[str, dict[str, int]]) -> None:
+        """Merge ``new_mapping`` into ``attachment_mapping.json`` atomically.
+
+        Each entry has shape ``{jira_key: {filename: attachment_id}}``.
+        Existing entries are preserved; per-key file maps are merged
+        with the new run's entries taking precedence on duplicate
+        filenames (e.g. when an existing OP attachment was re-attached
+        with a fresh id). Atomic write (tmp + rename) keeps the file
+        consistent if the process crashes mid-dump — same defence
+        PR #197 added for ``work_package_mapping``.
+        """
+        path = self.data_dir / "attachment_mapping.json"
+        existing: dict[str, dict[str, int]] = {}
+        if path.exists():
+            try:
+                with path.open(encoding="utf-8") as f:
+                    raw = json.load(f)
+                if isinstance(raw, dict):
+                    for k, v in raw.items():
+                        if isinstance(v, dict):
+                            existing[str(k)] = {
+                                str(fn): int(aid)
+                                for fn, aid in v.items()
+                                if isinstance(aid, (int, str)) and str(aid).lstrip("-").isdigit()
+                            }
+            except (OSError, json.JSONDecodeError) as exc:
+                self.logger.warning(
+                    "Existing attachment_mapping.json unreadable (%s) — recovery"
+                    " writes a fresh file from this run's results only.",
+                    exc,
+                )
+                existing = {}
+        for jk, file_map in new_mapping.items():
+            existing.setdefault(jk, {}).update(file_map)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(existing, f, indent=2, sort_keys=True)
+        tmp.replace(path)
+        self.logger.info(
+            "Recovery: persisted attachment_mapping for %d Jira keys (total %d entries)",
+            len(new_mapping),
+            sum(len(v) for v in existing.values()),
         )

--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -42,6 +42,43 @@ from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult, WorkPackageMappingEntry
 
 
+def compute_wp_lookup_by_jira_key(mappings: Any) -> dict[str, int]:
+    """Build a ``jira_key → openproject_id`` lookup from a mappings facade.
+
+    Walks the ``work_package`` mapping once and normalises each row
+    through :meth:`WorkPackageMappingEntry.from_legacy`. Production
+    ``wp_map`` is keyed by ``str(jira_id)`` outer with the
+    human-readable ``jira_key`` stored inside; legacy/test fixtures
+    sometimes key directly by ``jira_key``. Resolution rules:
+
+    * dict shape with inner ``jira_key`` → use the inner key.
+    * dict shape without inner ``jira_key`` → fall back to outer
+      (covers test fixtures keyed by ``jira_key``).
+    * bare ``int`` shape → SKIP. Legacy bare-int rows do not carry
+      a recoverable ``jira_key``; treating the numeric outer key as
+      a Jira issue key would produce invalid downstream queries
+      like ``key in (10001, …)``.
+
+    Lifted out of :class:`AttachmentsMigration` so
+    :class:`AttachmentRecoveryMigration` can call it without
+    constructing a full migration instance (which carries the heavy
+    ``BaseMigration.__init__`` chain).
+    """
+    wp_map = mappings.get_mapping("work_package") or {}
+    lookup: dict[str, int] = {}
+    for outer_key, raw_entry in wp_map.items():
+        if not isinstance(raw_entry, dict):
+            continue
+        inner_jira_key = raw_entry.get("jira_key")
+        jira_key = str(inner_jira_key or outer_key)
+        try:
+            entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
+        except ValueError:
+            continue
+        lookup[jira_key] = int(entry.openproject_id)
+    return lookup
+
+
 @register_entity_types("attachments")
 class AttachmentsMigration(BaseMigration):  # noqa: D101
     # Cache for the wp_map → jira_key lookup. Built lazily on first use
@@ -63,38 +100,16 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
     def _wp_lookup_by_jira_key(self) -> dict[str, int]:
         """Return a cached ``jira_key → openproject_id`` lookup.
 
-        Walks the ``work_package`` mapping once and normalises each row
-        through :meth:`WorkPackageMappingEntry.from_legacy`. Production
-        ``wp_map`` is keyed by ``str(jira_id)`` outer with the
-        human-readable ``jira_key`` stored inside; legacy/test fixtures
-        sometimes key directly by ``jira_key``. Resolution rules:
-
-        * dict shape with inner ``jira_key`` → use the inner key.
-        * dict shape without inner ``jira_key`` → fall back to outer
-          (covers test fixtures keyed by ``jira_key``).
-        * bare ``int`` shape → SKIP. Legacy bare-int rows do not carry
-          a recoverable ``jira_key``; treating the numeric outer key
-          as a Jira issue key would produce invalid downstream queries
-          like ``key in (10001, …)``.
-
-        Callers receive a copy so accidental mutation cannot poison
-        the cache.
+        Thin wrapper over the module-level
+        :func:`compute_wp_lookup_by_jira_key` helper so the
+        normalisation logic is reachable by sibling components
+        (notably :class:`AttachmentRecoveryMigration`) without
+        having to construct a full :class:`AttachmentsMigration`
+        (which carries the heavy ``BaseMigration.__init__`` chain).
+        Per PR #206 review.
         """
         if self._wp_lookup_cache is None:
-            wp_map = self.mappings.get_mapping("work_package") or {}
-            lookup: dict[str, int] = {}
-            for outer_key, raw_entry in wp_map.items():
-                if not isinstance(raw_entry, dict):
-                    # Bare-int legacy rows have no recoverable Jira key.
-                    continue
-                inner_jira_key = raw_entry.get("jira_key")
-                jira_key = str(inner_jira_key or outer_key)
-                try:
-                    entry = WorkPackageMappingEntry.from_legacy(jira_key, raw_entry)
-                except ValueError:
-                    continue
-                lookup[jira_key] = int(entry.openproject_id)
-            self._wp_lookup_cache = lookup
+            self._wp_lookup_cache = compute_wp_lookup_by_jira_key(self.mappings)
         return dict(self._wp_lookup_cache)
 
     def _get_current_entities_for_type(self, entity_type: str) -> list[dict[str, Any]]:

--- a/src/migration.py
+++ b/src/migration.py
@@ -24,6 +24,7 @@ from src.application.components.admin_scheme_migration import AdminSchemeMigrati
 from src.application.components.affects_versions_migration import AffectsVersionsMigration
 from src.application.components.agile_board_migration import AgileBoardMigration
 from src.application.components.attachment_provenance_migration import AttachmentProvenanceMigration
+from src.application.components.attachment_recovery_migration import AttachmentRecoveryMigration
 from src.application.components.attachments_migration import AttachmentsMigration
 from src.application.components.base_migration import BaseMigration
 from src.application.components.category_defaults_migration import CategoryDefaultsMigration
@@ -112,6 +113,12 @@ DEFAULT_COMPONENT_SEQUENCE: list[ComponentName] = [
     # === Phase 2: Attachments (creates mapping for URL conversion) ===
     "attachments",
     "attachment_provenance",
+    # Re-attempt attachments missing in OP after the main attachments
+    # run (transient mid-batch errors leave the partial-success
+    # classifier green; the original migration is idempotent
+    # Rails-side, so re-running it for the affected jira_keys fills
+    # the gap). Idempotent: no-op when OP already has every file.
+    "attachment_recovery",
     # === Phase 3: Work Package Content (with resolved attachment URLs) ===
     "work_packages_content",
     # Backfill assignee + provenance CFs on existing WPs (closes Bug A
@@ -426,6 +433,7 @@ def _build_component_factories(
         "remote_links": lambda: RemoteLinksMigration(jira_client=jira_client, op_client=op_client),
         "category_defaults": lambda: CategoryDefaultsMigration(jira_client=jira_client, op_client=op_client),
         "attachment_provenance": lambda: AttachmentProvenanceMigration(jira_client=jira_client, op_client=op_client),
+        "attachment_recovery": lambda: AttachmentRecoveryMigration(jira_client=jira_client, op_client=op_client),
         "wp_metadata_backfill": lambda: WpMetadataBackfillMigration(jira_client=jira_client, op_client=op_client),
         "inline_refs": lambda: InlineRefsMigration(jira_client=jira_client, op_client=op_client),
         "native_tags": lambda: NativeTagsMigration(jira_client=jira_client, op_client=op_client),

--- a/tests/unit/test_attachment_recovery_migration.py
+++ b/tests/unit/test_attachment_recovery_migration.py
@@ -27,8 +27,11 @@ def _make_migration(
     jira_client: Any,
     op_client: Any,
     wp_map: dict[str, Any] | None = None,
+    data_dir: Any = None,
 ) -> Any:
     """Bypass ``__init__`` to avoid the BaseMigration boot path."""
+    from pathlib import Path
+
     from src.application.components.attachment_recovery_migration import (
         AttachmentRecoveryMigration,
     )
@@ -45,6 +48,10 @@ def _make_migration(
         success=lambda *a, **kw: None,
         notice=lambda *a, **kw: None,
     )
+    # ``data_dir`` is needed by ``_merge_attachment_mapping``. Default
+    # to ``Path("/tmp")`` so tests that don't exercise persistence
+    # don't need to pass one.
+    instance.data_dir = Path(data_dir) if data_dir is not None else Path("/tmp")
 
     class FakeMappings:
         def __init__(self, m: dict[str, Any]) -> None:
@@ -77,15 +84,16 @@ def test_run_empty_wp_map_fails_loud() -> None:
     assert "missing_work_package_mapping" in (result.errors or [])
 
 
-def test_run_no_project_keys_in_scope_returns_success() -> None:
+def test_run_legacy_int_only_mapping_fails_loud() -> None:
     """WP map contains only legacy bare-int rows (no recoverable
-    project key) → no-op success, distinct from fail-loud.
+    Jira key) → fail loud with the same error tag as the empty-map
+    case. ``_wp_lookup_by_jira_key`` filters bare-int rows out, so
+    the lookup returns an empty dict — same fail-loud guard fires.
+    Pin: corrected docstring/name to match the asserted behaviour
+    (PR #206 review).
     """
-    # Bare ints can't yield a project key — the wp_lookup helper
-    # filters them out, so the map ends up empty for our purposes.
     mig = _make_migration(jira_client=None, op_client=None, wp_map={"PROJ-1": 42})
     result = mig.run()
-    # Bare int rows are stripped; mapping is effectively empty → fail loud.
     assert result.success is False
     assert "missing_work_package_mapping" in (result.errors or [])
 
@@ -383,5 +391,9 @@ def test_op_envelope_error_status_is_logged_and_skipped(monkeypatch: pytest.Monk
     result = mig.run()
     # Run completes (no crash).
     assert isinstance(result.message, str)
-    # OP fetch was attempted at least twice (initial + post-recover).
-    assert op.calls >= 1
+    # OP fetch was attempted twice — initial (sees nothing because
+    # the error envelope drops the data payload) AND the
+    # post-recover recompute (also sees an error envelope, so
+    # still_missing remains positive). Pin the exact contract per
+    # PR #206 review.
+    assert op.calls >= 2

--- a/tests/unit/test_attachment_recovery_migration.py
+++ b/tests/unit/test_attachment_recovery_migration.py
@@ -1,0 +1,387 @@
+"""Tests for ``AttachmentRecoveryMigration``.
+
+Pinned behaviours:
+
+* Empty WP map → fail loud (siblings #194/#197/#198/#199 pattern).
+* No project keys derivable → success, message reflects no-op.
+* Clean state (every Jira file present in OP) → success, recovered=0.
+* Missing files → delegates to
+  ``AttachmentsMigration._process_batch_end_to_end`` for the affected
+  jira_keys.
+* Multiset semantics for duplicate filenames.
+* Rails envelope parsed correctly (``status`` + ``data`` only — same
+  envelope-bug class PR #201 caught for ``wp_metadata_backfill``).
+* Recompute-after-recover: ``still_missing_total`` reflects post-recover
+  state, not the pre-recover count.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _make_migration(
+    jira_client: Any,
+    op_client: Any,
+    wp_map: dict[str, Any] | None = None,
+) -> Any:
+    """Bypass ``__init__`` to avoid the BaseMigration boot path."""
+    from src.application.components.attachment_recovery_migration import (
+        AttachmentRecoveryMigration,
+    )
+
+    instance = AttachmentRecoveryMigration.__new__(AttachmentRecoveryMigration)
+    instance.jira_client = jira_client
+    instance.op_client = op_client
+    instance.logger = SimpleNamespace(
+        info=lambda *a, **kw: None,
+        warning=lambda *a, **kw: None,
+        debug=lambda *a, **kw: None,
+        error=lambda *a, **kw: None,
+        exception=lambda *a, **kw: None,
+        success=lambda *a, **kw: None,
+        notice=lambda *a, **kw: None,
+    )
+
+    class FakeMappings:
+        def __init__(self, m: dict[str, Any]) -> None:
+            self._m = {"work_package": m}
+
+        def get_mapping(self, name: str) -> dict[str, Any]:
+            return self._m.get(name, {})
+
+    instance.mappings = FakeMappings(wp_map or {})
+    return instance
+
+
+def _envelope(status: str, data: Any) -> dict[str, Any]:
+    """Build a Rails ``execute_script_with_data`` response envelope."""
+    return {"status": status, "message": "ok", "data": data, "output": "<dummy>"}
+
+
+# --- fail-loud + scope guards -----------------------------------------------
+
+
+def test_run_empty_wp_map_fails_loud() -> None:
+    """No usable WP rows → success=False with stable error tag.
+
+    Mirrors the fail-loud pattern in attachments / attachment_provenance /
+    watchers / wp_skeleton (PRs #194/#197/#198/#199).
+    """
+    mig = _make_migration(jira_client=None, op_client=None, wp_map={})
+    result = mig.run()
+    assert result.success is False
+    assert "missing_work_package_mapping" in (result.errors or [])
+
+
+def test_run_no_project_keys_in_scope_returns_success() -> None:
+    """WP map contains only legacy bare-int rows (no recoverable
+    project key) → no-op success, distinct from fail-loud.
+    """
+    # Bare ints can't yield a project key — the wp_lookup helper
+    # filters them out, so the map ends up empty for our purposes.
+    mig = _make_migration(jira_client=None, op_client=None, wp_map={"PROJ-1": 42})
+    result = mig.run()
+    # Bare int rows are stripped; mapping is effectively empty → fail loud.
+    assert result.success is False
+    assert "missing_work_package_mapping" in (result.errors or [])
+
+
+# --- diff + delegation -------------------------------------------------------
+
+
+class _FakeJiraIssue:
+    def __init__(self, key: str, attachments: list[dict[str, Any]]) -> None:
+        self.key = key
+        self.fields = SimpleNamespace(
+            attachment=[
+                SimpleNamespace(
+                    filename=a["filename"],
+                    size=a.get("size"),
+                    id=a.get("id"),
+                    content=a.get("url"),
+                )
+                for a in attachments
+            ],
+        )
+
+
+class _FakeUnderlying:
+    def __init__(self, pages: list[list[Any]]) -> None:
+        self._pages = list(pages)
+
+    def search_issues(self, *_a, **_kw):
+        return self._pages.pop(0) if self._pages else []
+
+
+class _FakeJira:
+    def __init__(self, pages: list[list[Any]]) -> None:
+        self.jira = _FakeUnderlying(pages)
+
+
+class _RecordingOp:
+    """OP fake that records script calls + returns canned envelopes.
+
+    ``op_calls[i]`` is the i-th attachment-fetch envelope to return.
+    Each call advances a cursor; subsequent calls (e.g. the
+    post-recovery recompute) consume the next envelope.
+    """
+
+    def __init__(self, attachment_fetches: list[dict[int, list[str]]] | None = None) -> None:
+        self.script_calls: list[tuple[str, list[Any]]] = []
+        self._fetches = list(attachment_fetches or [])
+
+    def execute_script_with_data(self, script: str, data: list[Any]) -> dict[str, Any]:
+        self.script_calls.append((script, list(data)))
+        if self._fetches:
+            payload = self._fetches.pop(0)
+            return _envelope("success", {str(k): v for k, v in payload.items()})
+        return _envelope("success", {})
+
+
+def test_run_clean_state_no_recovery_no_op_call_to_attachments_migration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every Jira file already in OP → ``recovered=0``, no batch
+    delegation. Pin: idempotent on a healthy instance.
+    """
+    pages = [
+        [
+            _FakeJiraIssue("NRS-1", [{"filename": "ok.txt", "id": 1, "url": "u"}]),
+        ],
+    ]
+    jira = _FakeJira(pages)
+    # OP already has the file.
+    op = _RecordingOp(attachment_fetches=[{501: ["ok.txt"]}])
+
+    mig = _make_migration(
+        jira_client=jira,
+        op_client=op,
+        wp_map={"10001": {"jira_key": "NRS-1", "openproject_id": 501}},
+    )
+
+    # Spy on AttachmentsMigration to ensure we don't delegate.
+    delegated: list[list[str]] = []
+
+    def _spy_init(self, jira_client=None, op_client=None):
+        return None
+
+    def _spy_process(self, keys):
+        delegated.append(list(keys))
+        return (0, 0, {})
+
+    from src.application.components import attachments_migration as am_mod
+
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "__init__", _spy_init)
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "_process_batch_end_to_end", _spy_process)
+
+    result = mig.run()
+
+    assert result.success
+    assert result.updated == 0
+    assert delegated == []  # no delegation on a clean state
+    assert result.details["clean"] == 1
+    assert result.details["still_missing_total"] == 0
+
+
+def test_run_with_missing_files_delegates_to_attachments_migration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Jira has ``a.txt`` and ``b.txt``; OP only has ``a.txt`` →
+    delegates the affected jira_key to ``_process_batch_end_to_end``.
+
+    The post-recover recompute returns OP with both files (simulating
+    a successful recover) → ``still_missing_total = 0``.
+    """
+    pages = [
+        [
+            _FakeJiraIssue(
+                "NRS-1",
+                [{"filename": "a.txt", "id": 1, "url": "u1"}, {"filename": "b.txt", "id": 2, "url": "u2"}],
+            ),
+        ],
+    ]
+    jira = _FakeJira(pages)
+    op = _RecordingOp(
+        attachment_fetches=[
+            {501: ["a.txt"]},  # initial state — b.txt missing
+            {501: ["a.txt", "b.txt"]},  # after recover — both present
+        ],
+    )
+
+    mig = _make_migration(
+        jira_client=jira,
+        op_client=op,
+        wp_map={"10001": {"jira_key": "NRS-1", "openproject_id": 501}},
+    )
+
+    delegated_keys: list[list[str]] = []
+
+    def _spy_init(self, jira_client=None, op_client=None):
+        return None
+
+    def _spy_process(self, keys):
+        delegated_keys.append(list(keys))
+        # Simulate a successful recover.
+        return (1, 0, {"NRS-1": {"b.txt": 999}})
+
+    from src.application.components import attachments_migration as am_mod
+
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "__init__", _spy_init)
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "_process_batch_end_to_end", _spy_process)
+
+    result = mig.run()
+
+    assert result.success, result
+    assert result.updated == 1
+    assert delegated_keys == [["NRS-1"]]
+    assert result.details["recovered"] == 1
+    assert result.details["still_missing_total"] == 0
+    assert result.details["missing_total_before"] == 1
+
+
+def test_run_handles_duplicate_filenames_with_multiset_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Jira has ``screenshot.png`` twice and OP has it once →
+    ``missing_total_before == 1`` (NOT 0 — set-based dedup would
+    have masked the loss).
+    """
+    pages = [
+        [
+            _FakeJiraIssue(
+                "NRS-1",
+                [
+                    {"filename": "screenshot.png", "id": 1, "url": "u1"},
+                    {"filename": "screenshot.png", "id": 2, "url": "u2"},
+                ],
+            ),
+        ],
+    ]
+    jira = _FakeJira(pages)
+    op = _RecordingOp(
+        attachment_fetches=[
+            {501: ["screenshot.png"]},
+            {501: ["screenshot.png"]},  # post-recover unchanged (Rails dedup)
+        ],
+    )
+
+    mig = _make_migration(
+        jira_client=jira,
+        op_client=op,
+        wp_map={"10001": {"jira_key": "NRS-1", "openproject_id": 501}},
+    )
+
+    def _spy_init(self, jira_client=None, op_client=None):
+        return None
+
+    def _spy_process(self, keys):
+        # Rails dedup keeps OP at 1 file → still_missing remains 1.
+        return (0, 0, {})
+
+    from src.application.components import attachments_migration as am_mod
+
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "__init__", _spy_init)
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "_process_batch_end_to_end", _spy_process)
+
+    result = mig.run()
+
+    assert result.details["missing_total_before"] == 1
+    # Recovery couldn't help (Rails-side filename collision) → still missing.
+    assert result.details["still_missing_total"] == 1
+    assert result.success is False
+
+
+def test_run_extra_in_op_is_reported_but_does_not_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phantom OP attachment (in OP but not in Jira) is reported under
+    ``extra_total`` but does NOT trigger a recovery or a failure.
+
+    Pin: extras are informational; only true loss (missing) is
+    actionable here. Reverse direction would need a separate
+    "delete phantom" component (out of scope).
+    """
+    pages = [
+        [
+            _FakeJiraIssue("NRS-1", [{"filename": "real.txt", "id": 1, "url": "u"}]),
+        ],
+    ]
+    jira = _FakeJira(pages)
+    op = _RecordingOp(attachment_fetches=[{501: ["real.txt", "phantom.bin"]}])
+
+    mig = _make_migration(
+        jira_client=jira,
+        op_client=op,
+        wp_map={"10001": {"jira_key": "NRS-1", "openproject_id": 501}},
+    )
+
+    def _spy_init(self, jira_client=None, op_client=None):
+        return None
+
+    def _spy_process(self, keys):
+        msg = "delegation should not happen on extra-only state"
+        raise AssertionError(msg)
+
+    from src.application.components import attachments_migration as am_mod
+
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "__init__", _spy_init)
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "_process_batch_end_to_end", _spy_process)
+
+    result = mig.run()
+
+    assert result.success
+    assert result.updated == 0
+    assert result.details["extra_total"] == 1
+
+
+def test_op_envelope_error_status_is_logged_and_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rails ``status="error"`` → batch skipped, run continues.
+
+    Pin: the recovery uses ``envelope['data']`` (NOT top-level
+    keys), and a non-success status doesn't crash the run — same
+    envelope-bug class PR #201 caught for wp_metadata_backfill.
+    """
+
+    class _ErrOp:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def execute_script_with_data(self, script: str, data: list[Any]) -> dict[str, Any]:
+            self.calls += 1
+            return {"status": "error", "message": "no markers", "output": "garbage"}
+
+    pages = [
+        [_FakeJiraIssue("NRS-1", [{"filename": "x.txt", "id": 1, "url": "u"}])],
+    ]
+    jira = _FakeJira(pages)
+    op = _ErrOp()
+
+    mig = _make_migration(
+        jira_client=jira,
+        op_client=op,
+        wp_map={"10001": {"jira_key": "NRS-1", "openproject_id": 501}},
+    )
+
+    def _spy_init(self, jira_client=None, op_client=None):
+        return None
+
+    def _spy_process(self, keys):
+        # Rails error skipped the OP-side fetch → component sees OP
+        # as empty for that WP → file appears missing → delegation
+        # fires.
+        return (1, 0, {})
+
+    from src.application.components import attachments_migration as am_mod
+
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "__init__", _spy_init)
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "_process_batch_end_to_end", _spy_process)
+
+    result = mig.run()
+    # Run completes (no crash).
+    assert isinstance(result.message, str)
+    # OP fetch was attempted at least twice (initial + post-recover).
+    assert op.calls >= 1


### PR DESCRIPTION
## Summary

Replaces the **closed** PR [#203](https://github.com/netresearch/jira-to-openproject/pull/203) (tool form) with a proper transparent component. Operator feedback: alles im normalen Migrations-Lauf, keine separaten Tools für Mutation.

Live 2026-05-07 NRS audit caught **-131 attachments** (Jira=4572, OP=4441). The ``attachments`` migration is idempotent on the Rails side — files already attached are silently skipped — so a re-run can't fill the gap unless we tell it *which* issues are short.

## What it does

Slots after ``attachments`` + ``attachment_provenance``:

1. Enumerates Jira's per-issue attachments (paginated SDK call, project keys derived from the WP mapping — no CLI flags needed)
2. Enumerates OP's per-WP attachments via a single batched Rails query (with proper ``status`` + ``data`` envelope parsing — same fix [#201](https://github.com/netresearch/jira-to-openproject/pull/201) applied)
3. Builds the per-issue diff with **multiset semantics** so duplicate filenames match correctly
4. Delegates the actual re-attach to ``AttachmentsMigration._process_batch_end_to_end`` for the affected jira_keys — same path the original migration uses, no duplication
5. Re-queries OP after the recovery pass and reports ``still_missing_total`` (genuine 404s / collisions / transfer errors) — not the pre-recovery count

## Idempotency / safety

* Re-runs only re-attempt files genuinely missing in OP
* On a clean instance: fast no-op (no Rails delegation fired)
* ``success=True`` only when ``still_missing_total == 0``
* Same fail-loud guards as siblings: empty WP map → ``errors=["missing_work_package_mapping"]``

## Sequence position

```
attachments → attachment_provenance → attachment_recovery → work_packages_content → ...
```

## Test plan
- [x] 7 unit tests covering: fail-loud, no-op clean state, delegation on missing files, multiset duplicates, extras-only (informational), envelope-error handling
- [x] Existing siblings unaffected (29 tests passed across attachment_recovery / attachments / wp_metadata_backfill / migration_class_registrations)
- [x] ``ruff check`` + ``ruff format --check`` clean
- [x] ``mypy`` clean on the new file
- [ ] CI green
- [ ] Live re-run on NRS to verify the 131 missing files are recovered