### PR TITLE
chore(arch): enforce Cosmic Python layers via import-linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,24 @@ jobs:
       - name: mypy
         run: uv run mypy
 
+  architecture:
+    name: Architecture (import-linter)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+      - name: Install dev dependencies
+        run: uv sync --frozen --extra dev
+      - name: lint-imports
+        run: uv run lint-imports
+
   test:
     name: Tests (pytest)
     runs-on: ubuntu-latest

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,87 @@
+; Import-Linter contracts enforcing Cosmic Python layered architecture.
+;
+; Layer mapping (from architecture audit finding #7):
+;   models       -> src.domain, src.models
+;   adapters     -> src.infrastructure
+;   services     -> src.application (components + services)
+;   entrypoints  -> src.main, src.dashboard
+;
+; Cross-cutting (intentionally NOT layered):
+;   src.utils, src.config, src.mappings, src.display, src.migration
+;
+; The cross-cutting modules are leaf-level utilities or top-level orchestrators
+; that legitimately need to be imported from any layer; constraining them now
+; would force an unrelated refactor. Revisit once the migration.py god-file is
+; broken up.
+
+[importlinter]
+root_packages =
+    src
+
+; ---------------------------------------------------------------------------
+; Contract 1: Models cannot depend on adapters, services, or entrypoints.
+; The domain/model layer must remain framework-free and pure.
+; ---------------------------------------------------------------------------
+[importlinter:contract:models-isolated]
+name = Models layer must not depend on adapters, services, or entrypoints
+type = forbidden
+source_modules =
+    src.domain
+    src.models
+forbidden_modules =
+    src.infrastructure
+    src.application
+    src.dashboard
+    src.main
+
+; ---------------------------------------------------------------------------
+; Contract 2: Infrastructure cannot depend on application or entrypoints.
+; Adapters provide capabilities upward; they must not call into services.
+; ---------------------------------------------------------------------------
+[importlinter:contract:infra-no-application]
+name = Infrastructure must not depend on services or entrypoints
+type = forbidden
+source_modules =
+    src.infrastructure
+forbidden_modules =
+    src.application
+    src.dashboard
+    src.main
+
+; ---------------------------------------------------------------------------
+; Contract 3: Application cannot depend on dashboard or CLI entrypoints.
+; Services are reusable; they must not know about delivery mechanisms.
+; ---------------------------------------------------------------------------
+[importlinter:contract:app-no-dashboard]
+name = Application services must not depend on entrypoints
+type = forbidden
+source_modules =
+    src.application
+forbidden_modules =
+    src.dashboard
+    src.main
+
+; ---------------------------------------------------------------------------
+; Contract 4: Declarative layered contract (top-down).
+; Higher layers may import from lower layers, never the reverse.
+;
+; Delimiter semantics (per import-linter docs):
+;   "|"  -> peers at the same level that MUST remain independent of each other
+;   ":"  -> peers at the same level that MAY freely import from each other
+;
+; src.dashboard and src.main are the entrypoints; we keep them independent
+; because the FastAPI dashboard and the CLI must not couple to one another.
+;
+; src.domain and src.models legitimately reference each other today
+; (e.g. src.domain.results imports src.models.component_results, and
+; several src.models.* modules import src.domain.ids). Treat them as a
+; non-independent peer pair until the model/domain split is resolved.
+; ---------------------------------------------------------------------------
+[importlinter:contract:layers]
+name = Cosmic Python layered architecture
+type = layers
+layers =
+    src.dashboard | src.main
+    src.application
+    src.infrastructure
+    src.domain : src.models

--- a/.importlinter
+++ b/.importlinter
@@ -19,51 +19,11 @@ root_packages =
     src
 
 ; ---------------------------------------------------------------------------
-; Contract 1: Models cannot depend on adapters, services, or entrypoints.
-; The domain/model layer must remain framework-free and pure.
-; ---------------------------------------------------------------------------
-[importlinter:contract:models-isolated]
-name = Models layer must not depend on adapters, services, or entrypoints
-type = forbidden
-source_modules =
-    src.domain
-    src.models
-forbidden_modules =
-    src.infrastructure
-    src.application
-    src.dashboard
-    src.main
-
-; ---------------------------------------------------------------------------
-; Contract 2: Infrastructure cannot depend on application or entrypoints.
-; Adapters provide capabilities upward; they must not call into services.
-; ---------------------------------------------------------------------------
-[importlinter:contract:infra-no-application]
-name = Infrastructure must not depend on services or entrypoints
-type = forbidden
-source_modules =
-    src.infrastructure
-forbidden_modules =
-    src.application
-    src.dashboard
-    src.main
-
-; ---------------------------------------------------------------------------
-; Contract 3: Application cannot depend on dashboard or CLI entrypoints.
-; Services are reusable; they must not know about delivery mechanisms.
-; ---------------------------------------------------------------------------
-[importlinter:contract:app-no-dashboard]
-name = Application services must not depend on entrypoints
-type = forbidden
-source_modules =
-    src.application
-forbidden_modules =
-    src.dashboard
-    src.main
-
-; ---------------------------------------------------------------------------
-; Contract 4: Declarative layered contract (top-down).
-; Higher layers may import from lower layers, never the reverse.
+; Layered contract (top-down): higher layers may import from lower layers,
+; never the reverse. import-linter's layers contract type implicitly forbids
+; upward imports, so we don't need separate `forbidden` contracts to enforce
+; the same rules (e.g. "models can't import infrastructure" falls out of the
+; bottom→top relationship below).
 ;
 ; Delimiter semantics (per import-linter docs):
 ;   "|"  -> peers at the same level that MUST remain independent of each other

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ local-lint: ## Run linting locally
 	mypy src || uvx mypy src
 
 check-architecture: ## Enforce Cosmic Python layered architecture (import-linter)
-	.venv/bin/lint-imports || uvx --from import-linter lint-imports
+	uv run lint-imports
 
 local-format: ## Format code locally
 	ruff format src tests || uvx ruff format src tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build up down restart logs shell test clean dev status ps exec install lint format type-check pre-commit install-irbrc start-rails attach-rails
+.PHONY: help build up down restart logs shell test clean dev status ps exec install lint format type-check pre-commit install-irbrc start-rails attach-rails check-architecture
 
 # Default target
 help: ## Show this help message
@@ -246,6 +246,9 @@ local-test-live-ssh: ## Run tests locally with live SSH connections
 local-lint: ## Run linting locally
 	ruff check --fix src tests || uvx ruff check --fix src tests
 	mypy src || uvx mypy src
+
+check-architecture: ## Enforce Cosmic Python layered architecture (import-linter)
+	.venv/bin/lint-imports || uvx --from import-linter lint-imports
 
 local-format: ## Format code locally
 	ruff format src tests || uvx ruff format src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ dev = [
     "types-PyYAML>=6.0.12.20260408",
     "types-aiofiles>=25.1.0.20260409",
     "types-requests>=2.33.0.20260408",
+    # Architecture enforcement: see .importlinter for Cosmic Python layer contracts.
+    "import-linter>=2.11,<3",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -375,6 +375,39 @@ wheels = [
 ]
 
 [[package]]
+name = "grimp"
+version = "3.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/46/79764cfb61a3ac80dadae5d94fb10acdb7800e31fecf4113cf3d345e4952/grimp-3.14.tar.gz", hash = "sha256:645fbd835983901042dae4e1b24fde3a89bf7ac152f9272dd17a97e55cb4f871", size = 830882, upload-time = "2025-12-10T17:55:01.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/5f/ee02a3a1237282d324f596a50923bf9d2cb1b1230ef2fef49fb4d3563c2c/grimp-3.14-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3ccf03e65864d6bc7bf1c003c319f5330a7627b3677f31143f11691a088464c2", size = 2177150, upload-time = "2025-12-10T17:53:46.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/64/2a92889e5fc78e8ef5c548e6a5c6fed78b817eeb0253aca586c28108393a/grimp-3.14-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9ecd58fa58a270e7523f8bec9e6452f4fdb9c21e4cd370640829f1e43fa87a69", size = 2109280, upload-time = "2025-12-10T17:53:23.345Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/5d0b9ab54821e7fbdeb02f3919fa2cb8b9f0c3869fa6e4b969a5766f0ffa/grimp-3.14-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d75d1f8f7944978b39b08d870315174f1ffcd5123be6ccff8ce90467ace648a", size = 2283367, upload-time = "2025-12-10T17:52:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/96/a77c40c92faf7500f42ac019ab8de108b04ffe3db8ec8d6f90416d2322ce/grimp-3.14-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6f70bbb1dd6055d08d29e39a78a11c4118c1778b39d17cd8271e18e213524ca7", size = 2237125, upload-time = "2025-12-10T17:52:24.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/3e1483721c83057bff921cf454dd5ff3e661ae1d2e63150a380382d116c2/grimp-3.14-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f21b7c003626c902669dc26ede83a91220cf0a81b51b27128370998c2f247b4", size = 2391735, upload-time = "2025-12-10T17:53:05.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cb/25fad4a174fe672d42f3e5616761a8120a3b03c8e9e2ae3f31159561968a/grimp-3.14-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80d9f056415c936b45561310296374c4319b5df0003da802c84d2830a103792a", size = 2571388, upload-time = "2025-12-10T17:52:39.337Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/456df7f6a765ce3f160eb32a0f64ed0c1c3cd39b518555dde02087f9b6e4/grimp-3.14-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0332963cd63a45863775d4237e59dedf95455e0a1ea50c356be23100c5fc1d7c", size = 2359637, upload-time = "2025-12-10T17:52:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/98/3e5005ef21a4e2243f0da489aba86aaaff0bc11d5240d67113482cba88e0/grimp-3.14-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f4144350d074f2058fe7c89230a26b34296b161f085b0471a692cb2fe27036f", size = 2308335, upload-time = "2025-12-10T17:53:13.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/03/4e055f756946d6f71ab7e9d1f8536a9e476777093dd7a050f40412d1a2b1/grimp-3.14-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e148e67975e92f90a8435b1b4c02180b9a3f3d725b7a188ba63793f1b1e445a0", size = 2463680, upload-time = "2025-12-10T17:53:55.507Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b9/3c76b7c2e1587e4303a6eff6587c2117c3a7efe1b100cd13d8a4a5613572/grimp-3.14-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1093f7770cb5f3ca6f99fb152f9c949381cc0b078dfdfe598c8ab99abaccda3b", size = 2502808, upload-time = "2025-12-10T17:54:25.383Z" },
+    { url = "https://files.pythonhosted.org/packages/20/80/ada10b85ad3125ebedea10256d9c568b6bf28339d2f79d2d196a7b94f633/grimp-3.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a213f45ec69e9c2b28ffd3ba5ab12cc9859da17083ba4dc39317f2083b618111", size = 2504013, upload-time = "2025-12-10T17:54:39.762Z" },
+    { url = "https://files.pythonhosted.org/packages/05/45/7c369f749d50b0ceac23cd6874ca4695cc1359a96091c7010301e5c8b619/grimp-3.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f003ac3f226d2437a49af0b6036f26edba57f8a32d329275dbde1b2b2a00a56", size = 2515043, upload-time = "2025-12-10T17:54:54.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/85135fe83826ce11ae56a340d32a1391b91eed94d25ce7bc318019f735de/grimp-3.14-cp314-cp314-win32.whl", hash = "sha256:eec81be65a18f4b2af014b1e97296cc9ee20d1115529bf70dd7e06f457eac30b", size = 1877509, upload-time = "2025-12-10T17:55:17.062Z" },
+    { url = "https://files.pythonhosted.org/packages/db/61/e4a2234edecb3bb3cff8963bc4ec5cc482a9e3c54f8df0946d7d90003830/grimp-3.14-cp314-cp314-win_amd64.whl", hash = "sha256:cd3bab6164f1d5e313678f0ab4bf45955afe7f5bdb0f2f481014aa9cca7e81ba", size = 2014364, upload-time = "2025-12-10T17:55:08.896Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/3d304443fbf1df4d60c09668846d0c8a605c6c95646226e41d8f5c3254da/grimp-3.14-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1df33de479be4d620f69633d1876858a8e64a79c07907d47cf3aaf896af057", size = 2281385, upload-time = "2025-12-10T17:52:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/13/493e2648dbb83b3fc517ee675e464beb0154551d726053c7982a3138c6a8/grimp-3.14-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07096d4402e9d5a2c59c402ea3d601f4b7f99025f5e32f077468846fc8d3821b", size = 2231470, upload-time = "2025-12-10T17:52:26.104Z" },
+    { url = "https://files.pythonhosted.org/packages/80/84/e772b302385a6b7ec752c88f84ffe35c33d14076245ae27a635aed9c63a2/grimp-3.14-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:712bc28f46b354316af50c469c77953ba3d6cb4166a62b8fb086436a8b05d301", size = 2571579, upload-time = "2025-12-10T17:52:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/5b23aa7b89c5f4f2cfa636cbeaf33e784378a6b0a823d77a3448670dfacc/grimp-3.14-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abe2bbef1cf8e27df636c02f60184319f138dee4f3a949405c21a4b491980397", size = 2356545, upload-time = "2025-12-10T17:52:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/bcf2116f4b1c3939ab35f9cdddd9ca59e953e57e9a0ac0c143deaf9f29cc/grimp-3.14-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2f9ae3fabb7a7a8468ddc96acc84ecabd84f168e7ca508ee94d8f32ea9bd5de2", size = 2461022, upload-time = "2025-12-10T17:53:56.923Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ce/1a076dce6bc22bca4b9ad5d1bbcd7e1023dcf7bf20ea9404c6462d78f049/grimp-3.14-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:efaf11ea73f7f12d847c54a5d6edcbe919e0369dce2d1aabae6c50792e16f816", size = 2498256, upload-time = "2025-12-10T17:54:27.214Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ea/ac735bed202c1c5c019e611b92d3861779e0cfbe2d20fdb0dec94266d248/grimp-3.14-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e089c9ab8aa755ff5af88c55891727783b4eb6b228e7bdf278e17209d954aa1e", size = 2502056, upload-time = "2025-12-10T17:54:41.537Z" },
+    { url = "https://files.pythonhosted.org/packages/80/8f/774ce522de6a7e70fbeceeaeb6fbe502f5dfb8365728fb3bb4cb23463da8/grimp-3.14-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a424ad14d5deb56721ac24ab939747f72ab3d378d42e7d1f038317d33b052b77", size = 2515157, upload-time = "2025-12-10T17:54:55.874Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -427,6 +460,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "import-linter"
+version = "2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "grimp" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/55b697a17bb15c6cb88d97d73716813f5427281527b90f02cc0a600abc6e/import_linter-2.11.tar.gz", hash = "sha256:5abc3394797a54f9bae315e7242dc98715ba485f840ac38c6d3192c370d0085e", size = 1153682, upload-time = "2026-03-06T12:11:38.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/aa/2ed2c89543632ded7196e0d93dcc6c7fe87769e88391a648c4a298ea864a/import_linter-2.11-py3-none-any.whl", hash = "sha256:3dc54cae933bae3430358c30989762b721c77aa99d424f56a08265be0eeaa465", size = 637315, upload-time = "2026-03-06T12:11:36.599Z" },
 ]
 
 [[package]]
