### PR TITLE
refactor(infra): stop reconfiguring logging from infrastructure adapters

### DIFF
--- a/src/infrastructure/jira/decorators.py
+++ b/src/infrastructure/jira/decorators.py
@@ -24,12 +24,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from src.display import configure_logging
+from src.config import logger
 
 if TYPE_CHECKING:
     from jira import Issue
-
-logger = configure_logging("INFO", None)
 
 
 @runtime_checkable

--- a/src/infrastructure/jira/enhanced_jira_client.py
+++ b/src/infrastructure/jira/enhanced_jira_client.py
@@ -22,10 +22,8 @@ import requests
 if TYPE_CHECKING:
     from jira import Issue
 
-from src.display import configure_logging
+from src.config import logger
 from src.infrastructure.jira.jira_client import JiraClient
-
-logger = configure_logging("INFO", None)
 
 
 class EnhancedJiraClient(JiraClient):

--- a/src/infrastructure/jira/jira_client.py
+++ b/src/infrastructure/jira/jira_client.py
@@ -21,7 +21,7 @@ else:
     # At runtime, avoid importing jira to prevent stub issues
     AtlassianJIRAError = Exception  # type: ignore[misc,assignment]
 from src import config
-from src.display import configure_logging
+from src.config import logger
 from src.utils.config_validation import ConfigurationValidationError, SecurityValidator
 from src.utils.performance_optimizer import (
     PerformanceOptimizer,
@@ -31,11 +31,6 @@ from src.utils.rate_limiter import create_jira_rate_limiter
 HTTP_OK = 200
 HTTP_BAD_REQUEST_MIN = 400
 HTTP_NOT_FOUND = 404
-
-try:
-    from src.config import logger
-except Exception:
-    logger = configure_logging("INFO", None)
 
 
 class JiraError(Exception):

--- a/src/infrastructure/openproject/enhanced_openproject_client.py
+++ b/src/infrastructure/openproject/enhanced_openproject_client.py
@@ -27,10 +27,8 @@ from typing import Any
 
 import requests
 
-from src.display import configure_logging
+from src.config import logger
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
-
-logger = configure_logging("INFO", None)
 
 
 class EnhancedOpenProjectClient(OpenProjectClient):

--- a/src/infrastructure/openproject/openproject_client.py
+++ b/src/infrastructure/openproject/openproject_client.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from src import config
-from src.display import configure_logging
+from src.config import logger
 from src.infrastructure.exceptions import (
     ClientConnectionError,
     JsonParseError,
@@ -27,14 +27,6 @@ from src.utils.file_manager import FileManager
 from src.utils.idempotency_decorators import batch_idempotent
 from src.utils.performance_optimizer import PerformanceOptimizer
 from src.utils.rate_limiter import create_openproject_rate_limiter
-
-try:
-    # Prefer shared logger configured at startup
-    from src.config import logger
-except Exception:
-    # Fallback to local configuration if config logger is unavailable
-    logger = configure_logging("INFO", None)
-
 
 # Module-level constants
 BATCH_SIZE_DEFAULT = 50


### PR DESCRIPTION
## Summary

- Five infrastructure adapters were calling `configure_logging()` at module-import time, violating the Cosmic Python dependency-direction rule (finding #2 from the audit): cross-cutting observability initialisation must live in entrypoints/bootstrap, not in adapters that entrypoints depend on.
- Each adapter now imports the already-configured `migration` logger from `src.config` (a `logging.getLogger("migration")` with extended methods registered at config import time and handlers attached lazily by `bootstrap()`).
- The CLI entrypoint (`src/main.py`) and dashboard entrypoint (`src/dashboard/app.py` via FastAPI lifespan) already invoke `bootstrap()` before any infra is instantiated, so by the time these modules emit logs in production the shared logger is fully wired.

### Files changed

- `src/infrastructure/jira/jira_client.py`
- `src/infrastructure/jira/enhanced_jira_client.py`
- `src/infrastructure/jira/decorators.py`
- `src/infrastructure/openproject/openproject_client.py`
- `src/infrastructure/openproject/enhanced_openproject_client.py`

The redundant `try / except / fallback to configure_logging` block in `jira_client.py` and `openproject_client.py` is also removed — it was masking the import-direction issue and is no longer needed once `src.config.logger` is the single source of truth.

## Test plan

- [x] `.venv/bin/ruff check src/` — 0 issues
- [x] `.venv/bin/mypy src/` — 0 issues across 157 source files
- [x] `.venv/bin/pytest tests/unit/ -q` — 1508 passed, 0 failures
- [x] Verified `src/main.py` calls `bootstrap()` before `validate_database_configuration()` and any infra import
- [x] Verified `src/dashboard/app.py` calls `bootstrap()` inside the FastAPI `lifespan` context manager before any client is created