### PR TITLE
fix(audit): subtract OP author auto-subscriptions before watcher comparison

### DIFF
--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -59,6 +59,7 @@ def _baseline_metrics(**overrides: Any) -> dict[str, Any]:
         "wp_journal_total": 100,
         "wp_attachment_total": 0,
         "wp_watcher_total": 50,
+        "wp_watcher_author_auto": 0,
         "te_total": 10,
         "te_with_worklog_key": 10,
         "te_hours_sum": 12.5,
@@ -1605,3 +1606,75 @@ def test_assignee_no_jira_count_low_coverage_warns_only() -> None:
     )
     assert not any("assignee" in f.lower() for f in failures), failures
     assert any("assignee" in w.lower() for w in warnings), warnings
+
+
+# --- Watcher author auto-subscription correction (added 2026-05-08) ---
+
+
+def test_watcher_count_subtracts_author_auto_subscriptions() -> None:
+    """OP auto-subscribes a WP's author as a watcher. The audit must
+    subtract these from ``wp_watcher_total`` before comparing to
+    Jira's ``watchCount`` — otherwise the comparison conflates two
+    different effects.
+
+    Live 2026-05-08 NRS audit caught a +338 raw watcher delta that
+    was actually 552 OP author auto-subscriptions masking a -214
+    real undercount. With the correction:
+        op_total=3233, author_auto=552, op_non_author=2681,
+        jira=2895 → delta=-214 → still flags (genuine loss).
+    Without it, the +338 surface delta misled the operator.
+    """
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            wp_total=4082,
+            wp_with_subject=4082,
+            wp_with_description=4082,
+            wp_with_assignee=12,
+            wp_with_author=4082,
+            wp_with_type=4082,
+            wp_with_status=4082,
+            wp_with_priority=4082,
+            wp_journal_total=4082,
+            wp_provenance_cfs={
+                k: {"exists": True, "populated": 4082} for k in _baseline_metrics()["wp_provenance_cfs"]
+            },
+            wp_watcher_total=3233,
+            wp_watcher_author_auto=552,
+            jira_assignee_count=12,
+            jira_watcher_count=2895,
+        ),
+    )
+    watcher_failures = [f for f in failures if "watcher" in f.lower()]
+    assert watcher_failures, failures
+    # The reported numbers must reflect the corrected view (2681 non-author),
+    # not the raw 3233 — so an operator can read the message and act on it.
+    assert "2681" in watcher_failures[0], watcher_failures
+    assert "552" in watcher_failures[0], watcher_failures
+
+
+def test_watcher_count_clean_after_author_subtraction() -> None:
+    """When OP's non-author watcher count matches Jira within
+    tolerance, no failure should fire even if the raw total looks
+    higher because of auto-subscriptions.
+    """
+    failures, _warnings = _classify(
+        _baseline_metrics(
+            wp_total=1000,
+            wp_with_subject=1000,
+            wp_with_description=1000,
+            wp_with_assignee=1000,
+            wp_with_author=1000,
+            wp_with_type=1000,
+            wp_with_status=1000,
+            wp_with_priority=1000,
+            wp_journal_total=1000,
+            wp_provenance_cfs={
+                k: {"exists": True, "populated": 1000} for k in _baseline_metrics()["wp_provenance_cfs"]
+            },
+            wp_watcher_total=600,
+            wp_watcher_author_auto=200,  # 600 - 200 = 400 non-author
+            jira_assignee_count=1000,
+            jira_watcher_count=400,  # matches the non-author count
+        ),
+    )
+    assert not any("watcher" in f.lower() for f in failures), failures

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -308,6 +308,18 @@ def _build_audit_script(jira_project_key: str) -> str:
     'wp_journal_total' => Journal.where(journable_type: 'WorkPackage', journable_id: wp_id_scope).count,
     'wp_attachment_total' => Attachment.where(container_type: 'WorkPackage', container_id: wp_id_scope).count,
     'wp_watcher_total' => Watcher.where(watchable_type: 'WorkPackage', watchable_id: wp_id_scope).count,
