### PR TITLE
test: backfill unit tests for 7 untested migration components

### DIFF
--- a/tests/unit/test_admin_scheme_migration.py
+++ b/tests/unit/test_admin_scheme_migration.py
@@ -1,0 +1,192 @@
+"""Unit tests for AdminSchemeMigration component.
+
+Covers happy path (user + group role assignment), unmapped role skip,
+group fallback (refresh from OpenProject when mapping is empty), and
+loud-fail behaviour when the OP client raises during user assignment.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.application.components.admin_scheme_migration import AdminSchemeMigration
+
+
+class DummyJira:
+    """Stub of the bits of JiraClient AdminSchemeMigration touches."""
+
+    def __init__(self) -> None:
+        self.roles = {
+            "PROJ": [
+                {
+                    "name": "Administrators",
+                    "actors": [
+                        {"type": "atlassian-user-role-actor", "name": "alice", "accountId": "alice-id"},
+                        {"type": "atlassian-group-role-actor", "name": "devs", "groupName": "devs"},
+                    ],
+                },
+                {
+                    "name": "Unknown Role Here",
+                    "actors": [{"type": "atlassian-user-role-actor", "name": "bob"}],
+                },
+            ],
+        }
+
+    def get_project_roles(self, project_key: str):
+        return self.roles.get(project_key, [])
+
+    def get_project_permission_scheme(self, project_key: str):
+        return {"id": 100, "name": "Default"}
+
+
+class DummyOp:
+    def __init__(self, *, fail_user_assign: bool = False) -> None:
+        self.fail_user_assign = fail_user_assign
+        self.user_calls: list[dict] = []
+        self.group_calls: list[list[dict]] = []
+        self.refresh_groups: list[dict] = []
+
+    def get_roles(self):
+        return [
+            {"id": 3, "name": "Project admin"},
+            {"id": 4, "name": "Project member"},
+            {"id": 5, "name": "Reader"},
+        ]
+
+    def assign_user_roles(self, **kwargs):
+        self.user_calls.append(kwargs)
+        if self.fail_user_assign:
+            return {"success": False, "error": "boom"}
+        return {"success": True}
+
+    def assign_group_roles(self, assignments):
+        self.group_calls.append(assignments)
+        return {"updated": len(assignments), "errors": 0}
+
+    def get_groups(self):
+        return self.refresh_groups
+
+
+@pytest.fixture
+def _mock_mappings(monkeypatch: pytest.MonkeyPatch):
+    """Install DummyMappings via the cfg.mappings proxy seam."""
+    import src.config as cfg
+
+    class DummyMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "project": {"PROJ": {"openproject_id": 11}},
+                "user": {
+                    "alice": {"openproject_id": 21},
+                    "alice-id": {"openproject_id": 21},
+                },
+                "group": {"devs": {"openproject_id": 31}},
+            }
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, value):
+            self._m[name] = value
+
+    monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+
+
+def test_admin_scheme_migration_end_to_end_creates_user_and_group_assignments(
+    _mock_mappings: None,
+) -> None:
+    """Happy path: one user role, one group role, plus an unmapped role skip."""
+    op = DummyOp()
+    mig = AdminSchemeMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+
+    extracted = mig._extract()
+    mapped = mig._map(extracted)
+    result = mig._load(mapped)
+
+    assert extracted.success is True
+    assert extracted.total_count == 1  # one project
+    assert mapped.success is True
+    assert mapped.details["user_assignments"] == 1
+    assert mapped.details["group_assignments"] == 1
+    # The "Unknown Role Here" role and bob's actor (unmapped role) should be skipped.
+    assert mapped.details["skipped"] >= 1
+    assert result.success is True
+    # Group + 1 user assignment counted as "updated"
+    assert result.success_count == 2
+    # Both side-effects were invoked once
+    assert len(op.user_calls) == 1
+    assert op.user_calls[0]["project_id"] == 11
+    assert op.user_calls[0]["user_id"] == 21
+    assert sorted(op.user_calls[0]["role_ids"]) == [3]
+    assert len(op.group_calls) == 1
+
+
+def test_admin_scheme_migration_skips_projects_without_op_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A project with no openproject_id must not produce role data."""
+    import src.config as cfg
+
+    class EmptyProjectMappings:
+        def get_mapping(self, name: str):
+            return {} if name != "project" else {"PROJ": {}}
+
+        def set_mapping(self, name: str, value):
+            return None
+
+    monkeypatch.setattr(cfg, "mappings", EmptyProjectMappings(), raising=False)
+
+    mig = AdminSchemeMigration(jira_client=DummyJira(), op_client=DummyOp())  # type: ignore[arg-type]
+    extracted = mig._extract()
+
+    assert extracted.success is True
+    # Project is filtered out because op mapping is missing.
+    assert extracted.data == {"projects": []}
+
+
+def test_admin_scheme_migration_run_refreshes_group_mapping_when_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run() falls back to op_client.get_groups() when group mapping is empty."""
+    import src.config as cfg
+
+    class GrouplessMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "project": {"PROJ": {"openproject_id": 11}},
+                "user": {"alice": {"openproject_id": 21}, "alice-id": {"openproject_id": 21}},
+                "group": {},
+            }
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, value):
+            self._m[name] = value
+
+    monkeypatch.setattr(cfg, "mappings", GrouplessMappings(), raising=False)
+
+    op = DummyOp()
+    op.refresh_groups = [{"id": 99, "name": "devs"}]
+    mig = AdminSchemeMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+
+    result = mig.run()
+
+    assert result.success is True
+    # Refreshed group mapping picked up the OP-side group.
+    assert "devs" in mig.group_mapping
+
+
+def test_admin_scheme_migration_load_propagates_user_assignment_errors(
+    _mock_mappings: None,
+) -> None:
+    """When OP returns success=False on a user assignment, _load fails loud."""
+    op = DummyOp(fail_user_assign=True)
+    mig = AdminSchemeMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+
+    extracted = mig._extract()
+    mapped = mig._map(extracted)
+    result = mig._load(mapped)
+
+    assert result.success is False
+    assert result.failed_count >= 1

--- a/tests/unit/test_agile_board_migration.py
+++ b/tests/unit/test_agile_board_migration.py
@@ -1,0 +1,182 @@
+"""Unit tests for AgileBoardMigration component.
+
+Covers happy path (board → query, sprint → version), missing
+project-mapping skip, and the closed-sprint state mapping branch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.application.components.agile_board_migration import AgileBoardMigration
+
+
+class DummyJira:
+    def __init__(
+        self,
+        boards: list[dict] | None = None,
+        sprints_by_board: dict[int, list[dict]] | None = None,
+        configurations_by_board: dict[int, dict] | None = None,
+    ) -> None:
+        self._boards = boards if boards is not None else []
+        self._sprints = sprints_by_board or {}
+        self._configs = configurations_by_board or {}
+
+    def get_boards(self):
+        return self._boards
+
+    def get_board_configuration(self, board_id):
+        return self._configs.get(board_id, {})
+
+    def get_board_sprints(self, board_id):
+        return self._sprints.get(board_id, [])
+
+
+class DummyOp:
+    def __init__(self) -> None:
+        self.created_queries: list[dict] = []
+        self.created_versions: list[dict] = []
+
+    def create_or_update_query(self, **payload):
+        self.created_queries.append(payload)
+        return {"success": True, "created": True, "id": 700 + len(self.created_queries)}
+
+    def ensure_project_version(self, **payload):
+        self.created_versions.append(payload)
+        return {"success": True, "created": True, "id": 800 + len(self.created_versions)}
+
+
+@pytest.fixture
+def _mock_mappings(monkeypatch: pytest.MonkeyPatch):
+    import src.config as cfg
+
+    class DummyMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "project": {"PROJ": {"openproject_id": 11}},
+                "sprint": {},
+            }
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, value):
+            self._m[name] = value
+
+    monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+
+
+def test_agile_board_migration_end_to_end_creates_query_and_version(
+    _mock_mappings: None,
+) -> None:
+    """One mapped board → one query; one open sprint → one open version."""
+    boards = [
+        {
+            "id": 1,
+            "name": "Sprint Board",
+            "type": "scrum",
+            "location": {"projectKey": "PROJ"},
+        },
+    ]
+    configs = {
+        1: {
+            "columnConfig": {"columns": [{"statuses": [{"id": "10001"}]}]},
+            "filter": {"query": "project = PROJ"},
+        },
+    }
+    sprints = {
+        1: [
+            {
+                "id": 42,
+                "name": "Sprint 1",
+                "state": "active",
+                "startDate": "2025-01-01",
+                "endDate": "2025-01-14",
+                "goal": "ship it",
+            },
+        ],
+    }
+    op = DummyOp()
+    mig = AgileBoardMigration(
+        jira_client=DummyJira(boards=boards, sprints_by_board=sprints, configurations_by_board=configs),
+        op_client=op,
+    )  # type: ignore[arg-type]
+
+    extracted = mig._extract()
+    mapped = mig._map(extracted)
+    result = mig._load(mapped)
+
+    assert extracted.success is True
+    assert mapped.success is True
+    assert mapped.details["queries"] == 1
+    assert mapped.details["versions"] == 1
+    assert result.success is True
+    # One query + one version created.
+    assert result.details["queries_created"] == 1
+    assert result.details["versions_created"] == 1
+    # Closed status only on `state == 'closed'`; an active sprint must remain "open".
+    assert op.created_versions[0]["status"] == "open"
+
+
+def test_agile_board_migration_skips_unmapped_project_boards_and_sprints(
+    _mock_mappings: None,
+) -> None:
+    """A board / sprint whose projectKey isn't in project_mapping is skipped."""
+    boards = [
+        {"id": 2, "name": "Lonely Board", "type": "kanban", "location": {"projectKey": "MISSING"}},
+    ]
+    sprints = {2: [{"id": 99, "name": "Orphan Sprint", "state": "active"}]}
+    op = DummyOp()
+    mig = AgileBoardMigration(
+        jira_client=DummyJira(boards=boards, sprints_by_board=sprints),
+        op_client=op,
+    )  # type: ignore[arg-type]
+
+    extracted = mig._extract()
+    mapped = mig._map(extracted)
+
+    assert mapped.success is True
+    assert mapped.details["queries"] == 0
+    assert mapped.details["versions"] == 0
+    assert mapped.details["skipped_boards"] == 1
+    assert mapped.details["skipped_sprints"] == 1
+
+
+def test_agile_board_migration_closed_sprint_maps_to_closed_version(
+    _mock_mappings: None,
+) -> None:
+    """state='closed' (case-insensitive) → status='closed' on the version payload."""
+    boards = [{"id": 1, "name": "B", "type": "scrum", "location": {"projectKey": "PROJ"}}]
+    sprints = {1: [{"id": 50, "name": "Done Sprint", "state": "CLOSED"}]}
+    op = DummyOp()
+    mig = AgileBoardMigration(
+        jira_client=DummyJira(boards=boards, sprints_by_board=sprints),
+        op_client=op,
+    )  # type: ignore[arg-type]
+
+    extracted = mig._extract()
+    mapped = mig._map(extracted)
+    result = mig._load(mapped)
+
+    assert result.success is True
+    assert op.created_versions[0]["status"] == "closed"
+
+
+def test_agile_board_migration_handles_jira_failure_gracefully(
+    _mock_mappings: None,
+) -> None:
+    """If get_boards raises, _extract returns success with empty data (matches source)."""
+
+    class BoomJira:
+        def get_boards(self):
+            raise RuntimeError("jira down")
+
+    op = DummyOp()
+    mig = AgileBoardMigration(jira_client=BoomJira(), op_client=op)  # type: ignore[arg-type]
+
+    extracted = mig._extract()
+
+    # Source swallows in _get_current_entities_for_type → returns []
+    # then _extract wraps that in a successful empty payload.
+    assert extracted.success is True
+    assert extracted.data == {"boards": [], "sprints": []}

