### PR TITLE
fix(attachments): per-stage loss counters in extract / map / load

### DIFF
--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -96,6 +97,16 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         self.attachment_dir: Path = Path(ap or (Path(self.data_dir) / "attachments"))
         self.attachment_dir.mkdir(parents=True, exist_ok=True)
         self._wp_lookup_cache = None
+        # Per-stage loss counters. Each silent skip in
+        # ``_extract_batch`` / ``_map`` / ``_load`` increments a
+        # bucket; ``run()`` surfaces them under
+        # ``ComponentResult.details["loss_counters"]`` so an
+        # operator (or the audit) can pinpoint *which* stage drops
+        # files instead of seeing only the aggregate "-N missing"
+        # number from the audit. Caught by the live 2026-05-07 NRS
+        # audit where 9 sequential JPGs on NRS-3630 were silently
+        # missing with no log clue. Reset before every ``run()``.
+        self._loss_counters: Counter[str] = Counter()
 
     def _wp_lookup_by_jira_key(self) -> dict[str, int]:
         """Return a cached ``jira_key → openproject_id`` lookup.
@@ -189,17 +200,21 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                         # doesn't collapse multiple ``noname``s into
                         # one.
                         if not url:
+                            self._loss_counters["extract_no_url"] += 1
                             continue
                         if not filename or not str(filename).strip() or str(filename).lower() == "noname":
                             if aid is None:
+                                self._loss_counters["extract_no_id_no_filename"] += 1
                                 continue
                             filename = f"jira-attachment-{aid}"
                         items.append({"id": aid, "filename": filename, "size": size, "url": url})
                     except Exception:
+                        self._loss_counters["extract_per_attachment_exception"] += 1
                         continue
                 if items:
                     by_key[key] = items
             except Exception:
+                self._loss_counters["extract_per_issue_exception"] += 1
                 continue
 
         return by_key
@@ -266,6 +281,10 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         for key, items in att_by_key.items():
             wp_id = key_to_wp_id.get(key)
             if not wp_id:
+                # Issue's WP isn't in our mapping (out-of-scope project
+                # or skipped issue). Counted per-attachment so the
+                # totals match the recovery diagnostic's view.
+                self._loss_counters["map_wp_unmapped"] += len(items)
                 continue
 
             for item in items:
@@ -273,12 +292,17 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                     filename = str(item.get("filename"))
                     url = str(item.get("url"))
                     if not filename or not url:
+                        self._loss_counters["map_missing_filename_or_url"] += 1
                         continue
                     safe_name = filename.replace("/", "_")
                     local_path = self.attachment_dir / safe_name
                     # Download and hash
                     self._download_attachment(url, local_path)
                     if not local_path.exists():
+                        # ``_download_attachment`` already logs a
+                        # warning; record here so the operator sees
+                        # the count alongside the other buckets.
+                        self._loss_counters["map_download_failed"] += 1
                         continue
                     digest = self._sha256_of(local_path)
                     if digest in seen_digests:
@@ -295,6 +319,7 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                         },
                     )
                 except Exception:
+                    self._loss_counters["map_per_item_exception"] += 1
                     continue
 
         return ComponentResult(success=True, data={"ops": ops})
@@ -311,6 +336,11 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             try:
                 local_path = Path(str(op["local_path"]))
                 if not local_path.exists():
+                    # Local file vanished between ``_map`` and ``_load``
+                    # (rare — only possible if something else cleaned
+                    # up the attachment dir mid-run). Counted so the
+                    # operator sees the discrepancy.
+                    self._loss_counters["load_local_file_missing"] += 1
                     continue
                 wp_id = int(op["work_package_id"])  # type: ignore[arg-type]
                 jira_key = str(op["jira_key"])
@@ -324,6 +354,7 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                     logger.info("_load: transfer completed for %s", filename)
                 except Exception:
                     logger.exception("File transfer failed for %s", local_path)
+                    self._loss_counters["load_transfer_failed"] += 1
                     continue
                 container_ops.append(
                     {
@@ -334,6 +365,7 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                     },
                 )
             except Exception:
+                self._loss_counters["load_per_op_exception"] += 1
                 continue
 
         if not container_ops:
@@ -432,6 +464,7 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                         envelope.get("message"),
                     )
                     failed = len(container_ops)
+                    self._loss_counters["load_rails_status_not_success"] += len(container_ops)
                 else:
                     data = envelope.get("data") or {}
                     if not isinstance(data, dict):
@@ -450,9 +483,12 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                             if not r.get("existed"):
                                 updated += 1
                     failed = len(errors)
+                    if errors:
+                        self._loss_counters["load_rails_per_op_error"] += len(errors)
         except Exception:
             logger.exception("Rails attach operation failed")
             failed = len(container_ops)
+            self._loss_counters["load_rails_call_exception"] += len(container_ops)
 
         return ComponentResult(
             success=failed == 0,
@@ -520,6 +556,7 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             # Find work package ID from reverse lookup
             wp_id = key_to_wp.get(key)
             if not wp_id:
+                self._loss_counters["map_wp_unmapped"] += len(items)
                 continue
 
             for item in items:
@@ -527,12 +564,14 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                     filename = str(item.get("filename"))
                     url = str(item.get("url"))
                     if not filename or not url:
+                        self._loss_counters["map_missing_filename_or_url"] += 1
                         continue
                     safe_name = filename.replace("/", "_")
                     local_path = self.attachment_dir / safe_name
                     # Download
                     self._download_attachment(url, local_path)
                     if not local_path.exists():
+                        self._loss_counters["map_download_failed"] += 1
                         continue
                     digest = self._sha256_of(local_path)
                     seen_digests.add(digest)
@@ -546,6 +585,7 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                         },
                     )
                 except Exception:
+                    self._loss_counters["map_per_item_exception"] += 1
                     continue
 
         if not ops:
@@ -576,6 +616,14 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
     def run(self) -> ComponentResult:
         """Execute attachment migration pipeline - memory efficient per-project."""
         self.logger.info("Starting attachment migration (memory-efficient mode)")
+
+        # Reset per-stage loss counters at the start of every run so
+        # the surfaced totals reflect THIS invocation, not a prior one
+        # accumulated on the same instance (matters when ``run()`` is
+        # called more than once on the same migration object — e.g.
+        # ``attachment_recovery_migration`` constructs its own
+        # ``AttachmentsMigration`` and delegates).
+        self._loss_counters.clear()
 
         # Build the canonical Jira-key → wp-id lookup once, then group
         # the resolved Jira keys by project for batch-friendly processing.
@@ -673,12 +721,24 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         self._save_attachment_mapping(all_mappings)
 
         success = total_failed == 0 or (total_updated > 0 and total_failed < total_updated)
+        # Surface the per-stage drop breakdown so an operator can
+        # tell where files are getting lost (e.g. download failures
+        # vs Rails errors vs filename normalisation). The buckets
+        # also feed the next ``attachment_recovery`` run's
+        # diagnostics.
+        loss_counters = dict(self._loss_counters)
+        if loss_counters:
+            self.logger.info(
+                "Attachments loss breakdown (silent skips): %s",
+                loss_counters,
+            )
         return ComponentResult(
             success=success,
             updated=total_updated,
             failed=total_failed,
             data={"attachment_mapping": all_mappings},
             message=f"Processed {total_updated} attachments, {total_failed} failures",
+            details={"loss_counters": loss_counters},
         )
 
     def run_legacy(self) -> ComponentResult:

--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -340,7 +340,20 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             return ComponentResult(success=True, updated=0, data={"attachment_mapping": {}})
 
         # Rails script returns attachment IDs for mapping content migration
-        # Must output JSON between markers for execute_script_with_data to parse
+        # Must output JSON between markers for execute_script_with_data to parse.
+        #
+        # Filename fidelity: ``att.filename = fname`` runs through
+        # ActiveRecord's setter, which on OP / CarrierWave models can
+        # apply silent normalisation (strip internal whitespace,
+        # Unicode-normalise) — caught by the live 2026-05-07 NRS run
+        # where Jira's ``Screenshot 2026-04-21 122931.png`` was stored
+        # in OP as ``Screenshot2026-04-21 122931.png``. ``update_columns``
+        # bypasses callbacks/validations and writes the exact byte
+        # string we provide. Run AFTER ``save!`` so the row exists
+        # to update; the storage filename (CarrierWave's
+        # ``file_file_name``) is left untouched (it's the
+        # on-disk path) — only the user-visible ``filename`` column
+        # is corrected.
         ruby_runner = (
             "require 'json'\n"
             "start_marker = defined?($j2o_start_marker) && $j2o_start_marker ? $j2o_start_marker : 'JSON_OUTPUT_START'\n"
@@ -355,10 +368,13 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             "      next unless wp\n"
             "      jira_key = op['jira_key']\n"
             "      fname = op['filename']\n"
-            "      # Check if an attachment with same name already exists\n"
+            "      # Check if an attachment with same name already exists.\n"
+            "      # Compare against the byte-exact ``filename`` column the\n"
+            "      # post-save ``update_columns`` writes — case-insensitive\n"
+            "      # to match the project's existing idempotency contract.\n"
             "      existing = wp.attachments.where('LOWER(filename) = ?', fname.to_s.downcase).first\n"
             "      if existing\n"
-            "        # Return existing attachment ID for mapping\n"
+            "        # Return existing attachment ID for mapping.\n"
             "        results << { jira_key: jira_key, filename: fname, attachment_id: existing.id, existed: true }\n"
             "        next\n"
             "      end\n"
@@ -366,12 +382,18 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             "      file = File.open(path, 'rb')\n"
             "      author = User.where(admin: true).first\n"
             "      att = Attachment.new(container: wp, author: author)\n"
-            "      # Assign file using Paperclip-style API\n"
+            "      # Assign file using Paperclip-style API.\n"
             "      if att.respond_to?(:file=)\n"
             "        att.file = file\n"
             "      end\n"
             "      att.filename = fname if att.respond_to?(:filename=)\n"
             "      att.save!\n"
+            "      # Filename-fidelity guard: bypass any AR callbacks and\n"
+            "      # write the exact byte string. Without this, OP's\n"
+            "      # filename sanitiser strips selected internal\n"
+            "      # whitespace (NRS audit: ~31 of 163 'missing' files\n"
+            "      # were present under a normalised name).\n"
+            "      att.update_columns(filename: fname) if att.filename != fname\n"
             "      results << { jira_key: jira_key, filename: fname, attachment_id: att.id, existed: false }\n"
             "    rescue => e\n"
             "      errors << { jira_key: op['jira_key'], filename: op['filename'], error: e.message }\n"
@@ -391,23 +413,43 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         attachment_mapping: dict[str, dict[str, int]] = {}
         logger.info("_load: all %d files transferred, executing Rails script with %d ops", len(ops), len(container_ops))
         try:
-            res = self.op_client.execute_script_with_data(ruby_runner, container_ops)
+            envelope = self.op_client.execute_script_with_data(ruby_runner, container_ops)
             logger.info("_load: Rails script completed")
-            if isinstance(res, dict):
-                results = res.get("results", [])
-                errors = res.get("errors", [])
-                # Build attachment mapping: {jira_key: {filename: attachment_id}}
-                for r in results:
-                    jira_key = r.get("jira_key")
-                    filename = r.get("filename")
-                    att_id = r.get("attachment_id")
-                    if jira_key and filename and att_id:
-                        if jira_key not in attachment_mapping:
-                            attachment_mapping[jira_key] = {}
-                        attachment_mapping[jira_key][filename] = int(att_id)
-                        if not r.get("existed"):
-                            updated += 1
-                failed = len(errors)
+            # ``execute_script_with_data`` returns an envelope:
+            # ``{status, message, data, output}``. The actual results
+            # live under ``data`` (the parsed JSON the Ruby script
+            # printed between the markers). The pre-fix code read
+            # ``res.get("results")`` directly on the envelope and
+            # always saw an empty list — silently returning
+            # ``updated=0, failed=0`` regardless of what Rails did.
+            # Same envelope-bug class PR #201 caught for
+            # ``wp_metadata_backfill``.
+            if isinstance(envelope, dict):
+                if envelope.get("status") != "success":
+                    logger.warning(
+                        "_load: Rails returned status=%r message=%r — counting batch as failed",
+                        envelope.get("status"),
+                        envelope.get("message"),
+                    )
+                    failed = len(container_ops)
+                else:
+                    data = envelope.get("data") or {}
+                    if not isinstance(data, dict):
+                        data = {}
+                    results = data.get("results", [])
+                    errors = data.get("errors", [])
+                    # Build attachment mapping: {jira_key: {filename: attachment_id}}
+                    for r in results:
+                        jira_key = r.get("jira_key")
+                        filename = r.get("filename")
+                        att_id = r.get("attachment_id")
+                        if jira_key and filename and att_id:
+                            if jira_key not in attachment_mapping:
+                                attachment_mapping[jira_key] = {}
+                            attachment_mapping[jira_key][filename] = int(att_id)
+                            if not r.get("existed"):
+                                updated += 1
+                    failed = len(errors)
         except Exception:
             logger.exception("Rails attach operation failed")
             failed = len(container_ops)

--- a/tests/integration/test_attachment_provenance_flow.py
+++ b/tests/integration/test_attachment_provenance_flow.py
@@ -244,9 +244,29 @@ def test_attachment_provenance_pipeline(monkeypatch: pytest.MonkeyPatch, patched
     jira_client.batch_get_issues.return_value = {"KEY-1": issue}
 
     op_client = MagicMock()
+    # Two consecutive calls — first from ``AttachmentsMigration._load``
+    # (expects ``data.results``), second from
+    # ``AttachmentProvenanceMigration._load`` (expects ``data.updated``).
+    # Wrap each in the runner's real envelope so the production
+    # parser is exercised; the pre-fix flat shape only worked for
+    # the buggy ``res.get("results")`` path that the recent
+    # filename-fidelity PR closed.
     op_client.execute_script_with_data.side_effect = [
-        {"updated": 1, "failed": 0},
-        {"updated": 1, "failed": 0},
+        {
+            "status": "success",
+            "message": "ok",
+            "data": {
+                "results": [{"jira_key": "KEY-1", "filename": "note.txt", "attachment_id": 4242}],
+                "errors": [],
+            },
+            "output": "<dummy>",
+        },
+        {
+            "status": "success",
+            "message": "ok",
+            "data": {"updated": 1, "failed": 0},
+            "output": "<dummy>",
+        },
     ]
 
     def fake_download(self, url: str, dest_path: Path) -> Path:

--- a/tests/unit/migrations/test_attachment_and_time_entry_migrations.py
+++ b/tests/unit/migrations/test_attachment_and_time_entry_migrations.py
@@ -48,10 +48,19 @@ def test_attachments_migration_transfers_files(tmp_path, monkeypatch, dummy_mapp
 
     jira_client = MagicMock()
     op_client = MagicMock()
-    # _load expects {"results": [...], "errors": [...]} format
+    # ``execute_script_with_data`` returns the runner envelope:
+    # ``{status, message, data, output}``. The pre-fix flat shape
+    # masked the envelope-parsing bug closed in the recent
+    # filename-fidelity PR — keeping the real shape here means the
+    # production parser is exercised.
     op_client.execute_script_with_data.return_value = {
-        "results": [{"jira_key": "KEY-1", "filename": "foo.txt", "attachment_id": 1001}],
-        "errors": [],
+        "status": "success",
+        "message": "ok",
+        "data": {
+            "results": [{"jira_key": "KEY-1", "filename": "foo.txt", "attachment_id": 1001}],
+            "errors": [],
+        },
+        "output": "<dummy>",
     }
 
     migration = AttachmentsMigration(jira_client=jira_client, op_client=op_client)

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -50,7 +50,14 @@ class DummyOp:
 
     def execute_script_with_data(self, script_content: str, data: object):
         self.last_input = list(data) if isinstance(data, list) else []
-        # Return results in the expected format for attachments_migration._load
+        # Mirror the real ``OpenProjectRailsRunner.execute_script_with_data``
+        # envelope: ``{status, message, data, output}``. The counters live
+        # under ``data`` (the parsed JSON the Ruby script prints between
+        # ``$j2o_start_marker`` / ``$j2o_end_marker``). The earlier flat
+        # shape masked a real production bug where ``_load`` was reading
+        # ``res.get("results")`` directly off the envelope and silently
+        # always returning ``updated=0`` — caught alongside the
+        # filename-fidelity fix.
         results = []
         for i, item in enumerate(self.last_input):
             results.append(
@@ -60,7 +67,12 @@ class DummyOp:
                     "attachment_id": 1000 + i,
                 },
             )
-        return {"results": results, "errors": []}
+        return {
+            "status": "success",
+            "message": "ok",
+            "data": {"results": results, "errors": []},
+            "output": "<dummy>",
+        }
 
 
 @pytest.fixture(autouse=True)
@@ -293,3 +305,51 @@ def test_extract_batch_skips_when_no_id_and_no_filename(
     # The single attachment is skipped because there's no id to derive
     # a filename from; the issue key drops out entirely.
     assert result == {}
+
+
+# --- filename fidelity (added 2026-05-07) ---
+
+
+def test_load_rails_script_includes_update_columns_filename_guard():
+    """The generated Rails script MUST include the byte-exact filename
+    write so OP's silent normalisation (strip internal whitespace)
+    doesn't corrupt the stored filename.
+
+    Caught by the live 2026-05-07 NRS audit: ~31 of 163 "missing"
+    files were present in OP under a sanitised name (e.g.
+    ``Screenshot 2026-04-21 122931.png`` → ``Screenshot2026-04-21 122931.png``).
+    The user-visible ``filename`` column is a plain string in OP's
+    schema; ``update_columns`` skips callbacks/validations and writes
+    the byte-exact value — restoring fidelity without touching the
+    on-disk storage path.
+    """
+    op = DummyOp()
+    mig = AttachmentsMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    # Run the load on a small payload so we can inspect the script.
+    att_data = {"PRJ-1": [{"id": "1", "filename": "x.txt", "size": 1, "url": "http://example/x"}]}
+    ex = ComponentResult(success=True, data={"attachments": att_data})
+    mp = mig._map(ex)
+    mig._load(mp)
+    # Inspect the Rails script the dummy received via execute_script_with_data.
+    # The dummy stores its calls; pull the script content.
+    # ``transfers`` is set by transfer_file_to_container; the script is what
+    # _load passes to execute_script_with_data. The dummy doesn't store the
+    # script directly, so re-derive: the script source is computed in _load
+    # from a static template — assert against the running migration's
+    # method by re-invoking the same code path via inspecting it.
+    from src.application.components.attachments_migration import AttachmentsMigration as _AM
+
+    # Instead: find the Rails string in the source — pin the substring.
+    import inspect
+
+    src = inspect.getsource(_AM._load)
+    assert "att.update_columns(filename: fname)" in src, (
+        "Rails script must include the byte-exact filename guard "
+        "(att.update_columns) to prevent OP's silent filename"
+        " normalisation"
+    )
+    # Idempotency: only update if AR's setter mutated the value.
+    assert "att.filename != fname" in src, (
+        "update_columns must be conditional on a mismatch — otherwise"
+        " every save triggers a redundant UPDATE"
+    )

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -337,10 +337,10 @@ def test_load_rails_script_includes_update_columns_filename_guard():
     # script directly, so re-derive: the script source is computed in _load
     # from a static template — assert against the running migration's
     # method by re-invoking the same code path via inspecting it.
-    from src.application.components.attachments_migration import AttachmentsMigration as _AM
-
     # Instead: find the Rails string in the source — pin the substring.
     import inspect
+
+    from src.application.components.attachments_migration import AttachmentsMigration as _AM
 
     src = inspect.getsource(_AM._load)
     assert "att.update_columns(filename: fname)" in src, (
@@ -350,6 +350,84 @@ def test_load_rails_script_includes_update_columns_filename_guard():
     )
     # Idempotency: only update if AR's setter mutated the value.
     assert "att.filename != fname" in src, (
-        "update_columns must be conditional on a mismatch — otherwise"
-        " every save triggers a redundant UPDATE"
+        "update_columns must be conditional on a mismatch — otherwise every save triggers a redundant UPDATE"
     )
+
+
+# --- per-stage loss counters (added 2026-05-07) ---
+
+
+def test_extract_batch_increments_extract_no_url_when_url_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Attachment with no download URL → counted under
+    ``extract_no_url`` (not silently dropped without trace).
+
+    Live 2026-05-07 NRS regression: NRS-3630 had 9 sequential JPGs
+    silently missing with no log clue. The per-stage counters tell
+    operators *which* stage drops files instead of leaving them to
+    grep through 90k log lines.
+    """
+    from types import SimpleNamespace
+
+    class _Att:
+        def __init__(self, id_: str, filename: str, url: str | None) -> None:
+            self.id = id_
+            self.filename = filename
+            self.size = 100
+            self.content = url
+
+    class _FakeIssue:
+        def __init__(self, atts: list[_Att]) -> None:
+            self.key = "NRS-1"
+            self.fields = SimpleNamespace(attachment=atts)
+
+    class _Jira:
+        def __init__(self) -> None:
+            self.jira = SimpleNamespace(
+                search_issues=lambda *_a, **_kw: [
+                    _FakeIssue(
+                        [
+                            _Att("100", "good.txt", "http://jira/a"),
+                            _Att("200", "no-url.txt", None),
+                            _Att("300", "empty-url.txt", ""),
+                        ],
+                    ),
+                ],
+            )
+
+    mig = AttachmentsMigration(jira_client=_Jira(), op_client=DummyOp())  # type: ignore[arg-type]
+    mig._extract_batch(["NRS-1"])
+    assert mig._loss_counters["extract_no_url"] == 2, dict(mig._loss_counters)
+
+
+def test_run_resets_loss_counters_at_start(monkeypatch: pytest.MonkeyPatch):
+    """``run()`` must clear cumulative counters from any prior
+    invocation on the same instance.
+
+    Pin: when ``attachment_recovery_migration`` constructs an
+    ``AttachmentsMigration`` and delegates per-batch work, the
+    inner instance's counters reflect THAT recovery's run, not
+    leftover state from an earlier call.
+    """
+    import src.config as cfg
+
+    class _EmptyMappings:
+        def get_mapping(self, name):
+            return {}
+
+    monkeypatch.setattr(cfg, "mappings", _EmptyMappings(), raising=False)
+
+    mig = AttachmentsMigration(jira_client=DummyJira(), op_client=DummyOp())  # type: ignore[arg-type]
+    # Seed pre-existing counters as if from a previous invocation.
+    mig._loss_counters["extract_no_url"] = 99
+    mig._loss_counters["load_transfer_failed"] = 7
+    # ``run`` fail-louds on the empty WP map, but
+    # ``self._loss_counters.clear()`` happens BEFORE that exit so
+    # the pre-seeded buckets are gone regardless of exit path.
+    try:
+        mig.run()
+    except Exception:
+        pass
+    assert mig._loss_counters.get("extract_no_url", 0) == 0
+    assert mig._loss_counters.get("load_transfer_failed", 0) == 0


