### PR TITLE
fix(backfill): write alias entries when alternate identifier already mapped

### DIFF
--- a/src/application/components/user_mapping_backfill_migration.py
+++ b/src/application/components/user_mapping_backfill_migration.py
@@ -302,13 +302,71 @@ class UserMappingBackfillMigration(BaseMigration):
                 not_found_in_jira.append(name)
                 continue
 
-            # Second-chance dedup: if Jira reports an alternate
-            # identifier we already have mapped, skip.
+            # Build the candidate identifier ladder for this Jira user
+            # (``accountId`` → ``name`` → ``key`` → ``emailAddress`` →
+            # ``displayName``). The watcher / TE / etc. resolvers probe
+            # in that order; if even ONE of these isn't a key in
+            # ``user_map``, the consumer that probes that specific
+            # identifier first will miss the mapping.
             cand_keys = self._candidate_keys(jira_user)
-            if any(k in user_map for k in cand_keys):
-                already_mapped.append(name)
+
+            # Reuse path: an alternate identifier already maps this
+            # Jira user (e.g. ``user_map["JIRAUSER18400"]`` exists but
+            # ``user_map["anne.geissler"]`` doesn't). Reuse the
+            # existing entry's ``openproject_id`` instead of querying
+            # OP — extra API calls aren't needed and the existing
+            # entry may carry operator-set metadata we shouldn't
+            # overwrite.
+            #
+            # Caught by the live 2026-05-07 NRS run: 18 watcher
+            # ``unmapped_users`` were already mapped under their
+            # ``JIRAUSER<id>`` keys but the watcher resolver probes
+            # ``name`` first and never reached the ``key`` field. The
+            # earlier "skip if any candidate present" logic was too
+            # aggressive — it left the mapping reachable only via
+            # ``key`` and the consumer kept dropping watchers.
+            existing_op_id: int | None = None
+            for k in cand_keys:
+                rec = user_map.get(k)
+                if isinstance(rec, dict):
+                    op_id_val = rec.get("openproject_id")
+                    if isinstance(op_id_val, int):
+                        existing_op_id = op_id_val
+                        break
+                elif isinstance(rec, int):
+                    existing_op_id = rec
+                    break
+
+            if existing_op_id is not None:
+                missing_keys = [k for k in cand_keys if k not in user_map]
+                if not missing_keys:
+                    already_mapped.append(name)
+                    continue
+                # Emit a thin alias entry that points at the same OP
+                # user under each missing identifier. ``matched_by``
+                # marks these as alias-only writes so an audit can
+                # tell them apart from primary backfills.
+                alias_entry: dict[str, Any] = {
+                    "openproject_id": existing_op_id,
+                    "jira_name": jira_user.get("name"),
+                    "jira_email": jira_user.get("emailAddress"),
+                    "jira_display_name": jira_user.get("displayName"),
+                    "jira_key": jira_user.get("key"),
+                    "matched_by": "user_mapping_backfill_alias",
+                }
+                for k in missing_keys:
+                    user_map[k] = alias_entry
+                added.append(
+                    {
+                        "name": name,
+                        "openproject_id": existing_op_id,
+                        "alias_for_existing": True,
+                        "added_keys": missing_keys,
+                    },
+                )
                 continue
 
