### PR TITLE
fix(attachments): retry download with double-encoded slashes on HTTP 400

### DIFF
--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -227,36 +227,82 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         """
         return ComponentResult(success=True, extracted=0, data={"attachments": {}})
 
+    @staticmethod
+    def _double_encode_slashes(url: str) -> str | None:
+        """Return the same URL with each ``%2F`` / ``%2C`` in the *path*
+        re-encoded as ``%252F`` / ``%252C``.
+
+        Tomcat (Jira's web server) blocks URLs whose path contains a
+        literal encoded slash (``%2F``) by default — it returns
+        ``HTTP 400 Bad Request`` before the request ever reaches the
+        Jira app. Double-encoding bypasses Tomcat's check: the ``%25``
+        stays a percent literal at Tomcat's layer, and Jira's
+        application then decodes it once to ``%2F`` and parses it as a
+        slash inside the filename — which is what Jira originally
+        produced when generating the URL.
+
+        Live 2026-05-08 NRS audit: the last ``still_missing=1`` was
+        traced here. Returns ``None`` when no transform applies, so
+        callers can short-circuit.
+        """
+        replaced = url.replace("%2F", "%252F").replace("%2C", "%252C")
+        return replaced if replaced != url else None
+
     def _download_attachment(self, url: str, dest_path: Path) -> Path:
         """Download attachment from Jira to dest_path; return local path.
 
         Uses Jira client's authenticated session to download.
         Tests may monkeypatch this to avoid network IO.
+
+        On HTTP 400 with a URL containing ``%2F`` / ``%2C`` in the path,
+        retries once with the slashes/commas re-encoded as
+        ``%252F`` / ``%252C`` to bypass Tomcat's literal-encoded-slash
+        block. See :meth:`_double_encode_slashes`.
         """
-        try:
-            # Use Jira client's authenticated session
+
+        def _fetch(target_url: str) -> None:
             session = getattr(self.jira_client.jira, "_session", None)
             if session is None:
                 import requests
 
-                # Fallback to unauthenticated request (unlikely to work)
                 logger.warning("Jira session not available, attempting unauthenticated download")
-                with requests.get(url, stream=True, timeout=60) as r:
+                with requests.get(target_url, stream=True, timeout=60) as r:
                     r.raise_for_status()
                     with dest_path.open("wb") as f:
                         for chunk in r.iter_content(chunk_size=65536):
                             if chunk:
                                 f.write(chunk)
-            else:
-                # Use authenticated session (don't pass timeout - Jira session already sets it)
-                response = session.get(url, stream=True)
-                response.raise_for_status()
-                with dest_path.open("wb") as f:
-                    for chunk in response.iter_content(chunk_size=65536):
-                        if chunk:
-                            f.write(chunk)
+                return
+            response = session.get(target_url, stream=True)
+            response.raise_for_status()
+            with dest_path.open("wb") as f:
+                for chunk in response.iter_content(chunk_size=65536):
+                    if chunk:
+                        f.write(chunk)
+
+        try:
+            _fetch(url)
         except Exception as e:
-            logger.warning("Attachment download failed for %s: %s", url, e)
+            # Retry with double-encoded slashes/commas if the failure
+            # smells like Tomcat's encoded-slash block. Cheap to attempt
+            # — at most one extra HTTP call per legitimately-failing
+            # download, and the recovery is decisive (no silent loss).
+            retried = False
+            err_text = str(e)
+            if "400" in err_text or "Bad Request" in err_text:
+                fallback = self._double_encode_slashes(url)
+                if fallback:
+                    try:
+                        _fetch(fallback)
+                        retried = True
+                    except Exception as e2:
+                        logger.warning(
+                            "Attachment download failed for %s (also double-encoded retry): %s",
+                            url,
+                            e2,
+                        )
+            if not retried:
+                logger.warning("Attachment download failed for %s: %s", url, e)
         return dest_path
 
     @staticmethod

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -640,6 +640,35 @@ def test_disambiguate_filenames_in_group_avoids_existing_suffix_collision():
     assert out[2] == "a (3).png", out
 
 
+def test_double_encode_slashes_returns_none_when_nothing_to_change():
+    """No ``%2F`` / ``%2C`` in URL → no transform — caller short-circuits."""
+    assert AttachmentsMigration._double_encode_slashes("https://j/secure/attachment/1/foo.png") is None
+
+
+def test_double_encode_slashes_replaces_2f_and_2c():
+    """``%2F`` → ``%252F``, ``%2C`` → ``%252C``.
+
+    Live 2026-05-08 NRS regression: NRS-3127's
+    ``[EXTERNAL] ... 70227341// , INVDE196205.msg`` URL contained
+    ``%2F%2F%2C`` in the path. Tomcat rejects literal encoded
+    slashes; double-encoding bypasses that check.
+    """
+    src = "https://j/secure/attachment/92933/foo%2F%2F%2Cbar.msg"
+    assert AttachmentsMigration._double_encode_slashes(src) == (
+        "https://j/secure/attachment/92933/foo%252F%252F%252Cbar.msg"
+    )
+
+
+def test_double_encode_slashes_preserves_other_query_chars():
+    """The fallback only swaps ``%2F`` and ``%2C`` — other
+    percent-encoded characters in the URL must be left untouched
+    (e.g. ``%5B`` for ``[``, ``%20`` for space).
+    """
+    src = "https://j/x/%5BEXTERNAL%5D+foo%2Fbar%2Cbaz%20qux.msg"
+    out = AttachmentsMigration._double_encode_slashes(src)
+    assert out == "https://j/x/%5BEXTERNAL%5D+foo%252Fbar%252Cbaz%20qux.msg", out
+
+
 def test_disambiguate_per_wp_only(monkeypatch: pytest.MonkeyPatch):
     """``_disambiguate_duplicate_filenames`` only renames within the
     same ``work_package_id``. Two ops with the same filename for


### PR DESCRIPTION
## Summary
Live 2026-05-08 NRS audit traced the LAST remaining `still_missing=1` to a Jira-side **HTTP 400 Bad Request** on a filename containing `/` and `,`. URL: `.../92933/%5BEXTERNAL%5D+Acronis+License+Certificate+for+70227341%2F%2F%2C+...`

## Root cause
Tomcat (Jira's web server) blocks any URL whose path contains a literal encoded slash (`%2F`) by default — the request is rejected before it reaches the Jira application.

## Fix
Double-encode `%2F` → `%252F` and `%2C` → `%252C`. Tomcat sees `%25` (percent literal), forwards the request; Jira's app decodes it once back to `%2F` / `%2C` and reads the literal slash/comma in the filename. Verified end-to-end against `https://jira.netresearch.de/secure/attachment/92933/...` — returns the full 234432-byte file with the double-encoded URL.

Implemented as a one-time retry in `_download_attachment`: if the first attempt fails with `400` / `Bad Request`, swap the chars and try once more. At most one extra HTTP call per genuinely-failing download.

## Test plan
- [x] 3 unit tests pin: no-op, `%2F`/`%2C` swap, other percent-chars untouched.
- [x] `pytest tests/unit/test_attachments_migration.py -q` → 20 passed.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Live re-run on NRS expected: `still_missing` drops from 1 to 0 (or matches the natural baseline if more files exist with this URL pattern).