--- a/tests/unit/test_reporting_migration.py
+++ b/tests/unit/test_reporting_migration.py
@@ -1,0 +1,175 @@
+"""Unit tests for ReportingMigration component.
+
+Covers happy path (filter → query, dashboard → wiki page), dashboard
+without sharePermissions falling back to the reporting wiki project,
+extraction-failure propagation, and load-side error counting when OP
+returns success=False.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.application.components.reporting_migration import ReportingMigration
+from src.models import ComponentResult
+
+
+class DummyJira:
+    def __init__(
+        self,
+        filters: list[dict] | None = None,
+        dashboards: list[dict] | None = None,
+        boom_filters: bool = False,
+    ) -> None:
+        self._filters = filters or []
+        self._dashboards = dashboards or []
+        self._boom_filters = boom_filters
+
+    def get_filters(self):
+        if self._boom_filters:
+            raise RuntimeError("filters api down")
+        return self._filters
+
+    def get_dashboards(self):
+        return self._dashboards
+
+    def get_dashboard_details(self, dash_id: int):
+        # Production callers pass detail through; default to looking up the
+        # matching dashboard from the listing so tests can place metadata
+        # (sharePermissions, gadgets, …) on the listing entries directly.
+        for d in self._dashboards:
+            if d.get("id") == dash_id:
+                return d
+        return {"id": dash_id}
+
+
+class DummyOp:
+    def __init__(self, *, fail_query: bool = False, fail_wiki: bool = False) -> None:
+        self.fail_query = fail_query
+        self.fail_wiki = fail_wiki
+        self.queries: list[dict] = []
+        self.wikis: list[dict] = []
+        self.reporting_calls: list[tuple[str, str]] = []
+
+    def ensure_reporting_project(self, identifier: str, name: str):
+        self.reporting_calls.append((identifier, name))
+        return 555
+
+    def create_or_update_query(self, **payload):
+        self.queries.append(payload)
+        if self.fail_query:
+            return {"success": False, "error": "no"}
+        return {"success": True, "id": 700 + len(self.queries)}
+
+    def create_or_update_wiki_page(self, **payload):
+        self.wikis.append(payload)
+        if self.fail_wiki:
+            return {"success": False, "error": "no"}
+        return {"success": True, "id": 800 + len(self.wikis)}
+
+
+@pytest.fixture
+def _mock_mappings(monkeypatch: pytest.MonkeyPatch):
+    import src.config as cfg
+
+    class DummyMappings:
+        def __init__(self) -> None:
+            self._m = {"project": {"PROJ": {"openproject_id": 11}}}
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, value):
+            self._m[name] = value
+
+    monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+
+
+def test_reporting_migration_end_to_end_creates_query_and_wiki(_mock_mappings: None) -> None:
+    """One filter → one query, one dashboard with PROJ share → one wiki page."""
+    filters = [{"id": 10, "name": "My filter", "jql": "project = PROJ", "owner": {"displayName": "Alice"}}]
+    dashboards = [
+        {
+            "id": 20,
+            "name": "Ops",
+            "sharePermissions": [{"project": {"key": "PROJ"}}],
+            "gadgets": [{"title": "Pie chart"}],
+        },
+    ]
+    op = DummyOp()
+    mig = ReportingMigration(
+        jira_client=DummyJira(filters=filters, dashboards=dashboards),
+        op_client=op,
+    )  # type: ignore[arg-type]
+
+    extracted = mig._extract()
+    mapped = mig._map(extracted)
+    result = mig._load(mapped)
+
+    assert extracted.success is True
+    assert extracted.total_count == 2
+    assert mapped.success is True
+    assert mapped.details["filters"] == 1
+    assert mapped.details["dashboards"] == 1
+    assert result.success is True
+    # One filter-query + one dashboard-wiki = 2 successful artefacts.
+    assert result.success_count == 2
+    # Wiki page got the matched project_id from sharePermissions (11), not the
+    # reporting fallback (555).
+    assert op.wikis[0]["project_id"] == 11
+
+
+def test_reporting_migration_dashboard_without_share_uses_reporting_project(
+    _mock_mappings: None,
+) -> None:
+    """Dashboard with no share + ensure_reporting_project succeeds → falls back to reporting project."""
+    dashboards = [{"id": 30, "name": "Lonely", "sharePermissions": []}]
+    op = DummyOp()
+    mig = ReportingMigration(
+        jira_client=DummyJira(dashboards=dashboards),
+        op_client=op,
+    )  # type: ignore[arg-type]
+
+    extracted = mig._extract()
+    mapped = mig._map(extracted)
+
+    assert mapped.success is True
+    # Reporting project ensured at least once.
+    assert len(op.reporting_calls) == 1
+    # Wiki payload built using fallback reporting project id (555).
+    assert mapped.data["wiki_pages"][0]["project_id"] == 555
+    assert mapped.details["skipped_dashboards"] == 0
+
+
+def test_reporting_migration_map_returns_failure_when_extract_failed(
+    _mock_mappings: None,
+) -> None:
+    """A failed extract result short-circuits the map phase."""
+    op = DummyOp()
+    mig = ReportingMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+
+    failed = ComponentResult(success=False, message="upstream went away")
+    mapped = mig._map(failed)
+
+    assert mapped.success is False
+    assert "extraction failed" in (mapped.message or "").lower()
+
+
+def test_reporting_migration_load_counts_op_failures(_mock_mappings: None) -> None:
+    """When OP returns success=False on query create, _load reflects the failure count."""
+    filters = [{"id": 1, "name": "x", "jql": "project=PROJ"}]
+    dashboards = [{"id": 2, "name": "d", "sharePermissions": [{"project": {"key": "PROJ"}}]}]
+    op = DummyOp(fail_query=True)
+    mig = ReportingMigration(
+        jira_client=DummyJira(filters=filters, dashboards=dashboards),
+        op_client=op,
+    )  # type: ignore[arg-type]
+
+    extracted = mig._extract()
+    mapped = mig._map(extracted)
+    result = mig._load(mapped)
+
+    assert result.success is False
+    assert result.failed_count >= 1
+    # Wiki page still got created in this scenario.
+    assert result.success_count >= 1

--- a/tests/unit/test_tempo_account_migration.py
+++ b/tests/unit/test_tempo_account_migration.py
@@ -1,0 +1,118 @@
+"""Unit tests for TempoAccountMigration component.
+
+This component does not extend BaseMigration; it has standalone helper
+methods (extract_tempo_accounts, extract_openproject_companies,
+create_account_mapping, create_company_in_openproject, migrate_accounts).
+Tests cover happy paths plus error/empty branches.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.application.components import tempo_account_migration as tam
+from src.application.components.tempo_account_migration import TempoAccountMigration
+
+
+@pytest.fixture
+def tempo_mig(tmp_path: Path) -> TempoAccountMigration:
+    """Build a TempoAccountMigration with mocked clients and tmp data dir."""
+    jira = MagicMock()
+    op = MagicMock()
+    mig = TempoAccountMigration(jira_client=jira, op_client=op)
+    # Redirect data writes to tmp_path so json dumps don't pollute repo state.
+    mig.data_dir = tmp_path
+    return mig
+
+
+def test_extract_tempo_accounts_returns_data_on_200(tempo_mig: TempoAccountMigration) -> None:
+    """A 200 response is parsed and the accounts list is cached on self."""
+    fake_accounts = [
+        {"id": 1, "key": "ACCT-1", "name": "Customer A"},
+        {"id": 2, "key": "ACCT-2", "name": "Customer B"},
+    ]
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = fake_accounts
+
+    with patch.object(tam.requests, "get", return_value=fake_resp):
+        # The source references config.migration_config inside requests.get
+        # only as a kwarg default; module-level config is a SimpleNamespace
+        # without that attr by default — patch it for this call path.
+        with patch.object(tam.config, "migration_config", {"ssl_verify": False}, create=True):
+            accounts = tempo_mig.extract_tempo_accounts()
+
+    assert accounts == fake_accounts
+    assert tempo_mig.accounts == fake_accounts
+
+
+def test_extract_tempo_accounts_returns_empty_on_non_200(
+    tempo_mig: TempoAccountMigration,
+) -> None:
+    """A non-200 response yields an empty list rather than raising."""
+    fake_resp = MagicMock()
+    fake_resp.status_code = 500
+    fake_resp.text = "boom"
+
+    with patch.object(tam.requests, "get", return_value=fake_resp):
+        with patch.object(tam.config, "migration_config", {"ssl_verify": False}, create=True):
+            accounts = tempo_mig.extract_tempo_accounts()
+
+    assert accounts == []
+
+
+def test_create_account_mapping_matches_by_name_case_insensitive(
+    tempo_mig: TempoAccountMigration,
+) -> None:
+    """Existing OP companies are matched to Tempo accounts by lowercased name."""
+    tempo_mig.accounts = [
+        {"id": 1, "key": "ACCT-1", "name": "Acme"},
+        {"id": 2, "key": "ACCT-2", "name": "Brand new"},
+    ]
+    tempo_mig.op_companies = [
+        {"id": 100, "name": "ACME"},  # Case differs, must still match.
+    ]
+
+    mapping = tempo_mig.create_account_mapping()
+
+    assert mapping[1]["matched_by"] == "name"
+    assert mapping[1]["openproject_id"] == 100
+    assert mapping[2]["matched_by"] == "none"
+    assert mapping[2]["openproject_id"] is None
+
+
+def test_create_company_in_openproject_dry_run_returns_placeholder(
+    tempo_mig: TempoAccountMigration,
+) -> None:
+    """In dry_run mode no OP call is made; a placeholder dict is returned."""
+    with patch.object(tam.config, "migration_config", {"dry_run": True}, create=True):
+        result = tempo_mig.create_company_in_openproject(
+            {"id": 1, "key": "FOO", "name": "Foo Co"},
+        )
+
+    assert result["id"] is None
+    assert result["name"] == "Foo Co"
+    # No real OP call happened.
+    assert not tempo_mig.op_client.create_company.called
+
+
+def test_create_company_in_openproject_invokes_op_client(
+    tempo_mig: TempoAccountMigration,
+) -> None:
+    """Outside dry_run, the OP client is called with derived identifier."""
+    tempo_mig.op_client.create_company.return_value = {"id": 999, "name": "Foo Co"}
+    with patch.object(tam.config, "migration_config", {"dry_run": False}, create=True):
+        result = tempo_mig.create_company_in_openproject(
+            {"id": 1, "key": "FOO", "name": "Foo Co"},
+        )
+
+    assert result["id"] == 999
+    tempo_mig.op_client.create_company.assert_called_once()
+    kwargs = tempo_mig.op_client.create_company.call_args.kwargs
+    assert kwargs["name"] == "Foo Co"
+    # identifier derived from key, lowercased.
+    assert kwargs["identifier"] == "foo"