@@ -495,6 +543,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "import-linter" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "ruff" },
@@ -523,6 +572,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.5" },
     { name = "fastapi", specifier = ">=0.136.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.28.1" },
+    { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.11,<3" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jira", specifier = ">=3.10.5" },
     { name = "jsonschema", specifier = ">=4.26.0" },


### PR DESCRIPTION
## Summary

Audit finding #7: layer boundaries between domain/models, infrastructure, application services, and entrypoints are currently a gentleman's agreement enforced only by code review. This PR adds [import-linter](https://import-linter.readthedocs.io/) as a CI/CD-ready architecture gate so accidental upward imports break the build instead of leaking into `main`.

## Contracts added (see [`.importlinter`](../blob/chore/add-import-linter-contracts/.importlinter))

| # | Name | Type | What it enforces |
|---|------|------|------------------|
| 1 | `models-isolated` | forbidden | `src.domain`, `src.models` may not import `src.infrastructure`, `src.application`, `src.dashboard`, `src.main`. Keeps the model layer framework- and IO-free. |
| 2 | `infra-no-application` | forbidden | `src.infrastructure` may not import `src.application`, `src.dashboard`, `src.main`. Adapters provide capabilities upward. |
| 3 | `app-no-dashboard` | forbidden | `src.application` may not import `src.dashboard`, `src.main`. Services must not know about delivery mechanisms. |
| 4 | `layers` | layers | Declarative top-down: `dashboard \| main` > `application` > `infrastructure` > `domain : models`. |

