### PR TITLE
fix(attachments): use marker-fenced envelope for size-cap read/write

### DIFF
--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -509,39 +509,86 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             data={"attachment_mapping": attachment_mapping},
         )
 
+    @staticmethod
+    def _build_attachment_max_size_script(value_kb: int | None) -> str:
+        """Ruby that reads or writes ``Setting.attachment_max_size``.
+
+        ``value_kb is None`` → read; otherwise write that value first.
+        Output contract matches ``execute_script_with_data``: emit
+        ``{"value": int}`` between the runner's start/end markers so
+        ``envelope['data']`` carries it cleanly. The plain
+        ``execute_query`` path returns the raw tmux buffer which can
+        be polluted with leftover output from prior commands — caught
+        by the live 2026-05-07 NRS run where the read returned a
+        kilobyte-long JSON blob from a prior recovery query.
+        """
+        prelude = "" if value_kb is None else f"Setting.attachment_max_size = {int(value_kb)}\n"
+        return f"""
+require 'json'
+start_marker = defined?($j2o_start_marker) && $j2o_start_marker ? $j2o_start_marker : 'JSON_OUTPUT_START'
+end_marker = defined?($j2o_end_marker) && $j2o_end_marker ? $j2o_end_marker : 'JSON_OUTPUT_END'
+{prelude}value = Setting.attachment_max_size.to_i
+puts start_marker
+puts({{value: value}}.to_json)
+puts end_marker
+"""
+
+    def _read_envelope_value(self, envelope: object) -> int | None:
+        if not isinstance(envelope, dict):
+            return None
+        if envelope.get("status") != "success":
+            logger.warning(
+                "attachment_max_size read/write returned status=%r message=%r",
+                envelope.get("status"),
+                envelope.get("message"),
+            )
+            return None
+        data = envelope.get("data") or {}
+        if not isinstance(data, dict):
+            return None
+        try:
+            return int(data.get("value"))
+        except TypeError, ValueError:
+            return None
+
     def _get_op_attachment_max_kb(self) -> int | None:
         """Return OP's current ``Setting.attachment_max_size`` in KB.
 
-        OP stores this as a string of KB (Rails ``Setting`` integer
-        coercion). Returns ``None`` if the value can't be read — the
-        caller treats that as "don't bump".
+        Uses the marker-fenced ``execute_script_with_data`` envelope
+        (same pattern :class:`AttachmentRecoveryMigration` uses) so the
+        return value is parsed JSON, not raw tmux buffer output.
+        Returns ``None`` if the value can't be read — the caller treats
+        that as "don't bump".
         """
+        script = self._build_attachment_max_size_script(None)
         try:
-            raw = self.op_client.execute_query("Setting.attachment_max_size")
+            envelope = self.op_client.execute_script_with_data(script, [])
         except Exception:
             logger.exception("Failed to read Setting.attachment_max_size")
             return None
-        # Rails console echoes ``=> 5120`` for an integer setting; the
-        # runner returns the stripped value. Be tolerant of stray
-        # whitespace and non-numeric noise.
-        try:
-            return int(str(raw).strip().splitlines()[-1])
-        except ValueError, IndexError:
-            logger.warning("Could not parse attachment_max_size from %r", raw)
-            return None
+        return self._read_envelope_value(envelope)
 
     def _set_op_attachment_max_kb(self, value_kb: int) -> bool:
         """Write ``Setting.attachment_max_size = value_kb`` (in KB).
 
-        Returns True on apparent success.
+        Returns ``True`` only when the write round-trip emits the
+        new value back through the envelope — confirms the write
+        actually took effect rather than just trusting a fire-and-
+        forget `puts` over tmux.
         """
-        # ``execute_query`` is a thin shell over the Rails console; the
-        # write expression is fixed-shape and uses an int we control,
-        # so there's no shell-injection vector.
+        script = self._build_attachment_max_size_script(int(value_kb))
         try:
-            self.op_client.execute_query(f"Setting.attachment_max_size = {int(value_kb)}")
+            envelope = self.op_client.execute_script_with_data(script, [])
         except Exception:
             logger.exception("Failed to write Setting.attachment_max_size=%d", value_kb)
+            return False
+        observed = self._read_envelope_value(envelope)
+        if observed != int(value_kb):
+            logger.warning(
+                "attachment_max_size write did not stick: wanted=%d observed=%r",
+                value_kb,
+                observed,
+            )
             return False
         return True
 

