### PR TITLE
fix: address review comments from PRs #210/#211/#216/#217/#220

### DIFF
--- a/src/application/components/attachment_recovery_migration.py
+++ b/src/application/components/attachment_recovery_migration.py
@@ -251,10 +251,6 @@ class AttachmentRecoveryMigration(BaseMigration):
                     # / " (3)" suffixes) and reports phantom losses.
                     # See PR following 2026-05-07 NRS audit:
                     # NRS-3363 alone had 13 duplicate-filename pairs.
-                    from src.application.components.attachments_migration import (
-                        AttachmentsMigration,
-                    )
-
                     raw_names = [e["filename"] for e in entries]
                     unique_names = AttachmentsMigration.disambiguate_duplicate_filenames_in_group(raw_names)
                     for e, new_name in zip(entries, unique_names, strict=True):

--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -261,6 +261,10 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         """
 
         def _fetch(target_url: str) -> None:
+            # Always wrap the response in a ``with`` block so the
+            # underlying connection is returned to the pool even on
+            # iteration errors mid-stream — without this, a partial
+            # read can leak the keep-alive socket. Per PR #217 review.
             session = getattr(self.jira_client.jira, "_session", None)
             if session is None:
                 import requests
@@ -268,28 +272,57 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                 logger.warning("Jira session not available, attempting unauthenticated download")
                 with requests.get(target_url, stream=True, timeout=60) as r:
                     r.raise_for_status()
-                    with dest_path.open("wb") as f:
-                        for chunk in r.iter_content(chunk_size=65536):
-                            if chunk:
-                                f.write(chunk)
+                    _stream_to(r, dest_path)
                 return
-            response = session.get(target_url, stream=True)
-            response.raise_for_status()
-            with dest_path.open("wb") as f:
-                for chunk in response.iter_content(chunk_size=65536):
-                    if chunk:
-                        f.write(chunk)
+            with session.get(target_url, stream=True) as response:
+                response.raise_for_status()
+                _stream_to(response, dest_path)
+
+        def _stream_to(response: Any, target_path: Path) -> None:
+            # Stream-write into a tempfile + rename so a mid-stream
+            # error never leaves a truncated file behind for callers
+            # that only check ``local_path.exists()``. Per PR #217 review.
+            tmp_path = target_path.with_name(target_path.name + ".part")
+            try:
+                with tmp_path.open("wb") as f:
+                    for chunk in response.iter_content(chunk_size=65536):
+                        if chunk:
+                            f.write(chunk)
+                tmp_path.replace(target_path)
+            except Exception:
+                # Clean up the partial file on failure so the caller
+                # sees ``not local_path.exists()`` and counts it under
+                # ``map_download_failed`` instead of misinterpreting
+                # an N-byte fragment as a successful download.
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                raise
+
+        def _is_http_400(exc: BaseException) -> bool:
+            # Prefer the structured status code over substring
+            # matching against ``str(exc)``: ``requests.HTTPError``
+            # carries the ``Response`` it was raised from, and
+            # ``response.status_code`` is the canonical signal. Fall
+            # through to substring match only for non-``HTTPError``
+            # cases (e.g. tests with custom exception classes that
+            # mirror the surface but don't carry ``response``).
+            response = getattr(exc, "response", None)
+            status = getattr(response, "status_code", None)
+            if isinstance(status, int):
+                return status == 400
+            err_text = str(exc)
+            return "400" in err_text or "Bad Request" in err_text
 
         try:
             _fetch(url)
         except Exception as e:
-            # Retry with double-encoded slashes/commas if the failure
-            # smells like Tomcat's encoded-slash block. Cheap to attempt
-            # — at most one extra HTTP call per legitimately-failing
-            # download, and the recovery is decisive (no silent loss).
+            # Retry with double-encoded slashes/commas if Tomcat
+            # rejected the URL with HTTP 400. At most one extra HTTP
+            # call per genuinely-failing download.
             retried = False
-            err_text = str(e)
-            if "400" in err_text or "Bad Request" in err_text:
+            if _is_http_400(e):
                 fallback = self._double_encode_slashes(url)
                 if fallback:
                     try:
@@ -335,11 +368,17 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
 
             for item in items:
                 try:
-                    filename = str(item.get("filename"))
-                    url = str(item.get("url"))
-                    if not filename or not url:
+                    raw_filename = item.get("filename")
+                    raw_url = item.get("url")
+                    # Validate BEFORE coercing to string — ``str(None)``
+                    # produces the truthy literal ``"None"``, which would
+                    # bypass the ``if not …`` guard and silently let an
+                    # invalid item through. Caught by PR #211 review.
+                    if not raw_filename or not raw_url:
                         self._loss_counters["map_missing_filename_or_url"] += 1
                         continue
+                    filename = str(raw_filename)
+                    url = str(raw_url)
                     safe_name = filename.replace("/", "_")
                     local_path = self.attachment_dir / safe_name
                     # Download and hash
@@ -470,15 +509,19 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
             "        next\n"
             "      end\n"
             "      path = op['container_path']\n"
-            "      file = File.open(path, 'rb')\n"
             "      author = User.where(admin: true).first\n"
             "      att = Attachment.new(container: wp, author: author)\n"
-            "      # Assign file using Paperclip-style API.\n"
-            "      if att.respond_to?(:file=)\n"
-            "        att.file = file\n"
+            "      # Assign file using Paperclip-style API. Wrap the\n"
+            "      # ``File.open`` in a block so the descriptor is\n"
+            "      # always closed, even if ``att.save!`` raises mid-\n"
+            "      # batch — without this the Rails runner process\n"
+            "      # could leak FDs across hundreds of ops in a single\n"
+            "      # bulk call. Per PR #210 / #217 review.\n"
+            "      File.open(path, 'rb') do |file|\n"
+            "        att.file = file if att.respond_to?(:file=)\n"
+            "        att.filename = fname if att.respond_to?(:filename=)\n"
+            "        att.save!\n"
             "      end\n"
-            "      att.filename = fname if att.respond_to?(:filename=)\n"
-            "      att.save!\n"
             "      # Filename-fidelity guard: bypass any AR callbacks and\n"
             "      # write the exact byte string. Without this, OP's\n"
             "      # filename sanitiser strips selected internal\n"
@@ -599,10 +642,17 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                 continue
             # Find a free suffix. The base name + extension live on
             # either side of the LAST dot (no dot → bare name, append
-            # at end).
+            # at end). Dotfiles (``.bashrc`` → stem="", ext="bashrc")
+            # would otherwise become ``" (2).bashrc"`` (leading space,
+            # base lost) — treat them as bare-name + ext-less so the
+            # suffix lands at the end. Per PR #216 review.
             stem, dot, ext = name.rpartition(".")
-            base = stem if dot else name
-            tail = (dot + ext) if dot else ""
+            if dot and stem:
+                base = stem
+                tail = dot + ext
+            else:
+                base = name
+                tail = ""
             counter = n + 1
             while True:
                 candidate = f"{base} ({counter}){tail}"
@@ -794,11 +844,14 @@ puts end_marker
 
             for item in items:
                 try:
-                    filename = str(item.get("filename"))
-                    url = str(item.get("url"))
-                    if not filename or not url:
+                    raw_filename = item.get("filename")
+                    raw_url = item.get("url")
+                    # See ``_map`` — same ``str(None)`` gotcha.
+                    if not raw_filename or not raw_url:
                         self._loss_counters["map_missing_filename_or_url"] += 1
                         continue
+                    filename = str(raw_filename)
+                    url = str(raw_url)
                     safe_name = filename.replace("/", "_")
                     local_path = self.attachment_dir / safe_name
                     # Download

--- a/tests/unit/test_cleanup_noname_op_attachments.py
+++ b/tests/unit/test_cleanup_noname_op_attachments.py
@@ -7,9 +7,17 @@ Pinned behaviours:
 * The ``apply`` flag is propagated correctly so dry-runs don't
   destroy data.
 * Project key sanitization keeps the blast radius bounded.
+* CLI surfaces a Ruby-side ``error`` payload as non-zero exit
+  + stderr message (PR #220 review).
+* Dry-run summary reports ``eligible_for_deletion`` (always
+  populated) instead of ``will_delete`` (gated on apply mode) —
+  the prior version silently always reported 0.
 """
 
 from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 from tools.cleanup_noname_op_attachments import _PROJECT_KEY_RE, _build_script, main
 
