### PR TITLE
fix(audit): make assignee-coverage check source-aware

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -1546,7 +1546,9 @@ def test_low_assignee_coverage_does_not_fail_when_jira_matches() -> None:
             wp_with_status=4082,
             wp_with_priority=4082,
             wp_journal_total=4082,
-            wp_provenance_cfs={k: {"exists": True, "populated": 4082} for k in _baseline_metrics()["wp_provenance_cfs"]},
+            wp_provenance_cfs={
+                k: {"exists": True, "populated": 4082} for k in _baseline_metrics()["wp_provenance_cfs"]
+            },
             jira_assignee_count=12,
         ),
     )
@@ -1572,7 +1574,9 @@ def test_assignee_gap_beyond_tolerance_fails() -> None:
             wp_with_status=1000,
             wp_with_priority=1000,
             wp_journal_total=1000,
-            wp_provenance_cfs={k: {"exists": True, "populated": 1000} for k in _baseline_metrics()["wp_provenance_cfs"]},
+            wp_provenance_cfs={
+                k: {"exists": True, "populated": 1000} for k in _baseline_metrics()["wp_provenance_cfs"]
+            },
             jira_assignee_count=600,  # Jira has 600 — 200 missing in OP
         ),
     )

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -1523,3 +1523,81 @@ def test_zero_wps_short_circuits_before_new_checks() -> None:
     # Single failure about no WPs; not a cascade of NULL-field complaints.
     assert len(failures) == 1
     assert "no work packages" in failures[0].lower()
+
+
+# --- Source-aware assignee heuristic (added 2026-05-08) ---
+
+
+def test_low_assignee_coverage_does_not_fail_when_jira_matches() -> None:
+    """Low coverage that matches the Jira source = NOT a failure.
+
+    Live 2026-05-08 NRS audit: Jira itself reports 12/4082 issues
+    with an assignee. The migration faithfully copied all 12. The
+    old hard 5% threshold flagged this as ``Bug A`` — false positive.
+    """
+    failures, warnings = _classify(
+        _baseline_metrics(
+            wp_total=4082,
+            wp_with_assignee=12,
+            wp_with_subject=4082,
+            wp_with_description=4082,
+            wp_with_author=4082,
+            wp_with_type=4082,
+            wp_with_status=4082,
+            wp_with_priority=4082,
+            wp_journal_total=4082,
+            wp_provenance_cfs={k: {"exists": True, "populated": 4082} for k in _baseline_metrics()["wp_provenance_cfs"]},
+            jira_assignee_count=12,
+        ),
+    )
+    assert not any("assignee" in f.lower() for f in failures), failures
+    assert not any("assignee" in w.lower() for w in warnings), warnings
+
+
+def test_assignee_gap_beyond_tolerance_fails() -> None:
+    """If OP undercount diverges from Jira by more than 5% +5
+    issues, that's real loss.
+
+    Pin: source-aware comparison — the threshold scales with the
+    Jira-side count instead of being a fixed percentage.
+    """
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            wp_total=1000,
+            wp_with_assignee=400,  # OP has 400
+            wp_with_subject=1000,
+            wp_with_description=1000,
+            wp_with_author=1000,
+            wp_with_type=1000,
+            wp_with_status=1000,
+            wp_with_priority=1000,
+            wp_journal_total=1000,
+            wp_provenance_cfs={k: {"exists": True, "populated": 1000} for k in _baseline_metrics()["wp_provenance_cfs"]},
+            jira_assignee_count=600,  # Jira has 600 — 200 missing in OP
+        ),
+    )
+    assert any("assignee" in f.lower() and "missing" in f.lower() for f in failures), failures
+
+
+def test_assignee_no_jira_count_low_coverage_warns_only() -> None:
+    """Without a Jira-side count, very low coverage on a non-tiny
+    project surfaces as a warning, never a failure — operators may
+    legitimately run the audit without Jira creds.
+    """
+    failures, warnings = _classify(
+        _baseline_metrics(
+            wp_total=500,
+            wp_with_assignee=2,
+            wp_with_subject=500,
+            wp_with_description=500,
+            wp_with_author=500,
+            wp_with_type=500,
+            wp_with_status=500,
+            wp_with_priority=500,
+            wp_journal_total=500,
+            wp_provenance_cfs={k: {"exists": True, "populated": 500} for k in _baseline_metrics()["wp_provenance_cfs"]},
+            # jira_assignee_count omitted on purpose — simulates absent Jira creds.
+        ),
+    )
+    assert not any("assignee" in f.lower() for f in failures), failures
+    assert any("assignee" in w.lower() for w in warnings), warnings

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -392,13 +392,35 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
     if wp_with_subject < wp_total:
         failures.append(f"WPs missing subject: {wp_total - wp_with_subject}/{wp_total}")
 
-    # Assignee — coverage signal (was the bug at <1% before fix)
+    # Assignee — coverage signal. Compare to Jira source if available;
+    # only flag when OP undercount diverges from Jira by >5% of the
+    # Jira-side count. Jira projects can legitimately have very low
+    # assignee coverage (NRS itself: 12/4082 = 0.3% on the source
+    # side — flagging that as "Bug A" was a false positive).
     wp_with_assignee = _metric_int(metrics, "wp_with_assignee")