--- a/tests/integration/test_attachment_provenance_flow.py
+++ b/tests/integration/test_attachment_provenance_flow.py
@@ -244,30 +244,51 @@ def test_attachment_provenance_pipeline(monkeypatch: pytest.MonkeyPatch, patched
     jira_client.batch_get_issues.return_value = {"KEY-1": issue}
 
     op_client = MagicMock()
-    # Two consecutive calls — first from ``AttachmentsMigration._load``
-    # (expects ``data.results``), second from
-    # ``AttachmentProvenanceMigration._load`` (expects ``data.updated``).
-    # Wrap each in the runner's real envelope so the production
-    # parser is exercised; the pre-fix flat shape only worked for
-    # the buggy ``res.get("results")`` path that the recent
-    # filename-fidelity PR closed.
-    op_client.execute_script_with_data.side_effect = [
-        {
-            "status": "success",
-            "message": "ok",
-            "data": {
-                "results": [{"jira_key": "KEY-1", "filename": "note.txt", "attachment_id": 4242}],
-                "errors": [],
-            },
-            "output": "<dummy>",
-        },
-        {
+
+    # The attachments + provenance pipeline now issues three
+    # ``execute_script_with_data`` flavours:
+    #
+    # 1. ``AttachmentsMigration`` reads/writes ``Setting.attachment_max_size``
+    #    around its per-project loop (3 calls: read original, raise, restore)
+    # 2. ``AttachmentsMigration._load`` posts attach ops (expects ``data.results``)
+    # 3. ``AttachmentProvenanceMigration._load`` posts updates (expects ``data.updated``)
+    #
+    # A callable side_effect dispatches by inspecting the script
+    # content so the test stays stable as new envelope round-trips
+    # land. The 2026-05-07 attachment_max_size bump (NRS audit) is
+    # the latest example.
+    import re as _re
+
+    def _dispatch(script: str, data: object):
+        if "Setting.attachment_max_size" in script:
+            m = _re.search(r"Setting\.attachment_max_size\s*=\s*(\d+)", script)
+            value = int(m.group(1)) if m else 5120
+            return {
+                "status": "success",
+                "message": "ok",
+                "data": {"value": value},
+                "output": "<dummy>",
+            }
+        if "container_type" in script or "Attachment" in script:
+            # Attachments _load script (results/errors envelope).
+            return {
+                "status": "success",
+                "message": "ok",
+                "data": {
+                    "results": [{"jira_key": "KEY-1", "filename": "note.txt", "attachment_id": 4242}],
+                    "errors": [],
+                },
+                "output": "<dummy>",
+            }
+        # Provenance _load script (updated/failed envelope).
+        return {
             "status": "success",
             "message": "ok",
             "data": {"updated": 1, "failed": 0},
             "output": "<dummy>",
-        },
-    ]
+        }
+
+    op_client.execute_script_with_data.side_effect = _dispatch
 
     def fake_download(self, url: str, dest_path: Path) -> Path:
         dest_path.write_bytes(b"stub")
@@ -285,9 +306,14 @@ def test_attachment_provenance_pipeline(monkeypatch: pytest.MonkeyPatch, patched
     assert provenance_result.success is True
 
     op_client.transfer_file_to_container.assert_called_once()
-    assert op_client.execute_script_with_data.call_count == 2
-
-    _, provenance_call = op_client.execute_script_with_data.call_args_list
+    # Pull the provenance _load call by inspecting payload shape — the
+    # call list also contains setting reads/writes and the attachments
+    # _load, so positional indexing is brittle.
+    provenance_call = next(
+        c
+        for c in op_client.execute_script_with_data.call_args_list
+        if "AttachmentJournal" in c.args[0] or "Journal" in c.args[0] or "author_id" in str(c.args[1])
+    )
     payload = provenance_call.args[1]
     assert len(payload) == 1
     assert payload[0]["filename"] == "note.txt"

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -50,21 +50,27 @@ class DummyOp:
         # dummy. Tests can override before calling ``run()``.
         self.attachment_max_kb: int = 5120
 
-    def execute_query(self, query: str, timeout: int | None = None) -> str:
-        self.queries.append(query)
-        if query == "Setting.attachment_max_size":
-            return str(self.attachment_max_kb)
-        # Pattern-match the writer: ``Setting.attachment_max_size = 12345``
-        m = re.match(r"^\s*Setting\.attachment_max_size\s*=\s*(\d+)\s*$", query)
-        if m:
-            self.attachment_max_kb = int(m.group(1))
-            return str(self.attachment_max_kb)
-        return ""
-
     def transfer_file_to_container(self, local_path: Path, container_path: str):
         self.transfers.append((local_path, container_path))
 
     def execute_script_with_data(self, script_content: str, data: object):
+        # Marker-fenced ``Setting.attachment_max_size`` script — extract the
+        # write target (if any) so the dummy mirrors a real Rails read/write
+        # round-trip via the envelope.
+        if "Setting.attachment_max_size" in script_content:
+            m = re.search(
+                r"Setting\.attachment_max_size\s*=\s*(\d+)",
+                script_content,
+            )
+            if m:
+                self.attachment_max_kb = int(m.group(1))
+            self.queries.append(script_content)
+            return {
+                "status": "success",
+                "message": "ok",
+                "data": {"value": self.attachment_max_kb},
+                "output": "<dummy>",
+            }
         self.last_input = list(data) if isinstance(data, list) else []
         # Mirror the real ``OpenProjectRailsRunner.execute_script_with_data``
         # envelope: ``{status, message, data, output}``. The counters live
@@ -530,13 +536,12 @@ def test_run_raises_op_attachment_max_size_then_restores(
     # Verify the cap was raised and restored — the dummy stores the
     # latest write, so after ``run()`` it must be the original value.
     assert op.attachment_max_kb == 5120, "cap not restored"
-    # The query log must contain both the read, the bump write, and
-    # the restore write.
-    reads = [q for q in op.queries if q == "Setting.attachment_max_size"]
-    writes = [q for q in op.queries if "=" in q]
-    assert len(reads) >= 1, op.queries
-    assert any("1048576" in w for w in writes), op.queries
-    assert any("5120" in w for w in writes), op.queries
+    # Three envelope round-trips: read original, bump write, restore write.
+    setting_calls = [q for q in op.queries if "Setting.attachment_max_size" in q]
+    assert len(setting_calls) == 3, setting_calls
+    writes = [q for q in setting_calls if re.search(r"Setting\.attachment_max_size\s*=", q)]
+    assert any("1048576" in w for w in writes), setting_calls
+    assert any("= 5120" in w for w in writes), setting_calls
 
 
 def test_run_skips_bump_when_cap_already_high_enough(
@@ -559,7 +564,8 @@ def test_run_skips_bump_when_cap_already_high_enough(
 
     mig.run()
 
-    # Read happened once; no writes.
-    writes = [q for q in op.queries if "=" in q]
-    assert writes == [], writes
+    # Read happened once; no writes — only the read script is in queries.
+    setting_calls = [q for q in op.queries if "Setting.attachment_max_size" in q]
+    writes = [q for q in setting_calls if re.search(r"Setting\.attachment_max_size\s*=", q)]
+    assert writes == [], setting_calls
     assert op.attachment_max_kb == 2_000_000


### PR DESCRIPTION
## Summary
Live validation after PR #213 revealed the size-cap bump silently failed: `_get_op_attachment_max_kb` read `Setting.attachment_max_size` via `execute_query` (raw tmux), but the buffer was polluted with leftover output from a prior recovery query — a kilobyte-long JSON blob. Parser returned `None`, bump was skipped, and the same 34 `File is too large` rejections recurred.

## Fix
Switch both helpers to the marker-fenced `execute_script_with_data` envelope (same pattern `AttachmentRecoveryMigration` uses for its OP queries). The Ruby script reads (and optionally writes) the setting and emits `{"value": int}` between `$j2o_start_marker` / `$j2o_end_marker` — runner returns clean parsed JSON via `envelope['data']`.

Bonus: the write path now confirms the round-trip — only returns `True` when the observed value matches what was requested. Catches silent write failures that previously slipped past.

## Test plan
- [x] `pytest tests/unit/test_attachments_migration.py -q` → 11 passed (updated 2 size-cap tests + dummy contract).
- [x] `pytest tests/unit -q -x` → 1480 passed.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Live re-run on NRS expected: "Raised OP Setting.attachment_max_size from 5120 KB to 1048576 KB" log fires; `failed_batches` drops from 34 to 0.