+            # No existing alias — probe OP normally.
             op_user = self._find_op_user(jira_user)
             if op_user is None:
                 not_found_in_op.append(

--- a/src/application/components/user_mapping_backfill_migration.py
+++ b/src/application/components/user_mapping_backfill_migration.py
@@ -154,6 +154,57 @@ class UserMappingBackfillMigration(BaseMigration):
                     _harvest_users_from_issue(issue, out)
         return out
 
+    @staticmethod
+    def _resolve_existing_op_id(
+        user_map: dict[str, Any],
+        cand_keys: list[str],
+    ) -> tuple[int | None, bool]:
+        """Walk ``cand_keys``, collecting every distinct ``openproject_id``
+        already present in ``user_map``.
+
+        Returns ``(op_id, conflict)`` where:
+
+        * ``op_id`` is the unique OP user id when all populated entries
+          agree (or ``None`` when no cand key is mapped).
+        * ``conflict`` is ``True`` when two cand keys point to
+          DIFFERENT OP users — caller treats as
+          ``alias_op_id_conflict`` and refuses to write aliases that
+          would pick one silently. If any conflicting entry has
+          ``matched_by="manual"``, that one wins (operator's
+          manual mapping target is the source of truth).
+
+        Defensive on the int parse: malformed historical entries
+        (string ids, etc.) get coerced via ``int()``; on
+        ``ValueError`` / ``TypeError`` the entry is skipped instead
+        of crashing the run. Per PR #207 review.
+        """
+        seen_ids: set[int] = set()
+        manual_op_id: int | None = None
+        for k in cand_keys:
+            rec = user_map.get(k)
+            if rec is None:
+                continue
+            raw_op_id: Any = rec.get("openproject_id") if isinstance(rec, dict) else rec
+            if raw_op_id is None:
+                continue
+            try:
+                op_id = int(raw_op_id)
+            except TypeError, ValueError:
+                continue
+            seen_ids.add(op_id)
+            if isinstance(rec, dict) and rec.get("matched_by") == "manual":
+                manual_op_id = op_id
+
+        if not seen_ids:
+            return None, False
+        if len(seen_ids) == 1:
+            return next(iter(seen_ids)), False
+        # Multiple distinct ids → conflict. If one is operator-set,
+        # honour the "manual target wins" contract and use it.
+        if manual_op_id is not None:
+            return manual_op_id, False
+        return None, True
+
     def _candidate_keys(self, jira_user: dict[str, Any]) -> list[str]:
         """Identifier ladder mirroring the consumer migrations' resolvers.
 
@@ -304,10 +355,20 @@ class UserMappingBackfillMigration(BaseMigration):
 
             # Build the candidate identifier ladder for this Jira user
             # (``accountId`` → ``name`` → ``key`` → ``emailAddress`` →
-            # ``displayName``). The watcher / TE / etc. resolvers probe
-            # in that order; if even ONE of these isn't a key in
-            # ``user_map``, the consumer that probes that specific
-            # identifier first will miss the mapping.
+            # ``displayName``). The probe orders are NOT identical
+            # across consumer migrations:
+            #
+            #   - ``WatcherMigration._resolve_user_id``:
+            #     account_id → name → email_address → display_name (no ``key``).
+            #   - ``AttachmentProvenanceMigration._author_identifiers``:
+            #     accountId → name → key → emailAddress → email → displayName.
+            #   - ``WpMetadataBackfillMigration._resolve_user_id``:
+            #     accountId → name → key → emailAddress → displayName.
+            #
+            # Writing the alias under EVERY identifier (including
+            # ``key`` even though watcher skips it) ensures the same
+            # user is reachable from any probe path the consumers use
+            # now — or might use after a future code change.
             cand_keys = self._candidate_keys(jira_user)
 
             # Reuse path: an alternate identifier already maps this
@@ -325,17 +386,23 @@ class UserMappingBackfillMigration(BaseMigration):
             # earlier "skip if any candidate present" logic was too
             # aggressive — it left the mapping reachable only via
             # ``key`` and the consumer kept dropping watchers.
-            existing_op_id: int | None = None
-            for k in cand_keys:
-                rec = user_map.get(k)
-                if isinstance(rec, dict):
-                    op_id_val = rec.get("openproject_id")
-                    if isinstance(op_id_val, int):
-                        existing_op_id = op_id_val
-                        break
-                elif isinstance(rec, int):
-                    existing_op_id = rec
-                    break
+            existing_op_id, conflict = self._resolve_existing_op_id(user_map, cand_keys)
+            if conflict:
+                # Multiple cand_keys point to DIFFERENT OP users.
+                # Don't silently pick one — that would write alias
+                # entries pointing to whichever id we happened to see
+                # first and could redirect the consumer to the wrong
+                # OP user. Surface as ``not_found_in_op`` so the
+                # operator triages (the conflict could be a stale
+                # auto-mapped entry vs an operator-fixed one).
+                not_found_in_op.append(
+                    {
+                        "jira_name": name,
+                        "reason": "alias_op_id_conflict",
+                        "details": "multiple cand_keys map to different OP users; refusing to silently pick one",
+                    },
+                )
+                continue
 
             if existing_op_id is not None:
                 missing_keys = [k for k in cand_keys if k not in user_map]

--- a/tests/unit/test_user_mapping_backfill_migration.py
+++ b/tests/unit/test_user_mapping_backfill_migration.py
@@ -325,31 +325,88 @@ def test_run_skips_already_mapped_cheap_path(tmp_path: Path) -> None:
     assert res.details["already_mapped"] == 1
 
 
-def test_run_skips_already_mapped_via_alternate_identifier(tmp_path: Path) -> None:
-    """Name not directly mapped, but Jira reports an alternate
-    identifier (email) that IS mapped → second-chance dedup catches it.
+def test_run_alias_writes_missing_identifier_to_existing_mapping(tmp_path: Path) -> None:
+    """Alias path: an existing entry under one identifier (e.g.
+    ``JIRAUSER18400``) doesn't suppress the alias write under a
+    different identifier (e.g. ``anne.geissler``) the consumer
+    resolver probes first.
 
-    Pin: prevents adding a duplicate entry under a different key
-    when the OP user was already reachable via email or accountId.
+    Caught by the live 2026-05-07 NRS run: 18 watcher
+    ``unmapped_users`` were already mapped under their JIRAUSER ids
+    but the watcher resolver probes ``name`` first, so the watchers
+    kept getting dropped. Pin: the alias entry is written under
+    every cand_key NOT yet present, reusing the existing OP id.
+    No extra OP probe (fast).
     """
-    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["alice"]}}})
-    jira = _Jira({"alice": {"name": "alice", "emailAddress": "alice@x.com"}})
-    # Jira lookup will be queried, but mapping already has alice@x.com.
-    op = _Op(by_login={"alice": {"id": 42}})
 
