### PR TITLE
fix(attachments): bump OP attachment_max_size during run, restore in finally

### DIFF
--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -509,6 +509,42 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             data={"attachment_mapping": attachment_mapping},
         )
 
+    def _get_op_attachment_max_kb(self) -> int | None:
+        """Return OP's current ``Setting.attachment_max_size`` in KB.
+
+        OP stores this as a string of KB (Rails ``Setting`` integer
+        coercion). Returns ``None`` if the value can't be read — the
+        caller treats that as "don't bump".
+        """
+        try:
+            raw = self.op_client.execute_query("Setting.attachment_max_size")
+        except Exception:
+            logger.exception("Failed to read Setting.attachment_max_size")
+            return None
+        # Rails console echoes ``=> 5120`` for an integer setting; the
+        # runner returns the stripped value. Be tolerant of stray
+        # whitespace and non-numeric noise.
+        try:
+            return int(str(raw).strip().splitlines()[-1])
+        except ValueError, IndexError:
+            logger.warning("Could not parse attachment_max_size from %r", raw)
+            return None
+
+    def _set_op_attachment_max_kb(self, value_kb: int) -> bool:
+        """Write ``Setting.attachment_max_size = value_kb`` (in KB).
+
+        Returns True on apparent success.
+        """
+        # ``execute_query`` is a thin shell over the Rails console; the
+        # write expression is fixed-shape and uses an int we control,
+        # so there's no shell-injection vector.
+        try:
+            self.op_client.execute_query(f"Setting.attachment_max_size = {int(value_kb)}")
+        except Exception:
+            logger.exception("Failed to write Setting.attachment_max_size=%d", value_kb)
+            return False
+        return True
+
     def _save_attachment_mapping(self, mapping: dict[str, dict[str, int]]) -> None:
         """Save attachment mapping to file for content migration phase.
 
@@ -692,6 +728,64 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         all_mappings: dict[str, dict[str, int]] = {}
         batch_size = 50  # Process 50 issues at a time to limit memory usage
 
+        # Pre-flight: ensure OP's ``Setting.attachment_max_size`` is
+        # high enough that Rails won't reject oversized files with
+        # ``Validation failed: File is too large``. The 2026-05-07
+        # NRS audit traced 34 silent attachment losses to this 5 MB
+        # cap. ``J2O_ATTACHMENT_MAX_KB`` (default 1 GiB) controls the
+        # bumped value; the original is restored in ``finally`` so a
+        # crash mid-run doesn't leave the cap permanently elevated.
+        target_max_kb = int(os.environ.get("J2O_ATTACHMENT_MAX_KB", str(1024 * 1024)))
+        original_max_kb = self._get_op_attachment_max_kb()
+        cap_was_raised = False
+        if original_max_kb is not None and target_max_kb > original_max_kb:
+            if self._set_op_attachment_max_kb(target_max_kb):
+                cap_was_raised = True
+                self.logger.warning(
+                    "Raised OP Setting.attachment_max_size from %d KB to %d KB"
+                    " for the duration of this run; will restore in finally.",
+                    original_max_kb,
+                    target_max_kb,
+                )
+            else:
+                self.logger.error(
+                    "Could not raise OP attachment_max_size; oversized files"
+                    " (>%d KB) will be rejected by Rails validation.",
+                    original_max_kb,
+                )
+
+        try:
+            return self._run_per_project_loop(
+                by_project=by_project,
+                batch_size=batch_size,
+                total_updated=total_updated,
+                total_failed=total_failed,
+                all_mappings=all_mappings,
+            )
+        finally:
+            if cap_was_raised and original_max_kb is not None:
+                if self._set_op_attachment_max_kb(original_max_kb):
+                    self.logger.info(
+                        "Restored OP Setting.attachment_max_size to %d KB",
+                        original_max_kb,
+                    )
+                else:
+                    self.logger.error(
+                        "FAILED to restore OP attachment_max_size to %d KB —"
+                        " operator must reset manually (current: %d KB)",
+                        original_max_kb,
+                        target_max_kb,
+                    )
+
+    def _run_per_project_loop(
+        self,
+        *,
+        by_project: dict[str, list[str]],
+        batch_size: int,
+        total_updated: int,
+        total_failed: int,
+        all_mappings: dict[str, dict[str, int]],
+    ) -> ComponentResult:
         for project_key, jira_keys in by_project.items():
             self.logger.info(
                 "Processing project %s (%d issues)",

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 
 import pytest
@@ -44,6 +45,21 @@ class DummyOp:
     def __init__(self) -> None:
         self.transfers: list[tuple[Path, str]] = []
         self.last_input: list[dict] | None = None
+        self.queries: list[str] = []
+        # ``Setting.attachment_max_size`` value (in KB) seen by the
+        # dummy. Tests can override before calling ``run()``.
+        self.attachment_max_kb: int = 5120
+
+    def execute_query(self, query: str, timeout: int | None = None) -> str:
+        self.queries.append(query)
+        if query == "Setting.attachment_max_size":
+            return str(self.attachment_max_kb)
+        # Pattern-match the writer: ``Setting.attachment_max_size = 12345``
+        m = re.match(r"^\s*Setting\.attachment_max_size\s*=\s*(\d+)\s*$", query)
+        if m:
+            self.attachment_max_kb = int(m.group(1))
+            return str(self.attachment_max_kb)
+        return ""
 
     def transfer_file_to_container(self, local_path: Path, container_path: str):
         self.transfers.append((local_path, container_path))
@@ -477,3 +493,73 @@ def test_load_logs_sample_when_rails_returns_per_op_errors(
     joined = " ".join(rec.getMessage() for rec in caplog.records)
     assert "boom-1" in joined and "boom-2" in joined, joined
     assert mig._loss_counters["load_rails_per_op_error"] == 2
+
+
+# --- attachment_max_size pre-flight (added 2026-05-07) ---
+
+
+def test_run_raises_op_attachment_max_size_then_restores(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``run()`` must bump ``Setting.attachment_max_size`` if the
+    target value exceeds the current OP cap, then restore the
+    original cap after the per-project loop completes.
+
+    Live 2026-05-07 NRS regression: 34 silent attachment losses
+    traced to OP's default 5 MB ``attachment_max_size``. Without
+    this pre-flight, every Jira attachment >5 MB hits
+    ``Validation failed: File is too large`` and the file is lost.
+    """
+    monkeypatch.setenv("J2O_ATTACHMENT_MAX_KB", "1048576")  # 1 GiB
+
+    op = DummyOp()
+    op.attachment_max_kb = 5120  # OP default
+    jira = DummyJira()
+    mig = AttachmentsMigration(jira_client=jira, op_client=op)  # type: ignore[arg-type]
+
+    # Make the per-project loop a no-op so we just exercise the
+    # bump/restore wrap.
+    monkeypatch.setattr(
+        mig,
+        "_run_per_project_loop",
+        lambda **_kw: ComponentResult(success=True, updated=0, failed=0),
+    )
+
+    mig.run()
+
+    # Verify the cap was raised and restored — the dummy stores the
+    # latest write, so after ``run()`` it must be the original value.
+    assert op.attachment_max_kb == 5120, "cap not restored"
+    # The query log must contain both the read, the bump write, and
+    # the restore write.
+    reads = [q for q in op.queries if q == "Setting.attachment_max_size"]
+    writes = [q for q in op.queries if "=" in q]
+    assert len(reads) >= 1, op.queries
+    assert any("1048576" in w for w in writes), op.queries
+    assert any("5120" in w for w in writes), op.queries
+
+
+def test_run_skips_bump_when_cap_already_high_enough(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If OP's existing cap already meets the target, ``run()`` must
+    not write anything — avoiding pointless Rails round-trips and
+    keeping the operator's intentional cap intact.
+    """
+    monkeypatch.setenv("J2O_ATTACHMENT_MAX_KB", "1048576")
+
+    op = DummyOp()
+    op.attachment_max_kb = 2_000_000  # already higher than target
+    mig = AttachmentsMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    monkeypatch.setattr(
+        mig,
+        "_run_per_project_loop",
+        lambda **_kw: ComponentResult(success=True, updated=0, failed=0),
+    )
+
+    mig.run()
+
+    # Read happened once; no writes.
+    writes = [q for q in op.queries if "=" in q]
+    assert writes == [], writes
+    assert op.attachment_max_kb == 2_000_000


### PR DESCRIPTION
## Summary
- Live 2026-05-07 NRS audit traced **34 silent attachment losses** to OP's default 5 MB `Setting.attachment_max_size`.
- Per-op error sample (#212) revealed the cause: every oversized file hit `Validation failed: File is too large (maximum size is 5242880 Bytes)`.
- Pre-flight raise the cap to `J2O_ATTACHMENT_MAX_KB` (default 1 GiB) at run start; restore in `finally`.

## Why this approach
- **Bump only when needed**: read OP's current cap; skip the write if it already meets the target. Preserves intentional ceilings.
- **Restore in `finally`**: a crash mid-run won't leave the cap permanently elevated.
- **Env-var override**: `J2O_ATTACHMENT_MAX_KB` lets operators tune for their fleet (Jira limits vary widely).
- **Loop extracted to `_run_per_project_loop`**: keeps the bump/restore wrap tight without duplicating loop body.

## Combined effect (PRs #210 + #211 + #212 + this)
- #210 closed the 31-file filename-fidelity gap (CarrierWave whitespace stripping).
- #211 surfaced per-stage loss counters.
- #212 surfaced the Rails error text behind the `load_rails_per_op_error` bucket.
- This PR closes the 34-file size-cap gap that #212 made visible.

## Test plan
- [x] New unit test pins bump-then-restore happy path.
- [x] New unit test pins no-op when cap already meets target.
- [x] `pytest tests/unit/test_attachments_migration.py -q` → 11 passed.
- [x] Sibling integration tests for attachments + provenance still pass.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Live re-run on NRS expected: `still_missing` drops from 132 toward 132-34=98 (the size-cap losses recover); `failed_batches` drops from 34 toward 0.