### Why `domain : models` (colon, not pipe)

`src.domain` and `src.models` legitimately cross-reference today:
- `src.domain.results` imports `src.models.component_results`
- Several `src.models.*` modules import `src.domain.ids` (the `NewType` ID layer)

The colon `:` delimiter (per import-linter docs) marks them as **non-independent peers** — they sit at the same level and may import each other freely, while still being collectively forbidden from importing the layers above. Revisit once the model/domain split is resolved.

### Cross-cutting modules left un-layered

`src.utils`, `src.config`, `src.mappings`, `src.display`, and `src.migration` are intentionally **not** part of any contract. They are leaf-level utilities or — in `migration.py`'s case — the top-level orchestrator god-file. Layering them now would force an unrelated refactor. Revisit once `migration.py` is broken up.

## Current violations & temporary exceptions

**None.** All four contracts pass on `main` today with **zero `ignore_imports` exceptions**.

The audit predicted a violation from the `src.display` logging-leak in `src.infrastructure.*` (`from src.display import configure_logging` in 9 infrastructure modules). That import does not break any contract because `src.display` is correctly classified as cross-cutting and therefore is not part of any `forbidden_modules` list nor any layer in the layered contract. The parallel `refactor/centralise-logging-init` work can proceed independently.

## Tooling changes