+    class _BoomOp:
+        """OP fake that explodes if any method is called — proves the
+        alias path doesn't probe OP.
+        """
+
+        def get_user(self, identifier: int | str) -> dict[str, Any]:
+            msg = "OP must not be probed on alias path"
+            raise AssertionError(msg)
+
+        def get_user_by_email(self, email: str) -> dict[str, Any]:
+            msg = "OP must not be probed on alias path"
+            raise AssertionError(msg)
+
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["anne.geissler"]}}})
+    jira = _Jira(
+        {
+            "anne.geissler": {
+                "name": "anne.geissler",
+                "key": "JIRAUSER18400",
+                "emailAddress": "anne.geissler@x.com",
+            },
+        },
+    )
     mig = _make_migration(
         tmp_path,
         jira,
-        op,
-        user_map={"alice@x.com": {"openproject_id": 999, "matched_by": "manual"}},
+        _BoomOp(),
+        user_map={"JIRAUSER18400": {"openproject_id": 42, "matched_by": "users"}},
     )
     res = mig.run()
 
-    assert res.updated == 0
+    user_map = mig.mappings.get_mapping("user")
+    # Original entry preserved.
+    assert user_map["JIRAUSER18400"]["openproject_id"] == 42
+    assert user_map["JIRAUSER18400"]["matched_by"] == "users"
+    # Alias under the watcher's primary probe identifier.
+    assert user_map["anne.geissler"]["openproject_id"] == 42
+    assert user_map["anne.geissler"]["matched_by"] == "user_mapping_backfill_alias"
+    # And under email so the email-probe consumer (TE) also resolves.
+    assert user_map["anne.geissler@x.com"]["openproject_id"] == 42
+    # Counted as added (it's an alias addition, not a no-op).
+    assert res.details["added"] == 1
+    assert res.details["already_mapped"] == 0
+
+
+def test_run_alias_path_skips_when_all_identifiers_already_present(tmp_path: Path) -> None:
+    """Already-mapped under EVERY candidate identifier → nothing to add.
+
+    Pin: the cheap-skip path correctly distinguishes "fully aliased"
+    (no work to do, ``already_mapped += 1``) from "partially aliased"
+    (alias write fires, ``added += 1``).
+    """
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["alice"]}}})
+    jira = _Jira({"alice": {"name": "alice", "emailAddress": "alice@x.com"}})
+    mig = _make_migration(
+        tmp_path,
+        jira,
+        _Op(),  # Default _Op raises RecordNotFoundError on every lookup
+        user_map={
+            "alice": {"openproject_id": 999, "matched_by": "manual"},
+            "alice@x.com": {"openproject_id": 999, "matched_by": "manual"},
+        },
+    )
+    # The cheap-path skip catches the first iteration (``name in user_map``)
+    # so the alias logic doesn't even run.
+    res = mig.run()
     assert res.details["already_mapped"] == 1