-    assignee_pct = (wp_with_assignee / wp_total) * 100
-    if assignee_pct < 5:
-        failures.append(
-            f"Suspiciously low assignee coverage: {wp_with_assignee}/{wp_total} = {assignee_pct:.1f}% (Bug A indicator)"
-        )
+    jira_assignee_count = metrics.get("jira_assignee_count")
+    if isinstance(jira_assignee_count, int):
+        diff = jira_assignee_count - wp_with_assignee
+        # 5% tolerance, plus a small absolute floor so single-digit
+        # absences don't fire on tiny projects.
+        tolerance = max(int(jira_assignee_count * 0.05), 5)
+        if diff > tolerance:
+            failures.append(
+                f"Assignee coverage gap: Jira reports {jira_assignee_count} assigned"
+                f" issues, OP has {wp_with_assignee} ({diff} missing, tol {tolerance})"
+            )
+    else:
+        # No Jira-side count → fall back to a very conservative
+        # heuristic that only fires if assignee coverage is
+        # near-zero AND the project is non-trivially sized
+        # (avoids flagging genuine low-coverage projects when Jira
+        # creds are unavailable).
+        assignee_pct = (wp_with_assignee / wp_total) * 100
+        if wp_total >= 100 and assignee_pct < 1:
+            warnings.append(
+                f"Low assignee coverage: {wp_with_assignee}/{wp_total} = {assignee_pct:.1f}%"
+                " (no Jira-side count available for comparison; verify manually)"
+            )
 
     # created_at preservation — if >50% of WPs were created in the last 24h,
     # update_columns isn't sticking (Bug E indicator)
@@ -708,6 +730,40 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
         warnings.append(f"Only {desc_pct:.0f}% of WPs have a description")
 
     return failures, warnings
+
+
+def _fetch_jira_assignee_count(jira_project_key: str) -> int | None:
+    """Best-effort: count Jira issues that have an assignee.
+
+    Returns ``None`` if Jira can't be reached. Lets the assignee
+    coverage classifier compare migrated vs source instead of
+    flagging a fixed threshold — Jira projects can legitimately
+    have low coverage (caught by 2026-05-08 NRS audit:
+    Jira itself reports only 12 of 4082 NRS issues with an
+    assignee, so the migration's 12 isn't a loss).
+    """
+    if not _JIRA_PROJECT_KEY_RE.match(jira_project_key):
+        return None
+    try:
+        from src.infrastructure.jira.jira_client import JiraClient
+    except ImportError as exc:
+        sys.stderr.write(
+            f"[audit] Jira assignee comparison skipped — could not import JiraClient: {exc}\n",
+        )
+        return None
+    try:
+        jira = JiraClient()
+        # ``get_issue_count`` accepts a free-form JQL extension; the
+        # project filter and ``assignee is not EMPTY`` together count
+        # exactly the rows we need to compare against OP's
+        # ``assigned_to_id IS NOT NULL`` count.
+        jql = f'project = "{jira_project_key}" AND assignee is not EMPTY'
+        return int(jira.jira.search_issues(jql, maxResults=0).total)  # type: ignore[attr-defined]
+    except Exception as exc:
+        sys.stderr.write(
+            f"[audit] Jira assignee comparison skipped — {type(exc).__name__}: {exc}\n",
+        )
+        return None
 
 
 def _fetch_jira_issue_count(jira_project_key: str) -> int | None:
@@ -1166,6 +1222,7 @@ def _execute_audit(jira_project_key: str) -> dict[str, Any]:
         metrics["jira_relation_breakdown"] = None
         metrics["jira_relation_count"] = _fetch_jira_relation_count(jira_project_key)
     metrics["jira_watcher_count"] = _fetch_jira_watcher_count(jira_project_key)
+    metrics["jira_assignee_count"] = _fetch_jira_assignee_count(jira_project_key)
     return metrics
 
 


### PR DESCRIPTION
## Summary
Live 2026-05-08 NRS audit fired `Suspiciously low assignee coverage: 12/4082 = 0.3% (Bug A indicator)` — **but the source Jira project itself only has 12 assigneed issues**. The migration copied all 12 faithfully. The hard 5% threshold was a false positive that masked a real signal (a legitimate +338 watcher mismatch that operators should triage first).

## Fix
- New `_fetch_jira_assignee_count` mirrors the existing attachment / watcher fetchers; surfaces as `metrics["jira_assignee_count"]`.
- `_classify` now compares OP's count against the Jira count with `max(5%, 5)` tolerance — flags only real undercount.
- Without a Jira-side count, near-zero coverage on non-trivial projects becomes a **warning**, never a failure.

## Test plan
- [x] 3 new tests pin: matching low coverage = clean; real gap beyond tolerance = failure; absent Jira count + near-zero coverage = warning only.
- [x] `pytest tests/unit/test_audit_migrated_project.py -q` → 97 passed.
- [x] Live `python -m tools.audit_migrated_project NRS` no longer flags assignee — surfaces only the legitimate watcher discrepancy.