### PR TITLE
chore: gitignore Claude/MCP/repowise configs; remove empty src/clients,src/migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,8 +113,11 @@ test_reports/
 # AI Tools - ignore all IDE-specific directories
 .cursor/
 .taskmaster/
+.claude/
 .claude-composer/
+.mcp.json
 .repomix/
+.repowise/
 claudedocs/
 
 # Backup files


### PR DESCRIPTION
## Summary
- gitignore `.claude/`, `.mcp.json`, `.repowise/` — per-developer tooling configs that shouldn't be tracked
- delete empty `src/clients/` and `src/migrations/` directories (only contained stale `__pycache__`); their code lives at `src/infrastructure/` and `src/application/components/` respectively

## Why
First wave of [Cosmic Python audit](https://github.com/netresearch/jira-to-openproject/actions) cleanups. Removes confusion: the Repowise-indexed project CLAUDE.md still names files in these empty dirs as the codebase's biggest hotspots. Re-indexing after merge will refresh that.

## Test plan
- [x] `ruff check src/` → 0 issues
- [x] `mypy src/` → 0 issues
- [ ] CI green