### PR TITLE
fix(attachments): noname handling + diagnostic fidelity-pair pass

### DIFF
--- a/src/application/components/attachment_recovery_migration.py
+++ b/src/application/components/attachment_recovery_migration.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import json
 import re
+import unicodedata
 from collections import Counter
 from typing import Any
 
@@ -77,6 +78,59 @@ class AttachmentRecoveryMigration(BaseMigration):
             " state at runtime."
         )
         raise ValueError(msg)
+
+    @staticmethod
+    def _normalize_filename(name: str) -> str:
+        """Return a normalized form of ``name`` for false-positive
+        pairing.
+
+        Strips ALL whitespace (regular, NBSP, zero-width, …) and
+        applies Unicode NFC normalisation + case folding. Two
+        filenames that differ only in whitespace or Unicode
+        composition will share the same normalized form — which is
+        exactly the false-positive class CarrierWave / Rails creates
+        when it sanitises the stored filename on save.
+        """
+        # NFC-normalise then strip ALL Unicode whitespace classes
+        # (matches \s + NBSP + zero-width spaces).
+        nfc = unicodedata.normalize("NFC", name)
+        return re.sub(r"\s+", "", nfc, flags=re.UNICODE).casefold()
+
+    @classmethod
+    def _pair_by_normalized_name(
+        cls,
+        missing: Counter[str],
+        extra: Counter[str],
+    ) -> int:
+        """Mutate ``missing`` and ``extra`` in place: subtract any
+        files whose normalized name matches across both sides.
+
+        Returns the count of paired filenames (each pair == one
+        false positive). On a clean run with perfect filename
+        fidelity, returns 0.
+        """
+        paired = 0
+        # Index by normalized form to find matches in O(n).
+        missing_by_norm: dict[str, list[str]] = {}
+        for fn in list(missing.elements()):
+            missing_by_norm.setdefault(cls._normalize_filename(fn), []).append(fn)
+        for fn in list(extra.elements()):
+            norm = cls._normalize_filename(fn)
+            candidates = missing_by_norm.get(norm)
+            if not candidates:
+                continue
+            # Pop one candidate from missing.
+            paired_name = candidates.pop()
+            missing[paired_name] -= 1
+            if missing[paired_name] <= 0:
+                del missing[paired_name]
+            extra[fn] -= 1
+            if extra[fn] <= 0:
+                del extra[fn]
+            paired += 1
+            if not candidates:
+                missing_by_norm.pop(norm, None)
+        return paired
 
     @staticmethod
     def _read_attr(obj: Any, name: str) -> Any:
@@ -336,14 +390,36 @@ puts end_marker
         missing_total = 0
         extra_total = 0
 
+        # Track filename-fidelity false positives: files that ARE in
+        # OP but under a slightly-different name (CarrierWave / Rails
+        # strips certain whitespace + Unicode normalises the filename
+        # on save). Without this match-by-normalized-name pass, the
+        # diagnostic counts the same file as both "missing" (under the
+        # Jira name) AND "extra" (under the OP name), inflating the
+        # apparent loss. Live 2026-05-07 NRS run: ~31 of 163
+        # "missing" attachments are actually present under a
+        # space-stripped filename. A separate fix in the Rails-side
+        # attach script is needed to preserve fidelity; this only
+        # corrects the diagnostic accounting.
+        fidelity_false_positives = 0
+
         for jira_key, jira_list in jira_atts.items():
             wp_id = wp_map[jira_key]  # guaranteed by the in-scope filter above
             jira_filenames = [a["filename"] for a in jira_list]
             op_filenames = op_by_wp.get(wp_id, [])
             jira_counter = Counter(jira_filenames)
             op_counter = Counter(op_filenames)
-            missing = sorted((jira_counter - op_counter).elements())
-            extra = sorted((op_counter - jira_counter).elements())
+            raw_missing = jira_counter - op_counter
+            raw_extra = op_counter - jira_counter
+            # Pair raw_missing with raw_extra by normalized filename
+            # (case-folded, NFC-normalised, all whitespace stripped).
+            # If a missing file matches an extra under that key, the
+            # file is actually present in OP — just under a sanitised
+            # name. Subtract those pairs from both buckets.
+            paired = self._pair_by_normalized_name(raw_missing, raw_extra)
+            fidelity_false_positives += paired
+            missing = sorted(raw_missing.elements())
+            extra = sorted(raw_extra.elements())
             if missing:
                 per_issue_missing[jira_key] = missing
                 missing_total += len(missing)
@@ -356,10 +432,12 @@ puts end_marker
         recovery_keys = sorted(per_issue_missing)
         if not recovery_keys:
             self.logger.info(
-                "Recovery: no missing attachments detected (%d issues clean, %d extras, %d unmapped)",
+                "Recovery: no missing attachments detected (%d issues clean, %d extras,"
+                " %d unmapped, %d fidelity false positives paired)",
                 clean,
                 extra_total,
                 len(unmapped_jira_keys),
+                fidelity_false_positives,
             )
             # Use the same key names as the recovery branch so callers
             # can read ``details`` uniformly regardless of which path
