### PR TITLE
fix(attachments): suffix-disambiguate duplicate filenames per WP

### DIFF
--- a/src/application/components/attachment_recovery_migration.py
+++ b/src/application/components/attachment_recovery_migration.py
@@ -243,6 +243,22 @@ class AttachmentRecoveryMigration(BaseMigration):
                         },
                     )
                 if entries:
+                    # Apply the SAME per-WP duplicate-filename
+                    # disambiguation that ``AttachmentsMigration._load``
+                    # applies before upload. Without this, the audit
+                    # compares raw Jira filenames (with duplicates)
+                    # against OP's disambiguated filenames (with " (2)"
+                    # / " (3)" suffixes) and reports phantom losses.
+                    # See PR following 2026-05-07 NRS audit:
+                    # NRS-3363 alone had 13 duplicate-filename pairs.
+                    from src.application.components.attachments_migration import (
+                        AttachmentsMigration,
+                    )
+
+                    raw_names = [e["filename"] for e in entries]
+                    unique_names = AttachmentsMigration.disambiguate_duplicate_filenames_in_group(raw_names)
+                    for e, new_name in zip(entries, unique_names, strict=True):
+                        e["filename"] = new_name
                     out[str(key)] = entries
             start_at += len(page)
         else:

--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -371,6 +371,19 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         if not container_ops:
             return ComponentResult(success=True, updated=0, data={"attachment_mapping": {}})
 
+        # Within a single batch, multiple ops may target the same
+        # ``(work_package_id, filename)`` — e.g. a Jira issue with
+        # multiple ``logobottom.gif`` attachments. The Rails idempotency
+        # check (``LOWER(filename) = ?``) keeps the first and skips
+        # the rest, silently losing duplicates. Suffix-disambiguate
+        # in-batch so each op presents a unique filename to Rails.
+        # The matching audit-side disambiguation lives in
+        # ``AttachmentRecoveryMigration._iter_jira_issues_with_attachments``.
+        # Live 2026-05-07 NRS: 95 still_missing files traced largely to
+        # this collision class (NRS-3363 alone: 13 distinct duplicate
+        # filename pairs == 26 files).
+        container_ops = self._disambiguate_duplicate_filenames(container_ops)
+
         # Rails script returns attachment IDs for mapping content migration
         # Must output JSON between markers for execute_script_with_data to parse.
         #
@@ -508,6 +521,85 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             failed=failed,
             data={"attachment_mapping": attachment_mapping},
         )