-    # Manual entry preserved untouched.
-    assert mig.mappings.get_mapping("user")["alice@x.com"]["openproject_id"] == 999
-    # No write happened (nothing actually changed).
+    assert res.details["added"] == 0
     assert mig.mappings.set_calls == []
 
 
@@ -432,10 +489,15 @@ def test_run_combines_results_and_cache_sources(tmp_path: Path) -> None:
 def test_run_does_not_clobber_manual_entries(tmp_path: Path) -> None:
     """Operator's manual entry under one identifier is preserved when
     a backfill discovers the same OP user via another identifier.
+
+    Updated expectation: the alias path (added 2026-05-07) DOES write
+    a new entry under the missing identifier, but it reuses the
+    existing entry's ``openproject_id`` (so the operator's mapping
+    target isn't redirected). The manual entry's metadata is
+    preserved untouched.
     """
     _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["alice"]}}})
     jira = _Jira({"alice": {"name": "alice", "emailAddress": "alice@x.com"}})
-    # Mapping has alice@x.com → 999 (operator-set).
     op = _Op(by_email={"alice@x.com": {"id": 42, "mail": "alice@x.com"}})
 
     mig = _make_migration(
@@ -446,7 +508,11 @@ def test_run_does_not_clobber_manual_entries(tmp_path: Path) -> None:
     )
     mig.run()
     user_map = mig.mappings.get_mapping("user")
-    # Manual entry preserved.
+    # Manual entry preserved untouched.
     assert user_map["alice@x.com"]["openproject_id"] == 999
-    # Already-mapped via email → second-chance dedup; no new entry under "alice".
-    assert "alice" not in user_map
+    assert user_map["alice@x.com"]["matched_by"] == "manual"
+    # Alias under the missing identifier reuses the existing OP id.
+    # Operator's manual mapping target wins — backfill never overrides
+    # an existing entry's ``openproject_id``.
+    assert user_map["alice"]["openproject_id"] == 999
+    assert user_map["alice"]["matched_by"] == "user_mapping_backfill_alias"

--- a/tests/unit/test_user_mapping_backfill_migration.py
+++ b/tests/unit/test_user_mapping_backfill_migration.py
@@ -384,30 +384,146 @@ def test_run_alias_writes_missing_identifier_to_existing_mapping(tmp_path: Path)
     assert res.details["already_mapped"] == 0
 
 
-def test_run_alias_path_skips_when_all_identifiers_already_present(tmp_path: Path) -> None:
-    """Already-mapped under EVERY candidate identifier → nothing to add.
+def test_run_cheap_path_skips_when_seed_name_already_mapped(tmp_path: Path) -> None:
+    """Seed identifier ``alice`` IS a key in ``user_map`` → cheap-path
+    skip fires before the Jira lookup or alias logic runs.
 