@@ -369,7 +447,8 @@ puts end_marker
                 updated=0,
                 message=(
                     f"All in-scope attachments present in OP. clean={clean},"
-                    f" extra={extra_total}, wp_unmapped={len(unmapped_jira_keys)}"
+                    f" extra={extra_total}, wp_unmapped={len(unmapped_jira_keys)},"
+                    f" fidelity_false_positives={fidelity_false_positives}"
                 ),
                 details={
                     "projects_examined": len(project_keys),
@@ -379,6 +458,7 @@ puts end_marker
                     "missing_total_before": 0,
                     "still_missing_total": 0,
                     "extra_total": extra_total,
+                    "fidelity_false_positives": fidelity_false_positives,
                     "recovered": 0,
                 },
             )
@@ -454,7 +534,8 @@ puts end_marker
         msg = (
             f"Recovery: recovered={recovered}, still_missing={still_missing_total},"
             f" failed_batches={failed}, clean={clean}, extra={extra_total},"
-            f" wp_unmapped={len(unmapped_jira_keys)}"
+            f" wp_unmapped={len(unmapped_jira_keys)},"
+            f" fidelity_false_positives={fidelity_false_positives}"
         )
         self.logger.info(msg)
         return ComponentResult(
@@ -470,6 +551,7 @@ puts end_marker
                 "missing_total_before": missing_total,
                 "still_missing_total": still_missing_total,
                 "extra_total": extra_total,
+                "fidelity_false_positives": fidelity_false_positives,
                 "recovered": recovered,
                 "still_missing_sample": dict(list(per_issue_missing.items())[:20]),
                 "extra_sample": dict(list(per_issue_extra.items())[:20]),

--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -177,8 +177,23 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                         filename = getattr(a, "filename", None)
                         size = getattr(a, "size", None)
                         url = getattr(a, "content", None)
-                        if not filename or not url:
+                        # Without ``url`` we can't download — that's a
+                        # genuine skip. But ``filename`` may be empty
+                        # or the literal string ``"noname"`` for
+                        # rich-text-paste images / clipboard uploads;
+                        # those are still real attachments and we
+                        # must preserve them. Derive a stable name
+                        # from the Jira attachment id so the file
+                        # ends up under a unique key downstream and
+                        # the Rails LOWER(filename) idempotency check
+                        # doesn't collapse multiple ``noname``s into
+                        # one.
+                        if not url:
                             continue
+                        if not filename or not str(filename).strip() or str(filename).lower() == "noname":
+                            if aid is None:
+                                continue
+                            filename = f"jira-attachment-{aid}"
                         items.append({"id": aid, "filename": filename, "size": size, "url": url})
                     except Exception:
                         continue

--- a/tests/unit/test_attachment_recovery_migration.py
+++ b/tests/unit/test_attachment_recovery_migration.py
@@ -397,3 +397,117 @@ def test_op_envelope_error_status_is_logged_and_skipped(monkeypatch: pytest.Monk
     # still_missing remains positive). Pin the exact contract per
     # PR #206 review.
     assert op.calls >= 2
+
+
+# --- filename-fidelity false positives (added 2026-05-07) ---
+
+
+def test_normalize_filename_strips_whitespace_and_nfc_normalises() -> None:
+    """``_normalize_filename`` is the comparison key for missing/extra
+    pairing. Pin: ASCII spaces, NBSP, and zero-width spaces all strip;
+    Unicode forms compose to the same NFC form; case is folded.
+    """
+    from src.application.components.attachment_recovery_migration import (
+        AttachmentRecoveryMigration,
+    )
+
+    norm = AttachmentRecoveryMigration._normalize_filename
+    # ASCII space stripped.
+    assert norm("Screenshot 2026-04-21.png") == norm("Screenshot2026-04-21.png")
+    # Mixed (NBSP) stripped.
+    assert norm("Backup job.png") == norm("Backupjob.png")
+    # Case-folded.
+    assert norm("README.PDF") == norm("readme.pdf")
+    # NFC: precomposed ä equals decomposed a + combining-diaeresis.
+    assert norm("für.txt") == norm("für.txt")
+
+
+def test_pair_by_normalized_name_subtracts_matched_pairs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a file present in OP under a space-stripped name
+    is no longer counted as ``missing_total_before``.
+
+    Live 2026-05-07 NRS regression: 8 of 20 sampled "missing" files
+    were actually present in OP under whitespace-normalised names;
+    the diagnostic double-counted them. Pin: with the fidelity-pair
+    pass, those drop out of the missing tally and surface as
+    ``fidelity_false_positives``.
+    """
+    pages = [
+        [
+            _FakeJiraIssue(
+                "NRS-1",
+                [
+                    {"filename": "Screenshot 2026-04-21 122931.png", "id": 1, "url": "u1"},
+                    {"filename": "Real loss.txt", "id": 2, "url": "u2"},
+                ],
+            ),
+        ],
+    ]
+    jira = _FakeJira(pages)
+    op = _RecordingOp(
+        attachment_fetches=[
+            {501: ["Screenshot2026-04-21 122931.png"]},  # space-stripped — same file
+            {501: ["Screenshot2026-04-21 122931.png"]},  # post-recover unchanged
+        ],
+    )
+    mig = _make_migration(
+        jira_client=jira,
+        op_client=op,
+        wp_map={"10001": {"jira_key": "NRS-1", "openproject_id": 501}},
+    )
+
+    def _spy_init(self, jira_client=None, op_client=None):
+        return None
+
+    def _spy_process(self, keys):
+        return (0, 0, {})
+
+    from src.application.components import attachments_migration as am_mod
+
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "__init__", _spy_init)
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "_process_batch_end_to_end", _spy_process)
+
+    result = mig.run()
+    # ONE real loss (``Real loss.txt``); ONE fidelity false positive
+    # (the screenshot, present under sanitised name).
+    assert result.details["missing_total_before"] == 1, result.details
+    assert result.details["fidelity_false_positives"] == 1, result.details
+    assert result.details["extra_total"] == 0, result.details
+
+
+def test_pair_by_normalized_name_clean_state_has_no_pairs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clean run (filenames match exactly) → 0 fidelity false positives.
+
+    Pin: the new pairing logic doesn't accidentally merge files that
+    weren't actually missing.
+    """
+    pages = [
+        [_FakeJiraIssue("NRS-1", [{"filename": "ok.txt", "id": 1, "url": "u"}])],
+    ]
+    jira = _FakeJira(pages)
+    op = _RecordingOp(attachment_fetches=[{501: ["ok.txt"]}])
+    mig = _make_migration(
+        jira_client=jira,
+        op_client=op,
+        wp_map={"10001": {"jira_key": "NRS-1", "openproject_id": 501}},
+    )
+
+    def _spy_init(self, jira_client=None, op_client=None):
+        return None
+
+    def _spy_process(self, keys):
+        msg = "should not delegate on clean state"
+        raise AssertionError(msg)
+
+    from src.application.components import attachments_migration as am_mod
+
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "__init__", _spy_init)
+    monkeypatch.setattr(am_mod.AttachmentsMigration, "_process_batch_end_to_end", _spy_process)
+
+    result = mig.run()
+    assert result.details["fidelity_false_positives"] == 0, result.details
+    assert result.details["clean"] == 1, result.details

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -183,3 +183,113 @@ def test_attachments_migration_fails_loud_on_legacy_int_only_mapping(
     msg_lower = (result.message or "").lower()
     assert "no usable rows" in msg_lower, result.message
     assert "legacy" in msg_lower, result.message
+
+
+# --- noname / empty-filename handling (added 2026-05-07) ---
+
+
+def test_extract_batch_derives_filename_for_empty_or_noname(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Empty / ``"noname"`` Jira filename → derived ``jira-attachment-<id>``.
+
+    Live 2026-05-07 NRS regression: NRS-4347 had 3 attachments with
+    filename ``"noname"`` (Jira's placeholder for clipboard / paste
+    uploads without a real name). The pre-fix
+    ``_extract_batch`` skipped them via the ``not filename.strip()``
+    guard. The Rails-side ``LOWER(filename)`` idempotency would have
+    further collapsed them to one entry even if they made it through.
+    Pin: derived names per attachment id keep all three distinct so
+    Rails creates three rows.
+    """
+    from types import SimpleNamespace
+
+    # Build a fake issue with three attachments — empty, "noname",
+    # whitespace-only — exercising the three skip paths the
+    # pre-fix code took.
+    class _FakeAtt:
+        def __init__(self, id_: str, filename: str | None) -> None:
+            self.id = id_
+            self.filename = filename
+            self.size = 100
+            self.content = f"http://jira/secure/attachment/{id_}/blob"
+
+    class _FakeFields:
+        def __init__(self, atts: list[_FakeAtt]) -> None:
+            self.attachment = atts
+
+    class _FakeIssue:
+        def __init__(self, key: str, atts: list[_FakeAtt]) -> None:
+            self.key = key
+            self.fields = _FakeFields(atts)
+
+    class _BatchJira:
+        def __init__(self) -> None:
+            self.jira = SimpleNamespace(
+                search_issues=lambda *_a, **_kw: [
+                    _FakeIssue(
+                        "NRS-1",
+                        [
+                            _FakeAtt("100", ""),
+                            _FakeAtt("200", "noname"),
+                            _FakeAtt("300", "   "),
+                            _FakeAtt("400", "real-file.png"),
+                        ],
+                    ),
+                ],
+            )
+
+    mig = AttachmentsMigration(jira_client=_BatchJira(), op_client=DummyOp())  # type: ignore[arg-type]
+    result = mig._extract_batch(["NRS-1"])
+    items = result.get("NRS-1", [])
+    # All four attachments processed; empty/noname/whitespace get
+    # derived names, real-file passes through.
+    assert len(items) == 4
+    by_id = {it["id"]: it["filename"] for it in items}
+    assert by_id["100"] == "jira-attachment-100"
+    assert by_id["200"] == "jira-attachment-200"
+    assert by_id["300"] == "jira-attachment-300"
+    assert by_id["400"] == "real-file.png"
+
+
+def test_extract_batch_skips_when_no_id_and_no_filename(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Without ``aid`` AND without filename, there's no stable name to
+    derive — skip rather than write an unnameable row.
+
+    Pin: the ``aid is None`` defensive skip catches the impossible-
+    in-practice case where Jira returns an attachment with neither
+    id nor filename. We don't want to fabricate a filename like
+    ``jira-attachment-None``.
+    """
+    from types import SimpleNamespace
+
+    class _FakeAtt:
+        def __init__(self) -> None:
+            self.id = None
+            self.filename = ""
+            self.size = 100
+            self.content = "http://jira/secure/attachment/x/blob"
+
+    class _FakeFields:
+        def __init__(self, atts: list[_FakeAtt]) -> None:
+            self.attachment = atts
+
+    class _FakeIssue:
+        def __init__(self) -> None:
+            self.key = "NRS-1"
+            self.fields = _FakeFields([_FakeAtt()])
+
+    class _BatchJira:
+        def __init__(self) -> None:
+            self.jira = SimpleNamespace(
+                search_issues=lambda *_a, **_kw: [_FakeIssue()],
+            )
+
+    mig = AttachmentsMigration(jira_client=_BatchJira(), op_client=DummyOp())  # type: ignore[arg-type]
+    result = mig._extract_batch(["NRS-1"])
+    # The single attachment is skipped because there's no id to derive
+    # a filename from; the issue key drops out entirely.
+    assert result == {}


### PR DESCRIPTION
## Summary

Two of the four loss patterns from the live 2026-05-07 NRS audit:

### 1. ``noname`` / empty-filename handling

Live finding: [NRS-4347](https://jira.netresearch.de/browse/NRS-4347) had 3 attachments with filename ``noname`` (Jira's placeholder for clipboard pastes), [NRS-3693](https://jira.netresearch.de/browse/NRS-3693) had 2× the same filename. The pre-fix ``_extract_batch`` skipped them via the ``not filename.strip()`` guard. They're real attachments and must survive.

Now derive a stable ``jira-attachment-<id>`` per attachment id so:
- the file passes through extract → map → load;
- the Rails-side ``LOWER(filename)`` idempotency check doesn't collapse multiple ``noname``s on the same WP.

### 2. Diagnostic fidelity-pair pass

Live finding: ~31 of 163 NRS "missing" attachments were already in OP under a space-stripped name (Rails / CarrierWave strips internal whitespace on save). Examples:

| Jira | OP |
|---|---|
| ``Screenshot 2026-04-21 122931.png`` | ``Screenshot2026-04-21 122931.png`` |
| ``Bildschirmfoto vom 2025-07-29 17-23-26.png`` | ``Bildschirmfoto vom 2025-07-2917-23-26.png`` |

Recovery diagnostic now matches per-issue ``missing`` against ``extra`` by normalised filename (NFC-normalised, all-whitespace stripped, case-folded). Paired files surface as ``fidelity_false_positives`` in ``ComponentResult.details`` — an operator can tell apart real loss from a Rails-side filename fidelity bug.

## What this DOES NOT close

Two related items get separate PRs:

- **Filename fidelity** in the Rails attach script. The diagnostic now correctly reports the count, but Rails still strips internal whitespace on save — needs CarrierWave / OP-side investigation.
- **Bulk-upload losses** (e.g. NRS-3630: 9 sequential JPGs all missing) — symptoms suggest a per-batch transfer abort. Needs reproduction with traces.

## Test plan
- [x] 5 new unit tests (3 normalize/pair + 2 noname)
- [x] 37 existing tests across attachment_recovery / attachments / attachment_provenance / wp_metadata_backfill / migration_class_registrations all pass
- [x] ``ruff check`` + ``ruff format --check`` clean
- [x] ``mypy`` clean on touched files
- [ ] CI green
- [ ] Re-run on NRS to verify ``fidelity_false_positives`` matches the 31 ad-hoc count