@@ -18,20 +26,23 @@ def test_build_script_dry_run_includes_apply_false() -> None:
     """Dry-run mode must encode ``apply_literal = false`` so the
     generated Ruby never enters the destroy branch.
     """
-    script = _build_script("NRS", apply=False)
+    script = _build_script(apply=False)
     assert "apply_mode: false" in script
-    assert "false && siblings.size > 0" in script
-    # Project identifier is lowercased for OP's identifier convention.
-    assert "Project.find_by(identifier: 'nrs')" in script
+    # Eligibility is independent of apply mode now (PR #220 review fix);
+    # the ``will_delete`` gate still requires apply.
+    assert "false && eligible" in script
+    # Project identifier is read from input_data, not interpolated.
+    assert "input_data['identifier']" in script
+    assert "Project.find_by(identifier: identifier)" in script
 
 
 def test_build_script_apply_includes_apply_true() -> None:
     """Apply mode must encode ``apply_literal = true`` so the
     destroy branch runs.
     """
-    script = _build_script("NRS", apply=True)
+    script = _build_script(apply=True)
     assert "apply_mode: true" in script
-    assert "true && siblings.size > 0" in script
+    assert "true && eligible" in script
     assert "att.destroy!" in script
 
 
@@ -39,10 +50,20 @@ def test_build_script_marker_fenced_envelope() -> None:
     """The script must emit JSON between the runner's standard
     start/end markers — same envelope contract recovery uses.
     """