+    # OpenProject auto-subscribes a WP's author as a watcher (the
+    # default ``Setting.notification_*`` behaviour). These rows are
+    # not Jira-side watchers and the migration didn't create them —
+    # subtracting them out lets the watcher count comparison
+    # actually compare like-for-like with Jira's ``watchCount``.
+    # NRS audit (2026-05-08): 552 of 3233 OP watchers were author
+    # auto-subscriptions; the +338 "loss" surfaced by the raw count
+    # was actually a -214 undercount masked by them.
+    'wp_watcher_author_auto' => Watcher.where(watchable_type: 'WorkPackage', watchable_id: wp_id_scope)
+      .joins("INNER JOIN work_packages wp ON wp.id = watchers.watchable_id")
+      .where("wp.author_id = watchers.user_id")
+      .count,
     'te_total' => te.count,
     'te_with_worklog_key' => te_with_worklog_key,
     'te_hours_sum' => te.sum(:hours).to_f,
@@ -595,7 +607,17 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
                 "Jira watcher source comparison unavailable — check skipped",
             )
         else:
-            op_watch = _metric_int(metrics, "wp_watcher_total")
+            op_watch_total = _metric_int(metrics, "wp_watcher_total")
+            # Subtract the author auto-subscriptions OP creates by
+            # default — they're not Jira-side watchers and the
+            # migration didn't add them. Without this correction the
+            # comparison conflates two different effects: real Jira
+            # watcher drops (bug class to fix) and OP's intrinsic
+            # auto-subscribe behaviour (out of scope). Live NRS
+            # audit caught a +338 raw delta that was actually
+            # 552 author auto-watchers minus 214 real undercount.
+            author_auto = _metric_int(metrics, "wp_watcher_author_auto")
+            op_watch = op_watch_total - author_auto
             jira_watch_int = int(jira_watch)
             if jira_watch_int == 0:
                 tolerance_ok = op_watch == 0
@@ -606,8 +628,9 @@ def _classify(metrics: dict[str, Any]) -> tuple[list[str], list[str]]:
                 failures.append(
                     f"Jira→OP watcher count mismatch beyond ±5%:"
                     f" Jira reports {jira_watch_int}, OP has {op_watch}"
-                    f" ({op_watch - jira_watch_int:+d}) — watch records dropped"
-                    " or duplicated during migration",
+                    f" non-author watchers (raw {op_watch_total} − {author_auto}"
+                    f" author auto-subscriptions) — net delta"
+                    f" {op_watch - jira_watch_int:+d}",
                 )
 
     # Jira source comparison: relation (issue-link) count, ±5%


### PR DESCRIPTION
## Summary
Live 2026-05-08 NRS audit reported a misleading **+338 watcher count mismatch** (Jira 2895 vs OP 3233). Investigation showed OpenProject auto-subscribes a WP's author as a watcher by default (`Setting.notification_*` machinery), accounting for **552 of the 3233 OP rows**.

Subtracting them out reveals the real shape: 2681 non-author watchers vs 2895 Jira watchers — a **−214 undercount**, the opposite direction the raw delta showed. The audit was conflating two different effects (real migration drops + OP's intrinsic auto-subscribe behaviour) into one misleading sign.

## Fix
- New Ruby metric `wp_watcher_author_auto` counts OP watcher rows where `user_id == author_id`.
- Classifier subtracts it from `wp_watcher_total` before the ±5% comparison.
- Failure message shows both numbers so operators can read it and act: `"OP has 2681 non-author watchers (raw 3233 − 552 author auto-subscriptions) — net delta −214"`.

## Effect on the live NRS audit
Before this PR: `+338 — watch records dropped or duplicated during migration` (operator reads it as "extras", looks the wrong way).
After this PR: `−214 — net delta` (operator now knows real watchers are missing and can chase skip_reasons in the watcher migration).

## Test plan
- [x] 2 new tests pin: corrected delta with both numbers in message; clean state when corrected count matches Jira.
- [x] `pytest tests/unit/test_audit_migrated_project.py -q` → 99 passed.
- [x] `ruff check` + `ruff format --check` clean.
- [x] Live `python -m tools.audit_migrated_project NRS` confirms the corrected message.