### PR TITLE
fix(recovery): apply noname/empty filename transform in audit

### DIFF
--- a/src/application/components/attachment_recovery_migration.py
+++ b/src/application/components/attachment_recovery_migration.py
@@ -208,14 +208,37 @@ class AttachmentRecoveryMigration(BaseMigration):
                 atts = self._read_attr(fields_obj, "attachment") or []
                 entries: list[dict[str, Any]] = []
                 for a in atts:
-                    filename = self._read_attr(a, "filename")
-                    if not isinstance(filename, str) or not filename.strip():
-                        continue
+                    raw_filename = self._read_attr(a, "filename")
+                    aid = self._read_attr(a, "id")
+                    # Apply the SAME ``noname``/empty → ``jira-attachment-{aid}``
+                    # transformation that ``AttachmentsMigration._extract_batch``
+                    # applies before upload. Without this, the recovery
+                    # audit compares Jira's raw ``noname`` against OP's
+                    # uploaded ``jira-attachment-{aid}`` and reports the
+                    # files as missing even though the upload succeeded —
+                    # caught on the live 2026-05-07 NRS audit
+                    # (e.g. NRS-4347 reported ``['noname','noname','noname']``
+                    # missing while the same WP held the uploaded
+                    # ``jira-attachment-XXXX`` triplet under ``extra``).
+                    is_blank = (
+                        not isinstance(raw_filename, str)
+                        or not raw_filename.strip()
+                        or raw_filename.strip().lower() == "noname"
+                    )
+                    if is_blank:
+                        if not aid:
+                            # No id and no filename — genuinely
+                            # un-uploadable; the upload pipeline drops
+                            # these too via ``extract_no_id_no_filename``.
+                            continue
+                        filename = f"jira-attachment-{aid}"
+                    else:
+                        filename = raw_filename
                     entries.append(
                         {
                             "filename": filename,
                             "size": self._read_attr(a, "size"),
-                            "id": self._read_attr(a, "id"),
+                            "id": aid,
                             "url": self._read_attr(a, "content"),
                         },
                     )

--- a/tests/unit/test_attachment_recovery_migration.py
+++ b/tests/unit/test_attachment_recovery_migration.py
@@ -511,3 +511,76 @@ def test_pair_by_normalized_name_clean_state_has_no_pairs(
     result = mig.run()
     assert result.details["fidelity_false_positives"] == 0, result.details
     assert result.details["clean"] == 1, result.details
+
+
+# --- audit transforms (matching the upload pipeline) -----------------------
+
+
+def test_iter_jira_issues_transforms_noname_to_jira_attachment_aid() -> None:
+    """Audit must apply the same ``noname``/blank → ``jira-attachment-{aid}``
+    transformation that ``AttachmentsMigration._extract_batch`` applies
+    before upload.
+
+    Live 2026-05-07 NRS regression: NRS-4347 reported
+    ``['noname','noname','noname']`` missing while the same WP held the
+    successfully-uploaded ``jira-attachment-XXXX`` triplet under
+    ``extra``. The audit was comparing Jira's raw filename (``noname``)
+    against OP's stored filename (``jira-attachment-{id}``) and never
+    paired them — producing 3 phantom missing files plus 3 phantom
+    extras for every issue with ``noname`` attachments.
+    """
+    pages = [
+        [
+            _FakeJiraIssue(
+                "NRS-1",
+                [
+                    {"filename": "noname", "id": 1001, "url": "u1"},
+                    {"filename": "Noname", "id": 1002, "url": "u2"},
+                    {"filename": " ", "id": 1003, "url": "u3"},  # blank
+                    {"filename": "real.png", "id": 1004, "url": "u4"},
+                ],
+            ),
+        ],
+    ]
+    jira = _FakeJira(pages)
+    mig = _make_migration(
+        jira_client=jira,
+        op_client=_RecordingOp(),
+        wp_map={"NRS-1": {"jira_key": "NRS-1", "openproject_id": 501}},
+    )
+    out = mig._iter_jira_issues_with_attachments("NRS")
+    files = [e["filename"] for e in out["NRS-1"]]
+    assert "jira-attachment-1001" in files, files
+    assert "jira-attachment-1002" in files, files
+    assert "jira-attachment-1003" in files, files
+    assert "real.png" in files, files
+    # Raw 'noname' / blank entries must NOT appear in the audit set.
+    assert "noname" not in files, files
+    assert "Noname" not in files, files
+    assert " " not in files, files
+
+
+def test_iter_jira_issues_skips_blank_filename_with_no_id() -> None:
+    """No filename and no id → can't be uploaded, must not appear in
+    the audit either (matches the upload pipeline's drop).
+    """
+    pages = [
+        [
+            _FakeJiraIssue(
+                "NRS-1",
+                [
+                    {"filename": "noname", "id": None, "url": "u"},
+                    {"filename": "real.png", "id": 99, "url": "u"},
+                ],
+            ),
+        ],
+    ]
+    jira = _FakeJira(pages)
+    mig = _make_migration(
+        jira_client=jira,
+        op_client=_RecordingOp(),
+        wp_map={"NRS-1": {"jira_key": "NRS-1", "openproject_id": 501}},
+    )
+    out = mig._iter_jira_issues_with_attachments("NRS")
+    files = [e["filename"] for e in out["NRS-1"]]
+    assert files == ["real.png"], files


### PR DESCRIPTION
## Summary
The recovery audit was comparing Jira's raw filename (`noname`) against OP's stored filename (`jira-attachment-{id}`) and never pairing them — producing phantom missing files plus phantom extras for every Jira issue with `noname` attachments.

Live 2026-05-07 NRS audit example: NRS-4347 reported `['noname','noname','noname']` missing while the same WP held the successfully-uploaded triplet under `extra`.

## Fix
`AttachmentsMigration._extract_batch` already converts blank/`noname` filenames to `jira-attachment-{aid}` before upload (so distinct files get distinct filenames; OP's `LOWER(filename)` check would otherwise fold them). This PR applies the same transform in the audit's Jira-side enumeration so both halves of the diff use the same normalisation.

## Test plan
- [x] New unit test pins the transform (3 inputs: `noname`, `Noname`, blank → `jira-attachment-{id}`).
- [x] New unit test pins the `no-id, no-filename` drop case.
- [x] `pytest tests/unit/test_attachment_recovery_migration.py -q` → 12 passed.
- [x] `pytest tests/unit -q -x` → 1482 passed.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Live re-run: expected `still_missing` drop by however many `noname` triples exist (NRS-4347 had 3; live sample shows several more).