### PR TITLE
fix(backfill): always include seed name in cand_keys

### DIFF
--- a/src/application/components/user_mapping_backfill_migration.py
+++ b/src/application/components/user_mapping_backfill_migration.py
@@ -369,7 +369,20 @@ class UserMappingBackfillMigration(BaseMigration):
             # ``key`` even though watcher skips it) ensures the same
             # user is reachable from any probe path the consumers use
             # now — or might use after a future code change.
+            #
+            # **Always include the seed ``name``** even when Jira's
+            # profile doesn't return it as a string field. Locked /
+            # inactive Server users sometimes have ``name=None`` on
+            # the SDK object; without this guard the alias would
+            # never get written under the identifier the watcher
+            # probes for, which is the entire point of this backfill.
+            # Caught by the live 2026-05-07 NRS run: 18 watcher
+            # ``unmapped_users`` were marked ``already_mapped`` (no
+            # alias written) because their Jira profiles' ``name``
+            # was None and only ``key`` made it into cand_keys.
             cand_keys = self._candidate_keys(jira_user)
+            if name not in cand_keys:
+                cand_keys.insert(0, name)
 
             # Reuse path: an alternate identifier already maps this
             # Jira user (e.g. ``user_map["JIRAUSER18400"]`` exists but

--- a/tests/unit/test_user_mapping_backfill_migration.py
+++ b/tests/unit/test_user_mapping_backfill_migration.py
@@ -526,6 +526,55 @@ def test_run_alias_handles_malformed_historical_op_id(tmp_path: Path) -> None:
     assert res.details["added"] == 1
 
 
+def test_run_seed_name_aliased_when_jira_profile_omits_name(tmp_path: Path) -> None:
+    """Seed name is always written as an alias even when Jira's profile
+    doesn't return it as a string field.
+
+    Caught by the live 2026-05-07 NRS run: 18 watcher
+    ``unmapped_users`` were silently marked ``already_mapped``
+    because their Jira profiles for locked Server users had
+    ``name=None`` on the SDK object. Only ``key`` (e.g.
+    ``JIRAUSER18400``) made it into cand_keys; that key was
+    already in ``user_map`` so the alias path concluded "no
+    missing keys to write". Watchers kept dropping these users.
+
+    Pin: ``cand_keys`` always includes the seed name (the one
+    from ``unmapped_users`` that triggered this lookup), so the
+    alias gets written under the identifier the consumer
+    actually probes.
+    """
+
+    class _BoomOp:
+        def get_user(self, identifier: int | str):
+            msg = "OP must not be probed on alias path"
+            raise AssertionError(msg)
+
+        def get_user_by_email(self, email: str):
+            msg = "OP must not be probed"
+            raise AssertionError(msg)
+
+    _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["anne.geissler"]}}})
+    # Jira returns a profile with ``name=None`` (locked / minimal
+    # Server profile shape). Only ``key`` is a usable string.
+    jira = _Jira({"anne.geissler": {"name": None, "key": "JIRAUSER18400", "emailAddress": ""}})
+    mig = _make_migration(
+        tmp_path,
+        jira,
+        _BoomOp(),
+        user_map={"JIRAUSER18400": {"openproject_id": 42, "matched_by": "users"}},
+    )
+    res = mig.run()
+
+    user_map = mig.mappings.get_mapping("user")
+    # Alias under the seed name — what the watcher will probe for.
+    assert user_map["anne.geissler"]["openproject_id"] == 42
+    assert user_map["anne.geissler"]["matched_by"] == "user_mapping_backfill_alias"
+    # Existing JIRAUSER entry preserved.
+    assert user_map["JIRAUSER18400"]["matched_by"] == "users"
+    assert res.details["added"] == 1
+    assert res.details["already_mapped"] == 0
+
+
 def test_run_no_jira_user_records_not_found_in_jira(tmp_path: Path) -> None:
     """Jira returns ``None`` → user goes to ``not_found_in_jira``."""
     _write_results(tmp_path, components={"watchers": {"details": {"unmapped_users": ["ghost"]}}})


### PR DESCRIPTION
## Summary

The live 2026-05-07 NRS run caught the residual gap that PR [#207](https://github.com/netresearch/jira-to-openproject/pull/207) didn't close. After the full migration:

```
user_mapping_backfill: added=0, already_mapped=18, not_found_in_jira=0, not_found_in_op=0, jira_api_errors=0
watcher: skipped=3274, user_unmapped=755 (worse than the 748 from the first run!)
```

The 18 watcher ``unmapped_users`` (anne.geissler, caroline.kuhn, …) were silently marked ``already_mapped`` (added=0) — yet the watcher still dropped them.

## Root cause

``_candidate_keys`` builds from the Jira profile's ``accountId`` / ``name`` / ``key`` / ``emailAddress`` / ``displayName`` fields. For locked / inactive Jira Server users the SDK returns a profile with ``name=None`` and ``emailAddress=""``; only ``key`` (e.g. ``JIRAUSER18400``) makes it into cand_keys. That key was already in ``user_map`` from the original ``users`` component → alias path concluded "no missing keys to write" → the consumer-facing seed identifier (``name="anne.geissler"``, the one the watcher probes for FIRST) was never aliased.

## Fix

Explicitly include the **seed ``name``** in cand_keys before the alias resolution. The seed is the identifier that triggered this backfill (it came from a previous run's ``unmapped_users`` list, which means a consumer actually probes for it). Writing the alias under that identifier is the entire point of the component.

```python
cand_keys = self._candidate_keys(jira_user)
if name not in cand_keys:
    cand_keys.insert(0, name)
```

## Test plan
- [x] New regression test ``test_run_seed_name_aliased_when_jira_profile_omits_name`` — exercises the locked-Server-user shape (``name=None``, ``emailAddress=""``, only ``key`` populated)
- [x] All 20 unit tests pass
- [x] ``ruff check`` + ``ruff format --check`` clean
- [ ] CI green
- [ ] Re-run of ``user_mapping_backfill`` + ``watchers`` on NRS to confirm the 18 users now get aliased