--- a/tests/unit/test_time_entry_migration.py
+++ b/tests/unit/test_time_entry_migration.py
@@ -1,0 +1,153 @@
+"""Unit tests for TimeEntryMigration component.
+
+Covers preflight (Rails client missing), the no-mapping skip path, the
+zero-created-with-input gating policy, and successful delegation to
+TimeEntryMigrator.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def _mock_mappings(monkeypatch: pytest.MonkeyPatch):
+    """Install an empty DummyMappings via cfg.mappings (proxy seam)."""
+    import src.config as cfg
+
+    class DummyMappings:
+        def get_mapping(self, name: str):
+            return {}
+
+        def set_mapping(self, name: str, value):
+            return None
+
+    monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+
+
+def _make_mig(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    rails_present: bool = True,
+):
+    """Build a TimeEntryMigration with mocked clients and tmp data dir.
+
+    The TimeEntryMigrator constructor is stubbed so the test does not need
+    to satisfy its full surface — we only care about its
+    ``migrate_time_entries_for_issues`` method, which we override per-test.
+    """
+    from src.application.components import time_entry_migration as tem
+
+    # Patch TimeEntryMigrator so __init__ doesn't probe the OP client.
+    monkeypatch.setattr(tem, "TimeEntryMigrator", MagicMock())
+
+    jira = MagicMock()
+    op = MagicMock()
+    if rails_present:
+        op.rails_client = MagicMock()
+    else:
+        # Explicitly set to None so getattr(..., "rails_client", None) returns None.
+        op.rails_client = None
+
+    mig = tem.TimeEntryMigration(jira_client=jira, op_client=op)
+    mig.data_dir = tmp_path
+    return mig
+
+
+def test_run_fails_loud_when_rails_client_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _mock_mappings: None,
+) -> None:
+    """Rails console is required for OP time entry creation; absence is a hard fail."""
+    mig = _make_mig(tmp_path, monkeypatch, rails_present=False)
+
+    result = mig.run()
+
+    assert result.success is False
+    assert result.details["reason"] == "rails_client_missing"
+
+
+def test_run_skips_with_warning_when_no_migrated_work_packages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _mock_mappings: None,
+) -> None:
+    """No work_package_mapping.json on disk → skipped, success=True (idempotent re-runs)."""
+    mig = _make_mig(tmp_path, monkeypatch, rails_present=True)
+
+    result = mig.run()
+
+    assert result.success is True
+    assert result.details["status"] == "skipped"
+    assert result.details["reason"] == "no_migrated_work_packages"
+
+
+def test_run_zero_created_with_input_fails_loud(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _mock_mappings: None,
+) -> None:
+    """Discovered>0 but migrated==0 → ComponentResult(success=False) per gating policy."""
+    # Seed a mapping file so the loader returns at least one WP.
+    mapping = {
+        "1001": {"jira_key": "PROJ-1", "openproject_id": 5001},
+    }
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+
+    mig = _make_mig(tmp_path, monkeypatch, rails_present=True)
+
+    # Configure the migrator to return discovered>0, migrated==0.
+    mig.time_entry_migrator.migrate_time_entries_for_issues.return_value = {
+        "status": "success",
+        "jira_work_logs": {"discovered": 5},
+        "tempo_time_entries": {"discovered": 0},
+        "total_time_entries": {"migrated": 0, "failed": 0},
+    }
+
+    result = mig.run()
+
+    assert result.success is False
+    assert result.details["reason"] == "zero_created_with_input"
+    assert result.details["total_discovered"] == 5
+
+
+def test_run_returns_success_when_migrator_creates_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _mock_mappings: None,
+) -> None:
+    """Happy path: migrator reports migrated entries → success."""
+    mapping = {"1001": {"jira_key": "PROJ-1", "openproject_id": 5001}}
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+
+    mig = _make_mig(tmp_path, monkeypatch, rails_present=True)
+    mig.time_entry_migrator.migrate_time_entries_for_issues.return_value = {
+        "status": "success",
+        "jira_work_logs": {"discovered": 3, "migrated": 3, "failed": 0},
+        "tempo_time_entries": {"discovered": 0, "migrated": 0, "failed": 0},
+        "total_time_entries": {"migrated": 3, "failed": 0},
+    }
+
+    result = mig.run()
+
+    assert result.success is True
+    assert result.success_count == 3
+    assert result.failed_count == 0
+
+
+def test_get_current_entities_for_type_raises_value_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _mock_mappings: None,
+) -> None:
+    """Transformation-only migration: idempotent workflow is unsupported."""
+    mig = _make_mig(tmp_path, monkeypatch, rails_present=True)
+
+    with pytest.raises(ValueError, match="transformation-only"):
+        mig._get_current_entities_for_type("time_entries")

--- a/tests/unit/test_work_package_content_migration.py
+++ b/tests/unit/test_work_package_content_migration.py
@@ -1,0 +1,170 @@
+"""Unit tests for WorkPackageContentMigration component (Phase 2).
+
+Covers:
+- Hard-fail when work_package_mapping.json is absent.
+- Successful loading of mapping + jira_key→wp_id lookup index build.
+- _convert_jira_links rewrites known Jira keys (the markdown converter
+  produces ``#<wp_id>`` for known keys; unmapped keys are flagged).
+- Skipping legacy bare-int rows that have no recoverable jira_key.
+- Successful end-to-end run() returning success status.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def _mock_mappings(monkeypatch: pytest.MonkeyPatch):
+    import src.config as cfg
+
+    class DummyMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "project": {"PROJ": {"openproject_id": 11}},
+                "user": {"alice": {"openproject_id": 21}},
+                "custom_field": {"customfield_10001": {"openproject_id": 99}},
+            }
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, value):
+            self._m[name] = value
+
+    monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+
+
+def _build_mig(tmp_path: Path):
+    """Construct WorkPackageContentMigration redirected to tmp_path."""
+    from src.application.components.work_package_content_migration import (
+        WorkPackageContentMigration,
+    )
+
+    jira = MagicMock()
+    op = MagicMock()
+    mig = WorkPackageContentMigration(jira_client=jira, op_client=op)
+    # Redirect file paths to tmp_path; need to also re-load now-empty state.
+    mig.data_dir = tmp_path
+    mig.work_package_mapping_file = tmp_path / mig.WORK_PACKAGE_MAPPING_FILE
+    mig.attachment_mapping_file = tmp_path / mig.ATTACHMENT_MAPPING_FILE
+    return mig
+
+
+def test_run_hard_fails_when_mapping_file_missing(
+    tmp_path: Path,
+    _mock_mappings: None,
+) -> None:
+    """No work_package_mapping.json → run() returns ComponentResult(success=False)."""
+    mig = _build_mig(tmp_path)
+    # The constructor already attempted a load; ensure clean state.
+    mig.work_package_mapping = {}
+
+    result = mig.run()
+
+    assert result.success is False
+    assert "skeleton" in (result.error or "").lower()
+
+
+def test_load_work_package_mapping_builds_jira_key_lookup(
+    tmp_path: Path,
+    _mock_mappings: None,
+) -> None:
+    """Dict-shaped rows populate the jira_key → wp_id index used by link rewriting."""
+    mapping = {
+        "1001": {"jira_key": "PROJ-1", "openproject_id": 5001},
+        "1002": {"jira_key": "PROJ-2", "openproject_id": 5002},
+    }
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+
+    mig = _build_mig(tmp_path)
+    # Re-trigger load against the seeded file.
+    assert mig._load_work_package_mapping() is True
+    assert mig.jira_key_to_wp_id == {"PROJ-1": 5001, "PROJ-2": 5002}
+
+
+def test_load_work_package_mapping_skips_bare_int_legacy_rows(
+    tmp_path: Path,
+    _mock_mappings: None,
+) -> None:
+    """Bare-int legacy rows (no recoverable jira_key) must be skipped, not crash."""
+    mapping = {
+        "1001": {"jira_key": "PROJ-1", "openproject_id": 5001},
+        "1002": 9999,  # legacy bare-int row
+    }
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+
+    mig = _build_mig(tmp_path)
+    assert mig._load_work_package_mapping() is True
+    # Bare-int row excluded from the lookup index.
+    assert mig.jira_key_to_wp_id == {"PROJ-1": 5001}
+
+
+def test_convert_jira_links_rewrites_known_keys(
+    tmp_path: Path,
+    _mock_mappings: None,
+) -> None:
+    """Known Jira keys are converted to OP work-package references in the output.
+
+    The markdown converter produces ``#<wp_id>`` (not the literal ``WP#<id>``)
+    for matched keys; unmapped keys are wrapped to flag them as missing. We
+    care that PROJ-1 is *no longer present as a bare key* and that 5001 is
+    embedded in the output — the exact decoration is a converter concern.
+    """
+    mapping = {"1001": {"jira_key": "PROJ-1", "openproject_id": 5001}}
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+
+    mig = _build_mig(tmp_path)
+    mig._load_work_package_mapping()
+    mig._init_markdown_converter()
+
+    text = "See PROJ-1 for details"
+    converted = mig._convert_jira_links(text, jira_key="PROJ-1")
+
+    # PROJ-1 was rewritten — it must not survive verbatim as a bare key in the output.
+    assert "See PROJ-1 for" not in converted
+    # The mapped WP id appears in the converted output.
+    assert "5001" in converted
+
+
+def test_run_returns_success_on_clean_migration(
+    tmp_path: Path,
+    _mock_mappings: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: with a non-empty mapping, run() returns success=True.
+
+    Patches _migrate_content to avoid driving the full Jira+OP pipeline; we
+    only assert the run() wrapper produces the expected ComponentResult shape.
+    """
+    mapping = {"1001": {"jira_key": "PROJ-1", "openproject_id": 5001}}
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+
+    mig = _build_mig(tmp_path)
+    mig._load_work_package_mapping()
+
+    monkeypatch.setattr(
+        mig,
+        "_migrate_content",
+        lambda: {
+            "total_processed": 1,
+            "total_updated": 1,
+            "total_skipped": 0,
+            "total_failed": 0,
+            "descriptions_updated": 1,
+            "custom_fields_updated": 0,
+            "comments_migrated": 0,
+            "watchers_added": 0,
+            "projects": {},
+        },
+    )
+
+    result = mig.run()
+
+    assert result.success is True
+    assert result.details["total_updated"] == 1
+    assert result.details["descriptions_updated"] == 1

--- a/tests/unit/test_work_package_skeleton_migration.py
+++ b/tests/unit/test_work_package_skeleton_migration.py
@@ -1,0 +1,170 @@
+"""Unit tests for WorkPackageSkeletonMigration component (Phase 1).
+
+Covers:
+- Successful save_mapping persists JSON and reports last_save_succeeded=True.
+- _save_mapping returns False on IO failure and exposes the failure flag.
+- _load_existing_mapping picks up a pre-existing mapping for incremental runs.
+- run() post-condition fails loud if save failed despite created skeletons.
+- run() reports success when no skeletons were created (no save attempted).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def _mock_mappings(monkeypatch: pytest.MonkeyPatch):
+    import src.config as cfg
+
+    class DummyMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "project": {"PROJ": {"openproject_id": 11}},
+                "issue_type": {},
+                "issue_type_id": {},
+                "status": {},
+                "user": {},
+                "priority": {},
+            }
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, value):
+            self._m[name] = value
+
+    monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+
+
+def _build_mig(tmp_path: Path):
+    """Construct WorkPackageSkeletonMigration redirected to tmp_path."""
+    from src.application.components.work_package_skeleton_migration import (
+        WorkPackageSkeletonMigration,
+    )
+
+    jira = MagicMock()
+    op = MagicMock()
+    mig = WorkPackageSkeletonMigration(jira_client=jira, op_client=op)
+    mig.data_dir = tmp_path
+    mig.work_package_mapping_file = tmp_path / mig.WORK_PACKAGE_MAPPING_FILE
+    return mig
+
+
+def test_save_mapping_persists_to_disk(tmp_path: Path, _mock_mappings: None) -> None:
+    """_save_mapping writes the in-memory mapping to disk as JSON."""
+    mig = _build_mig(tmp_path)
+    mig.work_package_mapping = {
+        "1001": {"jira_key": "PROJ-1", "openproject_id": 5001, "project_key": "PROJ"},
+    }
+
+    assert mig._save_mapping() is True
+    assert mig._last_save_succeeded is True
+
+    on_disk = json.loads(mig.work_package_mapping_file.read_text())
+    assert on_disk == mig.work_package_mapping
+
+
+def test_save_mapping_records_failure_when_write_fails(
+    tmp_path: Path,
+    _mock_mappings: None,
+) -> None:
+    """A failing open() must flip _last_save_succeeded to False."""
+    mig = _build_mig(tmp_path)
+    # Point the mapping file at a non-existent directory to force a write failure
+    # without touching the production file system.
+    mig.work_package_mapping_file = tmp_path / "no" / "such" / "dir" / "wp_mapping.json"
+    mig.work_package_mapping = {"1001": {"jira_key": "PROJ-1", "openproject_id": 5001}}
+
+    assert mig._save_mapping() is False
+    assert mig._last_save_succeeded is False
+    assert not mig.work_package_mapping_file.exists()
+
+
+def test_load_existing_mapping_for_incremental_run(
+    tmp_path: Path,
+    _mock_mappings: None,
+) -> None:
+    """A pre-existing mapping file is loaded by the constructor for incremental runs."""
+    from src.application.components.work_package_skeleton_migration import (
+        WorkPackageSkeletonMigration,
+    )
+
+    seeded = {"1001": {"jira_key": "PROJ-1", "openproject_id": 5001}}
+    # Need to seed the file at the production data_dir location for the
+    # constructor to find it; do this by patching get_path before construction.
+    import src.config as cfg
+
+    monkeypatch_data_dir = tmp_path / "var_data"
+    monkeypatch_data_dir.mkdir()
+    (monkeypatch_data_dir / "work_package_mapping.json").write_text(json.dumps(seeded))
+
+    original_get_path = cfg.get_path
+    cfg.get_path = lambda key: monkeypatch_data_dir if key == "data" else original_get_path(key)
+    try:
+        mig = WorkPackageSkeletonMigration(jira_client=MagicMock(), op_client=MagicMock())
+    finally:
+        cfg.get_path = original_get_path
+
+    assert mig.work_package_mapping == seeded
+
+
+def test_run_fails_loud_when_save_failed_despite_creations(
+    tmp_path: Path,
+    _mock_mappings: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If _save_mapping recorded a failure but skeletons were created, run() returns failure."""
+    mig = _build_mig(tmp_path)
+
+    # Simulate a successful skeleton creation pipeline that nonetheless ended
+    # with a failed save.
+    mig._last_save_succeeded = False
+    monkeypatch.setattr(
+        mig,
+        "_migrate_skeletons",
+        lambda: {
+            "total_processed": 1,
+            "total_created": 1,
+            "total_skipped": 0,
+            "total_failed": 0,
+            "projects": {"PROJ": {}},
+        },
+    )
+
+    result = mig.run()
+
+    assert result.success is False
+    assert result.error == "work_package_mapping_save_failed"
+
+
+def test_run_succeeds_when_no_skeletons_were_created(
+    tmp_path: Path,
+    _mock_mappings: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No created skeletons → no save expected; run() must still succeed."""
+    mig = _build_mig(tmp_path)
+
+    # Migration ran but produced zero work packages (e.g. all already migrated).
+    monkeypatch.setattr(
+        mig,
+        "_migrate_skeletons",
+        lambda: {
+            "total_processed": 5,
+            "total_created": 0,
+            "total_skipped": 5,
+            "total_failed": 0,
+            "projects": {"PROJ": {"processed": 5, "created": 0, "skipped": 5, "failed": 0}},
+        },
+    )
+
+    result = mig.run()
+
+    assert result.success is True
+    assert result.details["total_created"] == 0
+    assert result.details["total_skipped"] == 5


### PR DESCRIPTION
## Summary

Closes Cosmic Python audit finding #4 — 7 components in `src/application/components/` had zero unit-test coverage. Each gets a focused 3-5 test regression file covering the happy path plus at least one error/edge-case branch.

| Component | Tests | Coverage focus |
|-----------|-------|----------------|
| `admin_scheme_migration` | 4 | user+group role assignment, group refresh fallback, unmapped-project skip, OP failure propagation |
| `agile_board_migration` | 4 | board→query + sprint→version pipeline, missing project skip, closed-state mapping, Jira-side failure tolerance |
| `reporting_migration` | 4 | filter+dashboard happy path, dashboard fallback to reporting project, extract-failure short-circuit, OP failure counting |
| `tempo_account_migration` | 5 | extract on 200/non-200, name-match case insensitivity, dry-run placeholder, op_client invocation |
| `time_entry_migration` | 5 | Rails preflight, no-mapping skip, zero-created-with-input gating, success delegation, transformation-only ValueError |
| `work_package_content_migration` | 5 | mapping-missing hard-fail, jira_key→wp_id index build, bare-int legacy row skip, link rewrite, run() success |
| `work_package_skeleton_migration` | 5 | save persistence, save IO failure, incremental load, save-failed-with-creations hard-fail, zero-creations success |

**Total: 32 new tests.**

Tests follow the established `cfg.mappings` proxy monkeypatch pattern (per `tests/conftest.py` and existing tests like `test_affects_versions_migration.py`). No source code changes.

## Test plan

- [x] `ruff check tests/` passes (0 issues)
- [x] All 32 new tests pass
- [x] Full unit suite passes: 1540 passed, 56 warnings in 298s
- [x] No source code modified — tests only