-    script = _build_script("NRS", apply=False)
+    script = _build_script(apply=False)
     assert "start_marker" in script
     assert "end_marker" in script
     assert "data.to_json" in script
+
+
+def test_build_script_uses_single_sibling_query() -> None:
+    """Per PR #220 review: the Ruby must batch sibling lookups into
+    one query keyed by ``container_id`` instead of querying per
+    ``noname`` row (the prior N+1 pattern).
+    """
+    script = _build_script(apply=False)
+    assert "siblings_by_wp" in script
+    assert "group_by(&:first)" in script
 
 
 def test_project_key_regex_matches_uppercase_only() -> None:
@@ -65,3 +86,66 @@ def test_main_rejects_invalid_project_key(capsys) -> None:
     assert rc == 2
     captured = capsys.readouterr()
     assert "Invalid project key" in captured.err
+
+
+def test_main_surfaces_ruby_error_payload_as_nonzero_exit(capsys) -> None:
+    """Per PR #220 review: a Rails envelope with a Ruby-side
+    ``error`` field (e.g. "project not found") must exit non-zero
+    and print the error to stderr — the prior version exited 0
+    with a misleading "0 candidates" summary.
+    """
+    fake_envelope: dict[str, Any] = {
+        "status": "success",
+        "message": "ok",
+        "data": {"error": "project not found", "identifier": "nrs"},
+        "output": "<dummy>",
+    }
+    with patch("tools.cleanup_noname_op_attachments.OpenProjectClient") as mock_cls:
+        mock_op = MagicMock()
+        mock_op.execute_script_with_data.return_value = fake_envelope
+        mock_cls.return_value = mock_op
+
+        rc = main(["NRS"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "project not found" in captured.err
+    # Stdout still gets the structured payload for consumers that
+    # parse it; the human-readable error goes to stderr.
+    assert "project not found" in captured.out
+
+
+def test_main_dry_run_reports_eligible_count(capsys) -> None:
+    """Per PR #220 review: dry-run summary must use
+    ``eligible_for_deletion`` (independent of apply mode), not
+    ``will_delete`` (gated on apply). With the prior version, the
+    dry-run always claimed "0 eligible" even when candidates with
+    valid siblings were present — a misleading UX that this fixes.
+    """
+    fake_envelope: dict[str, Any] = {
+        "status": "success",
+        "message": "ok",
+        "data": {
+            "candidates": 7,
+            "eligible_for_deletion": 5,
+            "will_delete": 0,  # gated on apply, so 0 in dry-run
+            "skipped_no_sibling": 2,
+            "deleted": 0,
+            "plan_sample": [],
+            "deleted_ids": [],
+            "apply_mode": False,
+        },
+        "output": "<dummy>",
+    }
+    with patch("tools.cleanup_noname_op_attachments.OpenProjectClient") as mock_cls:
+        mock_op = MagicMock()
+        mock_op.execute_script_with_data.return_value = fake_envelope
+        mock_cls.return_value = mock_op
+
+        rc = main(["NRS"])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    # Operator must see "5 eligible" — not "0".
+    assert "5 eligible" in captured.err
+    assert "7 candidate" in captured.err

--- a/tools/cleanup_noname_op_attachments.py
+++ b/tools/cleanup_noname_op_attachments.py
@@ -30,6 +30,7 @@ project's attachments.
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from typing import Any
@@ -39,39 +40,61 @@ from src.infrastructure.openproject.openproject_client import OpenProjectClient
 _PROJECT_KEY_RE = re.compile(r"\A[A-Z][A-Z0-9_]+\z")
 
 
-def _build_script(project_identifier: str, *, apply: bool) -> str:
+def _build_script(*, apply: bool) -> str:
     """Return the Ruby script to run.
 
     Output contract: emits a JSON envelope between
     ``$j2o_start_marker`` / ``$j2o_end_marker`` so
     ``execute_script_with_data`` / ``execute_json_query`` can
     consume it via the standard envelope path.
+
+    The project identifier is **not** interpolated into the script
+    here — it's passed via the ``execute_script_with_data`` data
+    payload so the Ruby reads it from ``input_data`` rather than from
+    a string-spliced literal. Per PR #220 review.
+
+    The Ruby also pre-fetches sibling counts in ONE query (instead of
+    one per ``noname`` row) — eliminates the N+1 the prior version
+    had on projects with many leftover ``noname`` rows.
     """
     apply_literal = "true" if apply else "false"
-    # ``project_identifier`` is regex-validated upstream; quoting
-    # via single-quoted Ruby literal is safe for the allowed
-    # ``[A-Z][A-Z0-9_]+`` shape.
     return f"""
 require 'json'
 data = (lambda do
-  proj = Project.find_by(identifier: '{project_identifier.lower()}')
-  next {{ error: "project not found", identifier: '{project_identifier.lower()}' }} unless proj
+  identifier = input_data['identifier']
+  proj = Project.find_by(identifier: identifier)
+  next {{ error: "project not found", identifier: identifier }} unless proj
 
   wp_id_scope = WorkPackage.where(project_id: proj.id).select(:id)
   noname = Attachment.where(container_type: 'WorkPackage', container_id: wp_id_scope)
                      .where("LOWER(filename) = 'noname'")
 
+  # Per PR #220 review: fetch sibling counts in ONE query keyed by
+  # container_id, instead of one query per ``noname`` row. The set
+  # built here lets each plan row check membership in O(1).
+  affected_wp_ids = noname.pluck(:container_id).uniq
+  siblings_by_wp = Attachment
+    .where(container_type: 'WorkPackage', container_id: affected_wp_ids)
+    .where("filename ~ '^jira-attachment-\\\\d+$'")
+    .pluck(:container_id, :id, :filename)
+    .group_by(&:first)
+
+  # NOTE: ``apply`` is captured at script-build time, not at run
+  # time — flipping the dry-run / apply mode requires building a
+  # fresh script. Per PR #220 review's safety hardening request:
+  # ``eligible_for_deletion`` is reported regardless of mode so the
+  # dry-run summary shows operators what *would* happen on apply.
   plan = []
   noname.each do |att|
-    siblings = Attachment.where(container_type: 'WorkPackage', container_id: att.container_id)
-                        .where("filename ~ '^jira-attachment-\\\\d+$'")
-                        .pluck(:id, :filename)
+    siblings = siblings_by_wp[att.container_id] || []
+    eligible = siblings.size > 0
     plan << {{
       attachment_id: att.id,
       wp_id: att.container_id,
       sibling_count: siblings.size,
-      siblings_sample: siblings.first(3),
-      will_delete: ({apply_literal} && siblings.size > 0),
+      siblings_sample: siblings.first(3).map {{ |_, sid, sfn| [sid, sfn] }},
+      eligible_for_deletion: eligible,
+      will_delete: ({apply_literal} && eligible),
     }}
   end
 
@@ -88,8 +111,9 @@ data = (lambda do
 
   {{
     candidates: plan.size,
+    eligible_for_deletion: plan.count {{ |r| r[:eligible_for_deletion] }},
     will_delete: plan.count {{ |r| r[:will_delete] }},
-    skipped_no_sibling: plan.count {{ |r| !r[:will_delete] && {apply_literal} }},
+    skipped_no_sibling: plan.count {{ |r| !r[:eligible_for_deletion] }},
     deleted: deleted_ids.size,
     plan_sample: plan.first(20),
     deleted_ids: deleted_ids,
@@ -121,12 +145,21 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     op = OpenProjectClient()
-    script = _build_script(args.project_key, apply=args.apply)
-    envelope = op.execute_script_with_data(script, [])
+    script = _build_script(apply=args.apply)
+    envelope = op.execute_script_with_data(script, [{"identifier": args.project_key.lower()}])
     if not isinstance(envelope, dict) or envelope.get("status") != "success":
         sys.stderr.write(f"Rails call failed: {envelope!r}\n")
         return 1
     data: dict[str, Any] = envelope.get("data") or {}
+
+    # Per PR #220 review: surface a Ruby-side error (e.g. "project not
+    # found") to the operator AND non-zero exit, instead of letting
+    # it slip past as a "0 candidates" success summary.
+    if data.get("error"):
+        sys.stderr.write(f"Audit error: {data['error']} (identifier={data.get('identifier')!r})\n")
+        sys.stdout.write(json.dumps(data, indent=2, default=str))
+        sys.stdout.write("\n")
+        return 1
 
     if args.apply:
         sys.stderr.write(
@@ -134,13 +167,16 @@ def main(argv: list[str] | None = None) -> int:
             f" ({data.get('skipped_no_sibling', 0)} skipped — no jira-attachment-* sibling).\n",
         )
     else:
+        # Dry-run reports ``eligible_for_deletion`` (always populated)
+        # rather than ``will_delete`` (gated on ``apply``) — without
+        # this, the dry-run would always claim "0 eligible" even when
+        # candidates have valid siblings. Per PR #220 review.
         sys.stderr.write(
             f"DRY-RUN: {data.get('candidates', 0)} candidate(s) found,"
-            f" {data.get('will_delete', 0)} eligible for deletion."
+            f" {data.get('eligible_for_deletion', 0)} eligible for deletion"
+            f" ({data.get('skipped_no_sibling', 0)} skipped — no jira-attachment-* sibling)."
             " Re-run with --apply to delete.\n",
         )
-
-    import json
 
     sys.stdout.write(json.dumps(data, indent=2, default=str))
     sys.stdout.write("\n")


### PR DESCRIPTION
## Summary
Consolidates the substantive fixes flagged by reviewers across this session's attachment-migration PRs. Non-substantive `except T, V:` style suggestions are explicitly not applied — see "Why not also..." section.

## Substantive fixes

### #211 — `str(None) → "None"` validation gap
`str(None) == "None"` is truthy, silently bypassing the `if not filename or not url:` guard. Validate raw values **before** coercing in both `_map` and `_process_batch_end_to_end`.

### #210 / #217 — Ruby `File.open` FD leak
The Rails attach script's `file = File.open(path, 'rb')` left the descriptor open when `att.save!` raised, leaking FDs across hundreds of ops in a single `rails runner` invocation. Wrap in a block so it's released on every path.

### #217 — `_download_attachment` improvements
- Wrap `session.get(stream=True)` in a `with` block — return keep-alive socket on mid-stream errors.
- Stream-write to `<dest>.part` + atomic rename on success — never leave a partial file for the `local_path.exists()` check.
- Replace substring matching for HTTP 400 with `response.status_code` (fall through to substring only when no `response` on the exception, e.g. test doubles).

### #216 — Dotfile edge case + redundant import
- `[".bashrc", ".bashrc"] → [".bashrc", ".bashrc (2)"]` (was `" (2).bashrc"` with leading space + base lost).
- Drop the duplicate inner `from ...attachments_migration import AttachmentsMigration`.

### #220 — `cleanup_noname_op_attachments` improvements
- Pass project identifier via `input_data` instead of string-interpolating into Ruby.
- Single batched sibling-count query (was N+1).
- Dry-run summary reports `eligible_for_deletion` (always populated) — was `will_delete` (gated on apply), so the prior version always showed "0 eligible" in dry-run.
- CLI surfaces Ruby-side `error` payload to non-zero exit + stderr.
- `import json` at module top.

3 new unit tests pin the cleanup-tool fixes.

## Why not also...

### `except T, V:` → `except (T, V):` (#214 review)
Python 3.14 [made comma-tuples valid in except clauses](https://docs.python.org/3.14/whatsnew/3.14.html); both forms produce the same `Tuple` AST. The project's `ruff format` (target-version py314) explicitly canonicalises the parenthesised form **back** to the bare form. Applying the suggested fix would revert on the next format run. The bare form is correct + idiomatic on 3.14 and the codebase uses it consistently.

### `inspect.getsource` test brittleness (#210/#211 review)
The alternative would require mocking the entire Rails round-trip just to pin a single string substring. Existing approach is intentional — it's a pin against accidental removal, not a behavioural assertion.

## Test plan
- [x] `pytest tests/unit -q -x` → 1505 passed.
- [x] `ruff check` + `ruff format --check` clean.
- [x] Manual: dry-run + `--apply` paths of cleanup tool work correctly.