+
+    @staticmethod
+    def disambiguate_duplicate_filenames_in_group(
+        names: list[str],
+    ) -> list[str]:
+        """Return a list of unique filenames given an input list that
+        may contain duplicates (case-insensitive).
+
+        First occurrence keeps its original name. Each subsequent
+        duplicate gets a ``" (N)"`` suffix inserted before the extension.
+
+        Examples:
+            ``["a.png", "a.png", "A.PNG"]`` →
+            ``["a.png", "a (2).png", "A (3).PNG"]``
+            ``["doc"]`` → ``["doc"]``  (no extension)
+            ``["doc", "doc"]`` → ``["doc", "doc (2)"]``
+
+        Naming scheme matches what browsers use when downloading
+        duplicate files — natural and human-readable.
+
+        """
+        used_lower: dict[str, int] = {}
+        out: list[str] = []
+        for name in names:
+            key = name.lower()
+            n = used_lower.get(key, 0)
+            if n == 0:
+                out.append(name)
+                used_lower[key] = 1
+                continue
+            # Find a free suffix. The base name + extension live on
+            # either side of the LAST dot (no dot → bare name, append
+            # at end).
+            stem, dot, ext = name.rpartition(".")
+            base = stem if dot else name
+            tail = (dot + ext) if dot else ""
+            counter = n + 1
+            while True:
+                candidate = f"{base} ({counter}){tail}"
+                if candidate.lower() not in used_lower:
+                    out.append(candidate)
+                    used_lower[candidate.lower()] = 1
+                    used_lower[key] = counter
+                    break
+                counter += 1
+        return out
+
+    def _disambiguate_duplicate_filenames(
+        self,
+        ops: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Disambiguate duplicate filenames per work-package group.
+
+        Each op's ``filename`` is rewritten so that within a single
+        ``work_package_id``, no two ops collide on
+        ``LOWER(filename)`` — Rails's idempotency check would
+        otherwise drop the duplicates. The disambiguator preserves
+        original input order so the first-seen filename keeps its
+        original name.
+        """
+        by_wp: dict[int, list[int]] = {}
+        for idx, op in enumerate(ops):
+            wp = int(op["work_package_id"])
+            by_wp.setdefault(wp, []).append(idx)
+
+        renamed = list(ops)
+        for indices in by_wp.values():
+            if len(indices) <= 1:
+                continue
+            originals = [str(renamed[i]["filename"]) for i in indices]
+            unique = self.disambiguate_duplicate_filenames_in_group(originals)
+            for i, new_name in zip(indices, unique, strict=True):
+                if new_name != renamed[i]["filename"]:
+                    # Mutate a fresh dict so the caller's payload
+                    # isn't surprised by an in-place edit.
+                    new_op = dict(renamed[i])
+                    new_op["filename"] = new_name
+                    renamed[i] = new_op
+        return renamed
 
     @staticmethod
     def _build_attachment_max_size_script(value_kb: int | None) -> str:

--- a/tests/unit/test_attachment_recovery_migration.py
+++ b/tests/unit/test_attachment_recovery_migration.py
@@ -560,6 +560,41 @@ def test_iter_jira_issues_transforms_noname_to_jira_attachment_aid() -> None:
     assert " " not in files, files
 
 
+def test_iter_jira_issues_disambiguates_duplicate_filenames_per_wp() -> None:
+    """Audit must apply the same per-WP duplicate-filename
+    disambiguation that ``AttachmentsMigration._load`` applies before
+    upload — otherwise the audit compares Jira's raw filenames
+    (with duplicates) against OP's disambiguated filenames (with
+    ``" (2)"`` / ``" (3)"`` suffixes) and reports phantom losses.
+
+    Live 2026-05-07 NRS regression: NRS-3363 alone had 13 duplicate
+    filename pairs (== 26 attachments) reported as missing because
+    Rails's idempotency check (``LOWER(filename) = ?``) kept one
+    of each pair and the audit counted the rest as gone.
+    """
+    pages = [
+        [
+            _FakeJiraIssue(
+                "NRS-1",
+                [
+                    {"filename": "logo.gif", "id": 1, "url": "u1"},
+                    {"filename": "logo.gif", "id": 2, "url": "u2"},
+                    {"filename": "logo.gif", "id": 3, "url": "u3"},
+                ],
+            ),
+        ],
+    ]
+    jira = _FakeJira(pages)
+    mig = _make_migration(
+        jira_client=jira,
+        op_client=_RecordingOp(),
+        wp_map={"NRS-1": {"jira_key": "NRS-1", "openproject_id": 501}},
+    )
+    out = mig._iter_jira_issues_with_attachments("NRS")
+    files = [e["filename"] for e in out["NRS-1"]]
+    assert files == ["logo.gif", "logo (2).gif", "logo (3).gif"], files
+
+
 def test_iter_jira_issues_skips_blank_filename_with_no_id() -> None:
     """No filename and no id → can't be uploaded, must not appear in
     the audit either (matches the upload pipeline's drop).

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -569,3 +569,90 @@ def test_run_skips_bump_when_cap_already_high_enough(
     writes = [q for q in setting_calls if re.search(r"Setting\.attachment_max_size\s*=", q)]
     assert writes == [], setting_calls
     assert op.attachment_max_kb == 2_000_000
+
+
+# --- duplicate filename disambiguation (added 2026-05-07) ---
+
+
+def test_disambiguate_filenames_in_group_no_duplicates_returns_input():
+    """No collisions → identity transform.
+
+    Pin: the disambiguator must not silently rename files when there's
+    nothing to fix.
+    """
+    out = AttachmentsMigration.disambiguate_duplicate_filenames_in_group(
+        ["a.png", "b.png", "c.txt"],
+    )
+    assert out == ["a.png", "b.png", "c.txt"]
+
+
+def test_disambiguate_filenames_in_group_basic_duplicates():
+    """Repeated filename → ``" (N)"`` suffix before the extension.
+
+    Live 2026-05-07 NRS regression: dozens of WPs each carried multiple
+    Jira attachments sharing a name (e.g. ``logobottom.gif`` x2). The
+    Rails idempotency check (``LOWER(filename) = ?``) kept the first
+    and silently dropped the rest.
+    """
+    out = AttachmentsMigration.disambiguate_duplicate_filenames_in_group(
+        ["a.png", "a.png", "a.png"],
+    )
+    assert out == ["a.png", "a (2).png", "a (3).png"]
+
+
+def test_disambiguate_filenames_in_group_case_insensitive():
+    """Disambiguation must use case-insensitive comparison — Rails's
+    idempotency check uses ``LOWER(filename)``.
+    """
+    out = AttachmentsMigration.disambiguate_duplicate_filenames_in_group(
+        ["IMG.PNG", "img.png", "Img.PNG"],
+    )
+    # The first wins its raw form; subsequent collisions get suffixes
+    # in the input's original casing.
+    assert out[0] == "IMG.PNG"
+    assert "img (2).png" in (n.lower() for n in out)
+    assert "img (3).png" in (n.lower() for n in out)
+
+
+def test_disambiguate_filenames_in_group_no_extension():
+    """Names without an extension still get a suffix appended.
+
+    The ``rpartition('.')`` fallback puts the suffix at the end so the
+    bare ``doc`` becomes ``doc (2)``.
+    """
+    out = AttachmentsMigration.disambiguate_duplicate_filenames_in_group(["doc", "doc"])
+    assert out == ["doc", "doc (2)"]
+
+
+def test_disambiguate_filenames_in_group_avoids_existing_suffix_collision():
+    """If the natural suffix is already taken, fall through to the
+    next available counter.
+
+    Edge case: input ``["a.png", "a (2).png", "a.png"]`` — the second
+    is already disambiguated, so the third must skip ``(2)`` and use
+    ``(3)``.
+    """
+    out = AttachmentsMigration.disambiguate_duplicate_filenames_in_group(
+        ["a.png", "a (2).png", "a.png"],
+    )
+    assert out[0] == "a.png"
+    assert out[1] == "a (2).png"
+    assert out[2] == "a (3).png", out
+
+
+def test_disambiguate_per_wp_only(monkeypatch: pytest.MonkeyPatch):
+    """``_disambiguate_duplicate_filenames`` only renames within the
+    same ``work_package_id``. Two ops with the same filename for
+    different WPs both keep their original names — Rails's
+    idempotency is per-WP, so cross-WP "collisions" aren't real.
+    """
+    op = DummyOp()
+    mig = AttachmentsMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    ops = [
+        {"work_package_id": 1, "filename": "a.png", "jira_key": "K-1", "container_path": "/x1"},
+        {"work_package_id": 2, "filename": "a.png", "jira_key": "K-2", "container_path": "/x2"},
+        {"work_package_id": 1, "filename": "a.png", "jira_key": "K-1", "container_path": "/x3"},
+    ]
+    out = mig._disambiguate_duplicate_filenames(ops)
+    names = [o["filename"] for o in out]
+    assert names == ["a.png", "a.png", "a (2).png"], names


### PR DESCRIPTION
## Summary
Live 2026-05-07 NRS audit reported **95 still_missing files** predominantly from one collision class: a Jira issue holding multiple attachments with the same filename (e.g. NRS-3363's 13 duplicate-filename pairs == 26 attachments).

Rails's idempotency check (`wp.attachments.where('LOWER(filename) = ?', fname.to_s.downcase)`) keeps the first match and silently drops the rest, so only one copy ever lands in OP.

## Fix
Two-sided so the audit math closes:

1. **Upload side** — `AttachmentsMigration._load` suffix-disambiguates ops that share `(work_package_id, LOWER(filename))` within a batch. Naming matches browsers: `a.png` / `a (2).png` / `a (3).png`. First occurrence keeps its original name.

2. **Audit side** — `AttachmentRecoveryMigration._iter_jira_issues_with_attachments` applies the SAME disambiguation so the Counter math compares apples to apples (without this, Jira side keeps duplicates while OP has suffixed names → phantom missing + phantom extra).

Shared helper `disambiguate_duplicate_filenames_in_group` is a static method on `AttachmentsMigration` so recovery can call it without constructing a full migration instance — same pattern as `compute_wp_lookup_by_jira_key`.

## Test plan
- [x] 6 new unit tests pin: no-op, basic dup, case-insensitive, no-extension, suffix-collision avoidance, per-WP scoping, audit-side parity.
- [x] `pytest tests/unit -q -x` → 1489 passed.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Live re-run on NRS expected: still_missing drops from 95 toward 0; previously-dropped duplicates land as `name (N).ext`.