-    Pin: the cheap-skip path correctly distinguishes "fully aliased"
-    (no work to do, ``already_mapped += 1``) from "partially aliased"
-    (alias write fires, ``added += 1``).
+    Reworded per PR #207 review: the previous docstring claimed
+    "already-mapped under EVERY candidate identifier", but the
+    fixture only ensures the seed (``"alice"``) is present. The
+    cheap-path skip is a ``name in user_map`` check that doesn't
+    even consult the Jira user's other identifiers — that's what
+    we're actually pinning here.
     """
     _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["alice"]}}})
-    jira = _Jira({"alice": {"name": "alice", "emailAddress": "alice@x.com"}})
+
+    class _BoomJira:
+        def get_user_info(self, name: str):
+            msg = "Jira must not be queried when cheap-path skip fires"
+            raise AssertionError(msg)
+
     mig = _make_migration(
         tmp_path,
-        jira,
-        _Op(),  # Default _Op raises RecordNotFoundError on every lookup
-        user_map={
-            "alice": {"openproject_id": 999, "matched_by": "manual"},
-            "alice@x.com": {"openproject_id": 999, "matched_by": "manual"},
-        },
+        _BoomJira(),
+        _Op(),  # _Op never queried either
+        user_map={"alice": {"openproject_id": 999, "matched_by": "manual"}},
     )
-    # The cheap-path skip catches the first iteration (``name in user_map``)
-    # so the alias logic doesn't even run.
     res = mig.run()
     assert res.details["already_mapped"] == 1
     assert res.details["added"] == 0
     assert mig.mappings.set_calls == []
+
+
+def test_run_alias_conflict_records_not_found_in_op(tmp_path: Path) -> None:
+    """Two cand_keys map to DIFFERENT OP users → conflict; refuse alias.
+
+    Pin (PR #207 review): the alias path collects every distinct
+    ``openproject_id`` across cand_keys before deciding. When two
+    or more distinct ids exist, the resolver returns a conflict
+    flag and the caller records ``not_found_in_op`` with reason
+    ``alias_op_id_conflict`` instead of silently picking one.
+    """
+
+    class _BoomOp:
+        def get_user(self, identifier: int | str):
+            msg = "OP must not be probed on alias path"
+            raise AssertionError(msg)
+
+        def get_user_by_email(self, email: str):
+            msg = "OP must not be probed on alias path"
+            raise AssertionError(msg)
+
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["dave"]}}})
+    jira = _Jira({"dave": {"name": "dave", "key": "JIRAUSER999", "emailAddress": "dave@x.com"}})
+    mig = _make_migration(
+        tmp_path,
+        jira,
+        _BoomOp(),
+        user_map={
+            "JIRAUSER999": {"openproject_id": 42, "matched_by": "users"},
+            "dave@x.com": {"openproject_id": 999, "matched_by": "auto"},
+        },
+    )
+    res = mig.run()
+    # Conflict surfaced — no alias written.
+    assert res.details["not_found_in_op_count"] == 1
+    item = res.details["not_found_in_op_sample"][0]
+    assert item["reason"] == "alias_op_id_conflict"
+    # Original entries untouched.
+    assert mig.mappings.set_calls == []
+
+
+def test_run_alias_conflict_resolved_when_manual_entry_present(tmp_path: Path) -> None:
+    """Manual entry wins over auto entry on conflict.
+
+    Pin: when one of the conflicting cand_keys carries
+    ``matched_by="manual"``, the resolver picks ITS
+    ``openproject_id`` and writes alias entries pointing there —
+    honouring the "manual target wins" contract.
+    """
+
+    class _BoomOp:
+        def get_user(self, identifier: int | str):
+            msg = "OP must not be probed"
+            raise AssertionError(msg)
+
+        def get_user_by_email(self, email: str):
+            msg = "OP must not be probed"
+            raise AssertionError(msg)
+
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["eve"]}}})
+    jira = _Jira({"eve": {"name": "eve", "key": "JIRAUSER123", "emailAddress": "eve@x.com"}})
+    mig = _make_migration(
+        tmp_path,
+        jira,
+        _BoomOp(),
+        user_map={
+            "JIRAUSER123": {"openproject_id": 42, "matched_by": "users"},  # auto
+            "eve@x.com": {"openproject_id": 999, "matched_by": "manual"},  # operator-set
+        },
+    )
+    res = mig.run()
+    user_map = mig.mappings.get_mapping("user")
+    # Alias entries point at the manual id (999), NOT the auto id (42).
+    assert user_map["eve"]["openproject_id"] == 999
+    assert user_map["eve"]["matched_by"] == "user_mapping_backfill_alias"
+    assert res.details["added"] == 1
+
+
+def test_run_alias_handles_malformed_historical_op_id(tmp_path: Path) -> None:
+    """Malformed historical entry (e.g. ``openproject_id="not-a-number"``)
+    is skipped silently — doesn't crash the run.
+
+    Pin (PR #207 review): defensive int parse with
+    ``try/except (TypeError, ValueError)`` so a single corrupted
+    historical record doesn't take down the whole component.
+    """
+
+    class _BoomOp:
+        def get_user(self, identifier: int | str):
+            msg = "OP must not be probed when alternate identifier is parseable"
+            raise AssertionError(msg)
+
+        def get_user_by_email(self, email: str):
+            msg = "OP must not be probed"
+            raise AssertionError(msg)
+
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["frank"]}}})
+    jira = _Jira({"frank": {"name": "frank", "key": "JIRAUSER555", "emailAddress": "frank@x.com"}})
+    mig = _make_migration(
+        tmp_path,
+        jira,
+        _BoomOp(),
+        user_map={
+            "JIRAUSER555": {"openproject_id": "garbage", "matched_by": "users"},  # bad id
+            "frank@x.com": {"openproject_id": 77, "matched_by": "users"},  # good id
+        },
+    )
+    res = mig.run()
+    user_map = mig.mappings.get_mapping("user")
+    # Bad entry skipped, good one used as the alias target.
+    assert user_map["frank"]["openproject_id"] == 77
+    assert res.details["added"] == 1
 
 
 def test_run_no_jira_user_records_not_found_in_jira(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

PR [#205](https://github.com/netresearch/jira-to-openproject/pull/205)'s second-chance dedup was too aggressive. Caught by the live 2026-05-07 NRS run **right after #205 merged**:

```
[12:55:26] Backfill candidates: 18 from previous migration_results, 0 from issue cache (18 unique)
[12:55:26] Component 'user_mapping_backfill' completed successfully (0/0 items migrated)
```

Zero added — but the 18 watcher ``unmapped_users`` are real users that ARE in OP. They're already mapped under their ``JIRAUSER<id>`` keys (from the original ``users`` migration), but the watcher resolver probes ``name`` first and never reaches the ``key`` field. The backfill saw the JIRAUSER entry → marked everything ``already_mapped`` → added zero alias keys → watchers kept getting dropped.

## Fix

When an alternate identifier already maps the user, instead of skipping, write **thin alias entries** under each MISSING identifier that **reuse the existing entry's ``openproject_id``**:

| Before | After |
|---|---|
| ``user_map["JIRAUSER18400"] = {op_id: 42, ...}`` | ``user_map["JIRAUSER18400"] = {op_id: 42, ...}`` (unchanged) |
| ``user_map["anne.geissler"]`` → KeyError | ``user_map["anne.geissler"] = {op_id: 42, matched_by: "user_mapping_backfill_alias"}`` |
| watcher resolver probes ``name=anne.geissler`` → miss → drop | watcher resolves → ``op_id=42`` ✓ |

## Safety

* Original entries preserved untouched — operator's manual mapping target wins (backfill never overrides an existing ``openproject_id``).
* Alias entries tagged ``matched_by="user_mapping_backfill_alias"`` so an audit can tell them apart from primary backfills.
* No extra OP API call on the alias path — existing ``openproject_id`` reused.
* Fully-aliased identities (every cand_key already present) still hit the cheap-skip path → ``already_mapped`` not ``added``.

## Test plan
- [x] 2 new regression tests pinning the alias path
- [x] Updated ``test_run_does_not_clobber_manual_entries`` to assert the new contract (manual entry preserved, alias added under missing identifier with same op_id)
- [x] All 16 unit tests pass
- [ ] CI green
- [ ] Live re-run of ``user_mapping_backfill`` on NRS to verify the 18 unmapped users now get alias entries