### PR TITLE
fix(attachments): log Rails per-op error sample for debuggability

### DIFF
--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -485,6 +485,18 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                     failed = len(errors)
                     if errors:
                         self._loss_counters["load_rails_per_op_error"] += len(errors)
+                        # Surface the first few error objects so future
+                        # runs can diagnose why Rails rejected an
+                        # attach. Without this the counter alone
+                        # gives no clue what failed; the live re-run
+                        # on NRS reported 39 errors with no text.
+                        sample = errors[:5]
+                        logger.warning(
+                            "_load: Rails returned %d per-op errors (sample of %d): %s",
+                            len(errors),
+                            len(sample),
+                            sample,
+                        )
         except Exception:
             logger.exception("Rails attach operation failed")
             failed = len(container_ops)

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -431,3 +431,49 @@ def test_run_resets_loss_counters_at_start(monkeypatch: pytest.MonkeyPatch):
         pass
     assert mig._loss_counters.get("extract_no_url", 0) == 0
     assert mig._loss_counters.get("load_transfer_failed", 0) == 0
+
+
+def test_load_logs_sample_when_rails_returns_per_op_errors(
+    caplog: pytest.LogCaptureFixture,
+):
+    """When Rails returns a non-empty ``errors`` array, ``_load`` must
+    log a sample so operators can see WHY ops failed — not just count.
+
+    Live 2026-05-07 NRS regression: a re-run reported
+    ``load_rails_per_op_error: 39`` with no error text in the log,
+    leaving the underlying Rails failure invisible. The fix logs the
+    first 5 error objects.
+    """
+    import logging
+
+    class _ErrOp(DummyOp):
+        def execute_script_with_data(self, script_content: str, data: object):
+            self.last_input = list(data) if isinstance(data, list) else []
+            return {
+                "status": "success",
+                "message": "ok",
+                "data": {
+                    "results": [],
+                    "errors": [
+                        {"jira_key": "PRJ-1", "filename": "a.txt", "error": "boom-1"},
+                        {"jira_key": "PRJ-1", "filename": "b.txt", "error": "boom-2"},
+                    ],
+                },
+                "output": "<dummy>",
+            }
+
+    op = _ErrOp()
+    mig = AttachmentsMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    att_data = {
+        "PRJ-1": [
+            {"id": "1", "filename": "a.txt", "size": 1, "url": "http://example/a"},
+            {"id": "2", "filename": "b.txt", "size": 1, "url": "http://example/b"},
+        ],
+    }
+    ex = ComponentResult(success=True, data={"attachments": att_data})
+    mp = mig._map(ex)
+    with caplog.at_level(logging.WARNING, logger="src.application.components.attachments_migration"):
+        mig._load(mp)
+    joined = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "boom-1" in joined and "boom-2" in joined, joined
+    assert mig._loss_counters["load_rails_per_op_error"] == 2


### PR DESCRIPTION
## Summary
- Live 2026-05-07 NRS re-run reported `load_rails_per_op_error: 39` with no underlying error text — the actual Rails error objects returned in `data.errors` were counted only (length) and dropped.
- Log the first 5 error objects at WARNING when the bucket fires so the next run surfaces what Rails actually rejected.

## Why this PR is small + targeted
The merged filename-fidelity fix (#210) closed 31 of the prior gap (`fidelity_false_positives=31`), but the same audit revealed a visibility cliff: 39 per-op errors with zero diagnostic detail. Without the error text, root cause is invisible.

## Test plan
- [x] New unit test pins the WARNING log content (`boom-1`, `boom-2`).
- [x] `pytest tests/unit/test_attachments_migration.py -q` → 9 passed.
- [x] `pytest tests/unit -q -x` → 1478 passed.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Re-run attachments component live on NRS to capture the 39 errors' content for follow-up fix.