### PR TITLE
refactor(attachments): drop dead seen_digests + redundant download try/except

### DIFF
--- a/src/application/components/attachments_migration.py
+++ b/src/application/components/attachments_migration.py
@@ -404,14 +404,17 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         aid = item.get("id") or ""
         safe_name = filename.replace("/", "_")
         local_path = self.attachment_dir / f"{aid}_{safe_name}" if aid else self.attachment_dir / safe_name
-        try:
-            self._download_attachment(url, local_path)
-        except Exception:
-            # ``_download_attachment`` swallows exceptions and logs a
-            # warning, but a bad return path could still raise.
-            # Catching here keeps the per-item loop resilient.
-            self._loss_counters["map_download_failed"] += 1
-            return None
+        # ``_download_attachment`` already swallows transport
+        # exceptions and logs a warning — the next-line ``exists()``
+        # check is the canonical "did the download produce a file"
+        # signal. Adding an outer try/except here would mask
+        # genuine programming errors (e.g., the helper itself
+        # raising on a bug in this module) by lumping them under
+        # ``map_download_failed``; the per-item ``except Exception``
+        # in the *caller* still catches anything truly unexpected
+        # and routes it to ``map_per_item_exception``. Per PR #225
+        # review.
+        self._download_attachment(url, local_path)
         if not local_path.exists():
             self._loss_counters["map_download_failed"] += 1
             return None
@@ -433,7 +436,6 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
         key_to_wp_id = self._wp_lookup_by_jira_key()
 
         ops: list[dict[str, Any]] = []
-        seen_digests: set[str] = set()
 
         for key, items in att_by_key.items():
             wp_id = key_to_wp_id.get(key)
@@ -449,7 +451,6 @@ class AttachmentsMigration(BaseMigration):  # noqa: D101
                     op = self._prepare_op_from_item(item=item, jira_key=key, work_package_id=int(wp_id))
                     if op is None:
                         continue
-                    seen_digests.add(op["digest"])
                     ops.append(op)
                 except Exception:
                     self._loss_counters["map_per_item_exception"] += 1
@@ -918,7 +919,6 @@ puts end_marker
 
         # Download attachments and prepare ops
         ops: list[dict[str, Any]] = []
-        seen_digests: set[str] = set()
 
         for key, items in att_by_key.items():
             # Find work package ID from reverse lookup
@@ -932,7 +932,6 @@ puts end_marker
                     op = self._prepare_op_from_item(item=item, jira_key=key, work_package_id=int(wp_id))
                     if op is None:
                         continue
-                    seen_digests.add(op["digest"])
                     ops.append(op)
                 except Exception:
                     self._loss_counters["map_per_item_exception"] += 1


### PR DESCRIPTION
## Summary
Two cleanups flagged on PR [#225](https://github.com/netresearch/jira-to-openproject/pull/225) review (copilot):

- **`seen_digests` is dead code** — only ever appended to, never consulted in either call site (`_map` and `_process_batch_end_to_end`). Predates #225's refactor; the refactor's diff highlighted it. Removing the unused set.
- **Redundant `try/except` around `_download_attachment`** — `_prepare_op_from_item` wrapped `self._download_attachment(...)` in `try: ... except Exception: map_download_failed += 1; return None`. But `_download_attachment` already swallows transport exceptions internally and the next-line `not local_path.exists()` check is the canonical "did the download produce a file" signal. The outer `except` would have masked genuine programming errors (e.g., a bug in this module) under `map_download_failed`. The per-item `except Exception` in the *caller* still routes truly unexpected errors to `map_per_item_exception`.

Behaviour unchanged on the success path. The download-failure path still increments `map_download_failed` via the `not local_path.exists()` check.

## Test plan
- [x] `pytest tests/unit -q -x` → 1508 passed.
- [x] `ruff check` + `ruff format --check` clean.