### PR TITLE
fix: additional review-comment fixes (PR #212/#211/#217/#218/#221)

### DIFF
--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -229,8 +229,19 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
 
     @staticmethod
     def _double_encode_slashes(url: str) -> str | None:
-        """Return the same URL with each ``%2F`` / ``%2C`` in the *path*
-        re-encoded as ``%252F`` / ``%252C``.
+        """Return the same URL with each ``%2F`` / ``%2C`` re-encoded
+        as ``%252F`` / ``%252C``.
+
+        The replace runs over the *whole* URL — for Jira attachment
+        URLs the offending ``%2F`` / ``%2C`` only ever appear inside
+        the filename component of the path (Jira percent-encodes them
+        when building the URL from the attachment metadata), so a
+        plain string replace is safe in practice; if a future caller
+        passes URLs whose query string also contains those encodings,
+        the behaviour will still be correct because the recipient (Jira)
+        decodes them the same way regardless of position. Per PR #217
+        review (the previous docstring claimed "path-only" while the
+        code does a whole-URL replace — clarify rather than narrow).
 
         Tomcat (Jira's web server) blocks URLs whose path contains a
         literal encoded slash (``%2F``) by default — it returns
@@ -571,10 +582,19 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                     data = envelope.get("data") or {}
                     if not isinstance(data, dict):
                         data = {}
-                    results = data.get("results", [])
-                    errors = data.get("errors", [])
+                    # Defensive type validation — a malformed Rails
+                    # response could send back a string/null/dict here,
+                    # which the downstream ``len()`` and iteration
+                    # would crash on without rescue. Per PR #211
+                    # review.
+                    raw_results = data.get("results", [])
+                    raw_errors = data.get("errors", [])
+                    results = raw_results if isinstance(raw_results, list) else []
+                    errors = raw_errors if isinstance(raw_errors, list) else []
                     # Build attachment mapping: {jira_key: {filename: attachment_id}}
                     for r in results:
+                        if not isinstance(r, dict):
+                            continue
                         jira_key = r.get("jira_key")
                         filename = r.get("filename")
                         att_id = r.get("attachment_id")

--- a/tests/unit/test_attachments_migration.py
+++ b/tests/unit/test_attachments_migration.py
@@ -494,7 +494,14 @@ def test_load_logs_sample_when_rails_returns_per_op_errors(
     }
     ex = ComponentResult(success=True, data={"attachments": att_data})
     mp = mig._map(ex)
-    with caplog.at_level(logging.WARNING, logger="src.application.components.attachments_migration"):
+    # ``AttachmentsMigration`` logs via ``from src.config import logger``,
+    # which is the stdlib ``"migration"`` logger configured in
+    # ``src/config/_bootstrap.py:139``. The previous attempt to gate
+    # capture by the module-path name was a no-op (the explicit
+    # ``logger=`` arg only sets the level on the named logger; capture
+    # itself flows through the root logger's handler) — caught by
+    # PR #212 review.
+    with caplog.at_level(logging.WARNING, logger="migration"):
         mig._load(mp)
     joined = " ".join(rec.getMessage() for rec in caplog.records)
     assert "boom-1" in joined and "boom-2" in joined, joined
@@ -659,10 +666,13 @@ def test_double_encode_slashes_replaces_2f_and_2c():
     )
 
 
-def test_double_encode_slashes_preserves_other_query_chars():
+def test_double_encode_slashes_preserves_other_percent_encoded_chars():
     """The fallback only swaps ``%2F`` and ``%2C`` — other
     percent-encoded characters in the URL must be left untouched
-    (e.g. ``%5B`` for ``[``, ``%20`` for space).
+    (e.g. ``%5B`` for ``[``, ``%20`` for space). Per PR #217 review:
+    the URL under test has no actual query string, so the previous
+    name "query_chars" was misleading — this is about preserving
+    other percent-encodings *anywhere* in the URL.
     """
     src = "https://j/x/%5BEXTERNAL%5D+foo%2Fbar%2Cbaz%20qux.msg"
     out = AttachmentsMigration._double_encode_slashes(src)

--- a/tests/unit/test_audit_migrated_project.py
+++ b/tests/unit/test_audit_migrated_project.py
@@ -993,7 +993,8 @@ def test_jira_watcher_count_above_tolerance_is_warning() -> None:
     # Watcher mismatch is a warning, not a failure: count comparison
     # has known noise sources (permission scope on ``watchCount``,
     # author/auto-subscription overlap, cross-project drift) that
-    # prevent exact reconciliation. See ``_WATCHER_TOLERANCE`` docstring.
+    # prevent exact reconciliation. See the comment block above
+    # ``_WATCHER_TOLERANCE`` for the noise-source rationale.
     failures, warnings = _classify(_baseline_metrics(jira_watcher_count=80))
     assert not any("watcher" in f.lower() for f in failures), failures
     assert any("watcher" in w.lower() and "jira" in w.lower() for w in warnings), warnings

--- a/tools/audit_migrated_project.py
+++ b/tools/audit_migrated_project.py
@@ -810,6 +810,13 @@ def _fetch_jira_assignee_count(jira_project_key: str) -> int | None:
     assignee, so the migration's 12 isn't a loss).
     """
     if not _JIRA_PROJECT_KEY_RE.match(jira_project_key):
+        # Mirror the other Jira fetch helpers' behaviour: surface a
+        # warning on stderr so an operator can tell "skipped" from
+        # "buggy". Per PR #218 review.
+        sys.stderr.write(
+            f"[audit] Jira assignee comparison skipped — invalid project key"
+            f" {jira_project_key!r} (expected uppercase Jira key like 'NRS')\n",
+        )
         return None
     try:
         from src.infrastructure.jira.jira_client import JiraClient
@@ -820,16 +827,21 @@ def _fetch_jira_assignee_count(jira_project_key: str) -> int | None:
         return None
     try:
         jira = JiraClient()
-        # ``get_issue_count`` accepts a free-form JQL extension; the
-        # project filter and ``assignee is not EMPTY`` together count
-        # exactly the rows we need to compare against OP's
-        # ``assigned_to_id IS NOT NULL`` count.
+        # Build the JQL directly (the project-key + ``assignee is not
+        # EMPTY`` filter) and read ``.total``. The previous comment
+        # claimed ``get_issue_count`` accepts a free-form JQL
+        # extension — that's wrong; ``get_issue_count`` only takes a
+        # project key. Per PR #218 review.
         jql = f'project = "{jira_project_key}" AND assignee is not EMPTY'
         return int(jira.jira.search_issues(jql, maxResults=0).total)  # type: ignore[attr-defined]
     except Exception as exc:
+        # Surface the same forensic trail the other Jira helpers
+        # provide — stderr line + traceback so operators can tell
+        # "no creds" (expected) from a real bug. Per PR #218 review.
         sys.stderr.write(
             f"[audit] Jira assignee comparison skipped — {type(exc).__name__}: {exc}\n",
         )
+        sys.stderr.write(traceback.format_exc())
         return None
 
 


### PR DESCRIPTION
## Summary
Follow-up to [#222](https://github.com/netresearch/jira-to-openproject/pull/222), addressing additional reviewer feedback that wasn't in the prior PR.

## Fixes
- **#212** — `caplog.at_level(..., logger=…)` was passing the wrong logger name (the module path); the actual logger is `"migration"` per `src/config/_bootstrap.py`. Test still captured logs via the root handler, but the explicit arg was a no-op.
- **#211** — Defensive `isinstance` checks on `data['results']` / `data['errors']` and individual result entries in `_load`. Malformed Rails responses no longer crash on `len()` / iteration.
- **#217** — Clarified `_double_encode_slashes` docstring (whole-URL replace is safe for Jira attachment URLs in practice). Renamed `test_..._preserves_other_query_chars` → `..._preserves_other_percent_encoded_chars` since the URL has no query string.
- **#218** — `_fetch_jira_assignee_count`: stderr warning on invalid project keys, traceback on exceptions (mirrors other Jira helpers); corrected the misleading `get_issue_count` comment.
- **#221** — Test comment said "see `_WATCHER_TOLERANCE` docstring" but the constant has an inline comment block, not a docstring.

## Test plan
- [x] `pytest tests/unit -q -x` passes.
- [x] `ruff check` + `ruff format --check` clean.