### PR DESCRIPTION
## Summary

Live 2026-05-07 NRS audit symptom the previous PRs couldn't diagnose: [NRS-3630](https://jira.netresearch.de/browse/NRS-3630) had 9 sequential JPGs silently missing with NO log clue about which migration stage dropped them. The recovery component reported ``recovered=0, still_missing=163`` but had zero visibility into whether the files were dropped during extract / map / load — operators had to grep through 90k log lines.

## Approach

Add a ``self._loss_counters: Counter[str]`` (reset at the start of every ``run()``) and increment at every silent skip in extract / map / load. ``run()`` surfaces the dict under ``ComponentResult.details["loss_counters"]`` and logs an INFO line when non-empty, so the next run's ``migration_results_*.json`` contains enough info to pinpoint the loss class without re-running.

## Buckets

| Stage | Buckets |
|---|---|
| ``_extract_batch`` | ``extract_no_url``, ``extract_no_id_no_filename``, ``extract_per_attachment_exception``, ``extract_per_issue_exception`` |
| ``_map`` / ``_process_batch_end_to_end`` | ``map_wp_unmapped``, ``map_missing_filename_or_url``, ``map_download_failed``, ``map_per_item_exception`` |
| ``_load`` | ``load_local_file_missing``, ``load_transfer_failed``, ``load_per_op_exception``, ``load_rails_status_not_success``, ``load_rails_per_op_error``, ``load_rails_call_exception`` |

## Test plan
- [x] 2 new regression tests pinning the per-stage incrementing
- [x] All 8 tests in ``test_attachments_migration.py`` pass
- [x] ``ruff check`` + ``ruff format --check`` clean
- [ ] CI green
- [ ] Live re-run on NRS to verify the 163 still-missing attachments are accounted for in specific buckets (likely ``map_download_failed`` for bulk-upload sprees, ``load_transfer_failed`` for SSH timeouts)