- `pyproject.toml`: add `import-linter>=2.11,<3` to `[project.optional-dependencies] dev`
- `.importlinter`: new INI config at repo root with the four contracts + cross-cutting commentary
- `Makefile`: new `check-architecture` target that runs `.venv/bin/lint-imports` (falls back to `uvx --from import-linter lint-imports` when the venv binary is absent)
- `uv.lock`: regenerated to include `import-linter` and its `grimp` dependency

## Quality gates

| Gate | Result |
|------|--------|
| `.venv/bin/ruff check src/` | All checks passed! |
| `.venv/bin/mypy src/` | Success: no issues found in 157 source files |
| `.venv/bin/pytest tests/unit/ -q` | 1508 passed, 56 warnings |
| `.venv/bin/lint-imports` | 4 kept, 0 broken |

## Test plan

- [ ] CI runs `ruff`, `mypy`, `pytest`, all green
- [ ] Reviewer runs `make check-architecture` locally and sees `4 kept, 0 broken`
- [ ] Reviewer confirms the four contracts read correctly against the current layer mapping in [`src/`](../tree/chore/add-import-linter-contracts/src)
- [ ] Future PRs that introduce an upward import (e.g. `src.application` importing `src.dashboard`) cause `lint-imports` to fail — manual smoke test optional