### PR TITLE
refactor(work-package): extract IssueTransformer (Phase 1 of decomposition)

### DIFF
--- a/src/application/components/work_package_migration.py
+++ b/src/application/components/work_package_migration.py
@@ -423,23 +423,21 @@ class WorkPackageMigration(BaseMigration):
     # (bypassing ``__init__``) and call these delegates directly. To keep
     # those tests working, the transformer is created lazily on first
     # access via the :pyattr:`_transformer` property.
-    #
-    # See ``claudedocs/refactoring/work-package-migration-decomposition-plan.md``.
     # ------------------------------------------------------------------ #
 
     @property
     def _transformer(self) -> IssueTransformer:
         """Lazily-created :class:`IssueTransformer` bound to this owner."""
-        cached = self.__dict__.get("_transformer_cache")
+        cached = getattr(self, "_transformer_cache", None)
         if cached is None:
             cached = IssueTransformer(owner=self)
-            self.__dict__["_transformer_cache"] = cached
+            self._transformer_cache = cached
         return cached
 
     @_transformer.setter
     def _transformer(self, value: IssueTransformer) -> None:
         """Allow ``__init__`` to seed the cached transformer eagerly."""
-        self.__dict__["_transformer_cache"] = value
+        self._transformer_cache = value
 
     def _resolve_journal_author_id(
         self,

--- a/src/application/components/work_package_migration.py
+++ b/src/application/components/work_package_migration.py
@@ -33,6 +33,7 @@ from pydantic import ValidationError
 from jira import Issue
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
+from src.application.transformers.issue_transformer import IssueTransformer
 from src.config import logger
 from src.display import ProgressTracker
 from src.domain.enums import JournalEntryType
@@ -197,6 +198,13 @@ class WorkPackageMigration(BaseMigration):
         self._version_cache: dict[tuple[int, str], int] = {}
         # Current project context for changelog processing (set during issue processing)
         self._current_project_id: int | None = None
+
+        # Phase 1 decomposition: pure mapping methods live on IssueTransformer.
+        # The transformer reads owner attributes lazily (``self._owner.<attr>``)
+        # so post-construction reassignments (e.g. ``markdown_converter`` being
+        # rebuilt by ``_update_markdown_converter_mappings``) remain visible.
+        # See ``claudedocs/refactoring/work-package-migration-decomposition-plan.md``.
+        self._transformer = IssueTransformer(owner=self)
 
         # Logging
         self.logger.debug(
@@ -390,14 +398,48 @@ class WorkPackageMigration(BaseMigration):
 
     # Default fallback user id used when a journal author cannot be resolved
     # from the user mapping. See ``_resolve_journal_author_id`` (BUG #32).
-    _BUG32_FALLBACK_USER_ID = 148941
+    # Kept as a class attribute for backwards compatibility — the canonical
+    # value now lives on :class:`IssueTransformer`.
+    _BUG32_FALLBACK_USER_ID = IssueTransformer._BUG32_FALLBACK_USER_ID
 
     # Probe order for resolving Jira changelog/comment authors against
     # ``self.user_mapping``. Mirrors the multi-key fallback documented in
     # BUG #32 — the user_mapping is augmented with secondary indices on
     # ``name`` / ``displayName`` / ``emailAddress`` (and others) so any of
     # these raw Jira fields will resolve to the same OP user when present.
-    _JOURNAL_AUTHOR_PROBE_KEYS: tuple[str, ...] = ("name", "displayName", "emailAddress")
+    # Kept as a class attribute for backwards compatibility — the canonical
+    # value now lives on :class:`IssueTransformer`.
+    _JOURNAL_AUTHOR_PROBE_KEYS: tuple[str, ...] = IssueTransformer._JOURNAL_AUTHOR_PROBE_KEYS
+
+    # ------------------------------------------------------------------ #
+    # Phase 1 decomposition: thin delegates to :class:`IssueTransformer`.
+    #
+    # The 16 pure-mapping methods listed below were moved verbatim into
+    # :class:`~src.application.transformers.issue_transformer.IssueTransformer`.
+    # The methods that remain on the class are *delegates* — they exist
+    # solely to preserve the public surface used by callers and tests.
+    #
+    # Tests construct migration instances via ``WorkPackageMigration.__new__``
+    # (bypassing ``__init__``) and call these delegates directly. To keep
+    # those tests working, the transformer is created lazily on first
+    # access via the :pyattr:`_transformer` property.
+    #
+    # See ``claudedocs/refactoring/work-package-migration-decomposition-plan.md``.
+    # ------------------------------------------------------------------ #
+
+    @property
+    def _transformer(self) -> IssueTransformer:
+        """Lazily-created :class:`IssueTransformer` bound to this owner."""
+        cached = self.__dict__.get("_transformer_cache")
+        if cached is None:
+            cached = IssueTransformer(owner=self)
+            self.__dict__["_transformer_cache"] = cached
+        return cached
+
+    @_transformer.setter
+    def _transformer(self, value: IssueTransformer) -> None:
+        """Allow ``__init__`` to seed the cached transformer eagerly."""
+        self.__dict__["_transformer_cache"] = value
 
     def _resolve_journal_author_id(
         self,
@@ -405,77 +447,12 @@ class WorkPackageMigration(BaseMigration):
         jira_key: str,
         kind: JournalEntryType,
     ) -> int:
-        """Resolve a journal-entry author to an OpenProject user id.
-
-        Walks ``author_data`` against ``self.user_mapping`` using the
-        canonical probe order in :attr:`_JOURNAL_AUTHOR_PROBE_KEYS` and
-        returns the first matching ``openproject_id``. If no probe key
-        resolves, returns :attr:`_BUG32_FALLBACK_USER_ID` and logs a
-        ``[BUG32]`` warning listing every probe field that was present
-        on ``author_data`` so unresolved authors are diagnosable from
-        production logs.
-
-        Args:
-            author_data: Raw Jira author payload from a comment or
-                changelog entry. Tolerates ``None``/empty inputs by
-                resolving to the fallback user.
-            jira_key: Jira issue key, used purely for log context.
-            kind: Discriminator for the journal entry (``COMMENT`` or
-                ``CHANGELOG``) used to distinguish the warning message
-                between callers.
-
-        Returns:
-            The resolved ``openproject_id`` (int) or the BUG #32
-            fallback user id when the author cannot be resolved.
-
-        """
-        if not isinstance(author_data, dict):
-            author_data = {}
-        for key in self._JOURNAL_AUTHOR_PROBE_KEYS:
-            value = author_data.get(key)
-            if not value:
-                continue
-            user_dict = self.user_mapping.get(value)
-            if not user_dict:
-                continue
-            op_id = user_dict.get("openproject_id")
-            if op_id:
-                self.logger.debug(
-                    f"{jira_key}: Found user via {key}: {value} → {op_id}",
-                )
-                return int(op_id)
-
-        # No probe key resolved — fall back to the BUG #32 admin user.
-        attempted_fields = {k: author_data.get(k) for k in self._JOURNAL_AUTHOR_PROBE_KEYS if k in author_data}
-        fallback_id = self._BUG32_FALLBACK_USER_ID
-        self.logger.warning(
-            f"[BUG32] {jira_key}: User not found in mapping for {kind} (tried: {attempted_fields}), "
-            f"using fallback user {fallback_id}",
-        )
-        return fallback_id
+        """Delegate to :meth:`IssueTransformer.resolve_journal_author_id`."""
+        return self._transformer.resolve_journal_author_id(author_data, jira_key, kind)
 
     def _track_mentioned_users(self, text: str | None, project_id: int) -> None:
-        """Extract mentioned user IDs from text and track them for membership assignment.
-
-        Args:
-            text: Jira markup text that may contain user mentions
-            project_id: OpenProject project ID where mentions were found
-
-        """
-        if not text or not project_id:
-            return
-
-        if not hasattr(self, "markdown_converter") or not self.markdown_converter:
-            return
-
-        try:
-            mentioned_ids = self.markdown_converter.extract_mentioned_user_ids(text)
-            if mentioned_ids:
-                if project_id not in self._mentioned_users_by_project:
-                    self._mentioned_users_by_project[project_id] = set()
-                self._mentioned_users_by_project[project_id].update(mentioned_ids)
-        except Exception as e:
-            self.logger.debug(f"Error extracting mentioned users: {e}")
+        """Delegate to :meth:`IssueTransformer.track_mentioned_users`."""
+        return self._transformer.track_mentioned_users(text, project_id)
 
     def _assign_memberships_for_mentioned_users(self, project_id: int) -> dict[str, Any]:
         """Assign project membership to users who were mentioned in the project.
@@ -617,54 +594,8 @@ class WorkPackageMigration(BaseMigration):
         return None
 
     def _extract_final_workflow(self, jira_issue: Any) -> str | None:
-        """Extract the final/current workflow scheme name from Jira changelog.
-
-        The Jira "Workflow" field in changelog represents workflow scheme changes
-        (not status changes). We extract the most recent "toString" value to get
-        the current workflow scheme name.
-
-        Args:
-            jira_issue: The Jira issue object
-
-        Returns:
-            Final workflow scheme name, or None if not found
-
-        """
-        try:
-            # Access changelog from issue
-            changelog = getattr(jira_issue, "changelog", None)
-            if not changelog:
-                return None
-
-            histories = getattr(changelog, "histories", None)
-            if not histories:
-                return None
-
-            # Find all Workflow field changes, sorted by date (most recent last)
-            workflow_changes = []
-            for history in histories:
-                items = getattr(history, "items", [])
-                for item in items:
-                    field = getattr(item, "field", None) or (item.get("field") if isinstance(item, dict) else None)
-                    if field == "Workflow":
-                        to_string = getattr(item, "toString", None) or (
-                            item.get("toString") if isinstance(item, dict) else None
-                        )
-                        if to_string:
-                            created = getattr(history, "created", "")
-                            workflow_changes.append((created, to_string))
-
-            if workflow_changes:
-                # Sort by timestamp and get the most recent
-                workflow_changes.sort(key=lambda x: x[0])
-                final_workflow = workflow_changes[-1][1]
-                self.logger.debug(f"[WORKFLOW] Extracted final workflow scheme: {final_workflow}")
-                return str(final_workflow)
-
-        except Exception as e:
-            self.logger.debug(f"[WORKFLOW] Error extracting workflow: {e}")
-
-        return None
+        """Delegate to :meth:`IssueTransformer.extract_final_workflow`."""
+        return self._transformer.extract_final_workflow(jira_issue)
 
     def _load_start_date_fields(self) -> list[str]:
         fields = list(self.START_DATE_FIELD_IDS_DEFAULT)
@@ -681,52 +612,8 @@ class WorkPackageMigration(BaseMigration):
 
     @staticmethod
     def _parse_datetime(value: Any) -> datetime | None:
-        """Best-effort parsing for Jira/ISO datetime payloads."""
-        if isinstance(value, datetime):
-            if value.tzinfo:
-                return value.astimezone(UTC)
-            return value.replace(tzinfo=UTC)
-
-        if not isinstance(value, str):
-            return None
-
-        candidate = value.strip()
-        if not candidate:
-            return None
-
-        # Normalize Z suffix to ISO compatible form
-        candidate_iso = candidate.replace("Z", "+00:00")
-        try:
-            parsed = datetime.fromisoformat(candidate_iso)
-            if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=UTC)
-            else:
-                parsed = parsed.astimezone(UTC)
-            return parsed
-        except ValueError:
-            pass
-
-        patterns = [
-            "%Y-%m-%dT%H:%M:%S.%f%z",
-            "%Y-%m-%dT%H:%M:%S%z",
-            "%Y-%m-%d %H:%M:%S.%f%z",
-            "%Y-%m-%d %H:%M:%S%z",
-            "%Y-%m-%dT%H:%M:%S",
-            "%Y-%m-%d %H:%M:%S",
-            "%Y-%m-%d %H:%M",
-            "%Y-%m-%dT%H:%M",
-        ]
-        for pattern in patterns:
-            try:
-                parsed = datetime.strptime(candidate, pattern)
-                if parsed.tzinfo is None:
-                    parsed = parsed.replace(tzinfo=UTC)
-                else:
-                    parsed = parsed.astimezone(UTC)
-                return parsed
-            except ValueError:
-                continue
-        return None
+        """Delegate to :meth:`IssueTransformer.parse_datetime`."""
+        return IssueTransformer.parse_datetime(value)
 
     @staticmethod
     def _ensure_checkpoint_table(conn: sqlite3.Connection) -> None:
@@ -806,29 +693,13 @@ class WorkPackageMigration(BaseMigration):
         return self._parse_datetime(timestamp_value)
 
     def _derive_snapshot_timestamp(self, snapshot: list[dict[str, Any]]) -> datetime | None:
-        """Derive the most recent migration timestamp from existing OpenProject rows."""
-        latest: datetime | None = None
-        for entry in snapshot or []:
-            if not isinstance(entry, dict):
-                continue
-            for key in ("jira_migration_date", "updated_at", "updated_at_utc"):
-                candidate = entry.get(key)
-                parsed = self._parse_datetime(candidate)
-                if parsed and (latest is None or parsed > latest):
-                    latest = parsed
-        return latest
+        """Delegate to :meth:`IssueTransformer.derive_snapshot_timestamp`."""
+        return self._transformer.derive_snapshot_timestamp(snapshot)
 
     @staticmethod
     def _build_key_exclusion_clause(existing_keys: set[str]) -> str | None:
-        """Return a JQL fragment for excluding already-migrated issue keys."""
-        if not existing_keys:
-            return None
-        limited = [key for key in sorted({k.strip() for k in existing_keys if k and k.strip()}) if key][
-            :200
-        ]  # Keep under 8KB URL limit (200 keys × ~10 chars = ~2KB)
-        if not limited:
-            return None
-        return f"key NOT IN ({','.join(limited)})"
+        """Delegate to :meth:`IssueTransformer.build_key_exclusion_clause`."""
+        return IssueTransformer.build_key_exclusion_clause(existing_keys)
 
     def _update_project_checkpoint(
         self,
@@ -3155,436 +3026,34 @@ class WorkPackageMigration(BaseMigration):
         return work_package
 
     def _resolve_start_date(self, issue: Any) -> str | None:
-        """Resolve start date from configured Jira custom fields."""
-        candidates: list[str] = list(self.start_date_fields)
-
-        # jira.Issue style access
-        if hasattr(issue, "fields"):
-            fields_obj = getattr(issue, "fields", None)
-            for field_id in candidates:
-                try:
-                    value = getattr(fields_obj, field_id)
-                except AttributeError:
-                    value = None
-                if value:
-                    normalized = self.enhanced_timestamp_migrator._normalize_timestamp(str(value))
-                    if normalized:
-                        return normalized.split("T", 1)[0]
-
-        # Raw dict fields from jira.Issue
-        raw_fields = {}
-        if hasattr(issue, "raw"):
-            raw_fields = getattr(issue, "raw", {}).get("fields", {})
-        if isinstance(issue, dict):
-            raw_fields = issue.get("fields", issue)
-
-        if isinstance(raw_fields, dict):
-            for field_id in candidates:
-                value = raw_fields.get(field_id)
-                if value:
-                    normalized = self.enhanced_timestamp_migrator._normalize_timestamp(str(value))
-                    if normalized:
-                        return normalized.split("T", 1)[0]
-
-        # Fallback: derive start date from Jira status history
-        history_start = self._resolve_start_date_from_history(issue)
-        if history_start:
-            return history_start
-
-        return None
+        """Delegate to :meth:`IssueTransformer.resolve_start_date`."""
+        return self._transformer.resolve_start_date(issue)
 
     def _resolve_start_date_from_history(self, issue: Any) -> str | None:
-        """Infer start date from the first transition into an 'In Progress' category."""
-        histories = self._extract_changelog_histories(issue)
-        if not histories:
-            return None
-
-        # Sort histories chronologically (oldest first) using their created timestamp
-        normalized_histories: list[tuple[str, Any]] = []
-        for history in histories:
-            created_raw = self._get_attr(history, "created")
-            if not created_raw:
-                continue
-            normalized = self.enhanced_timestamp_migrator._normalize_timestamp(str(created_raw))
-            if not normalized:
-                continue
-            normalized_histories.append((normalized, history))
-
-        normalized_histories.sort(key=lambda pair: pair[0])
-
-        for normalized, history in normalized_histories:
-            items = self._get_attr(history, "items") or []
-            for item in items:
-                field_name = str(self._get_attr(item, "field") or "").lower()
-                if field_name != "status":
-                    continue
-
-                status_id = str(self._get_attr(item, "to") or "").strip()
-                status_name = str(self._get_attr(item, "toString") or "").strip().lower()
-
-                category = {}
-                if status_id and status_id in self.status_category_by_id:
-                    category = self.status_category_by_id[status_id] or {}
-                elif status_name and status_name in self.status_category_by_name:
-                    category = self.status_category_by_name[status_name] or {}
-
-                if not category and status_name:
-                    # Attempt loose lookup by name if exact match missing
-                    category = next(
-                        (val for key, val in self.status_category_by_name.items() if key == status_name),
-                        {},
-                    )
-
-                if self._is_in_progress_category(category):
-                    return normalized.split("T", 1)[0]
-
-        return None
+        """Delegate to :meth:`IssueTransformer.resolve_start_date_from_history`."""
+        return self._transformer.resolve_start_date_from_history(issue)
 
     @staticmethod
     def _get_attr(obj: Any, key: str) -> Any:
-        """Safely fetch attribute/key from Jira objects or dicts."""
-        if isinstance(obj, dict):
-            return obj.get(key)
-        return getattr(obj, key, None)
+        """Delegate to :meth:`IssueTransformer.get_attr`."""
+        return IssueTransformer.get_attr(obj, key)
 
     def _process_changelog_item(self, item: dict[str, Any]) -> dict[str, list[Any]] | None:
-        """Process a single changelog item into OpenProject field changes.
-
-        Bug #28 fix: Transform Jira changelog entries into structured field changes
-        for journal.data instead of text-only comments.
-
-        Args:
-            item: Jira changelog item with 'field', 'fromString', 'toString'
-
-        Returns:
-            Dictionary mapping OpenProject field names to [old_value, new_value] or None
-
-        """
-        field = item.get("field")
-        if not field:
-            return None
-
-        # Field mapping from Jira to OpenProject
-        # BUG #32 FIX (REGRESSION #3): Only map fields that exist in Journal::WorkPackageJournal
-        # BUG #17 FIX: Added timeestimate and timeoriginalestimate mappings
-        # fixVersion: Enabled with on-the-fly version creation
-        field_mappings = {
-            "summary": "subject",
-            "description": "description",
-            "status": "status_id",
-            "assignee": "assigned_to_id",
-            "priority": "priority_id",
-            "issuetype": "type_id",
-            # "resolution": "resolution",  # NOT a valid Journal::WorkPackageJournal attribute  # noqa: ERA001
-            # "labels": "tags",  # NOT a valid Journal::WorkPackageJournal attribute  # noqa: ERA001
-            "Fix Version": "version_id",  # On-the-fly version creation enabled
-            # "component": "category_id",  # Requires category_mapping - falls through to Bug #16 notes for now
-            "reporter": "author_id",
-            # BUG #17 FIX: Time estimate fields (Jira stores in seconds, OpenProject in hours)
-            "timeestimate": "remaining_hours",
-            "timeoriginalestimate": "estimated_hours",
-        }
-
-        # BUG #32 FIX (REGRESSION #3): Skip unmapped fields to prevent invalid Journal::WorkPackageJournal attributes
-        if field not in field_mappings:
-            return None
-
-        op_field = field_mappings[field]
-
-        # Get values from changelog item
-        from_value = item.get("fromString") or item.get("from")
-        to_value = item.get("toString") or item.get("to")
-
-        # Special handling for user fields (assignee, reporter)
-        if field in ["assignee", "reporter"]:
-            # BUG #20 FIX: Use 'from'/'to' (username) not 'fromString'/'toString' (display name)
-            # Jira changelog provides:
-            #   - from/to: username (e.g., "enrico.tischendorf")
-            #   - fromString/toString: display name (e.g., "Enrico Tischendorf")
-            # Our user_mapping is keyed by username, so we must use from/to
-            from_username = item.get("from")
-            to_username = item.get("to")
-
-            # Map usernames to OpenProject IDs
-            from_id = None
-            to_id = None
-
-            if from_username and self.user_mapping:
-                user_dict = self.user_mapping.get(from_username)
-                from_id = user_dict.get("openproject_id") if user_dict else None
-                if not user_dict:
-                    self.logger.debug(f"[BUG20] User not found in mapping: {from_username}")
-
-            if to_username and self.user_mapping:
-                user_dict = self.user_mapping.get(to_username)
-                to_id = user_dict.get("openproject_id") if user_dict else None
-                if not user_dict:
-                    self.logger.debug(f"[BUG20] User not found in mapping: {to_username}")
-
-            # BUG #19 FIX: Skip no-change mappings (from == to, including both None)
-            # This prevents "retracted" phantom journals from operations with no actual change
-            if from_id == to_id:
-                return None
-
-            return {op_field: [from_id, to_id]}
-
-        # BUG #11 FIX: Map Jira IDs to OpenProject IDs for status, issuetype
-        # The progressive state building needs OpenProject integer IDs, not Jira string values
-        if field == "issuetype":
-            # Get Jira type IDs (not string names)
-            from_jira_id = item.get("from")  # e.g., "3" for Task
-            to_jira_id = item.get("to")  # e.g., "10404" for Access
-
-            # Map to OpenProject type IDs
-            from_op_id = None
-            to_op_id = None
-
-            if from_jira_id and self.issue_type_id_mapping:
-                from_op_id = self.issue_type_id_mapping.get(str(from_jira_id))
-            if to_jira_id and self.issue_type_id_mapping:
-                to_op_id = self.issue_type_id_mapping.get(str(to_jira_id))
-
-            # BUG #11 DEBUG: Log type mapping results
-            self.logger.info(
-                f"[BUG11-TYPE] issuetype change: from_jira={from_jira_id} -> from_op={from_op_id}, to_jira={to_jira_id} -> to_op={to_op_id}",
-            )
-
-            # BUG #19 FIX: Skip no-change mappings
-            if from_op_id == to_op_id:
-                return None
-
-            return {op_field: [from_op_id, to_op_id]}
-
-        if field == "status":
-            # Get Jira status IDs (not string names)
-            from_jira_id = item.get("from")  # e.g., "1" for Open
-            to_jira_id = item.get("to")  # e.g., "6" for Closed
-
-            # Map to OpenProject status IDs
-            from_op_id = None
-            to_op_id = None
-
-            if from_jira_id and self.status_mapping:
-                mapping = self.status_mapping.get(str(from_jira_id))
-                from_op_id = mapping.get("openproject_id") if mapping else None
-            if to_jira_id and self.status_mapping:
-                mapping = self.status_mapping.get(str(to_jira_id))
-                to_op_id = mapping.get("openproject_id") if mapping else None
-
-            # BUG #11 DEBUG: Log status mapping results
-            self.logger.info(
-                f"[BUG11-STATUS] status change: from_jira={from_jira_id} -> from_op={from_op_id}, to_jira={to_jira_id} -> to_op={to_op_id}",
-            )
-
-            # BUG #19 FIX: Skip no-change mappings
-            if from_op_id == to_op_id:
-                return None
-
-            return {op_field: [from_op_id, to_op_id]}
-
-        # Handle Fix Version -> version_id with on-the-fly version creation
-        if field == "Fix Version":
-            # Version names are in fromString/toString (like user display names)
-            from_version_name = item.get("fromString")
-            to_version_name = item.get("toString")
-
-            # Map to OpenProject version IDs (create if needed)
-            from_version_id = None
-            to_version_id = None
-
-            if self._current_project_id:
-                if from_version_name:
-                    from_version_id = self._get_or_create_version(from_version_name, self._current_project_id)
-                if to_version_name:
-                    to_version_id = self._get_or_create_version(to_version_name, self._current_project_id)
-
-            self.logger.info(
-                f"[FIXVERSION] project_id={self._current_project_id}, from='{from_version_name}' -> {from_version_id}, to='{to_version_name}' -> {to_version_id}",
-            )
-
-            # Skip no-change mappings
-            if from_version_id == to_version_id:
-                return None
-
-            return {op_field: [from_version_id, to_version_id]}
-
-        # For priority, keep string values for now (mapping not critical for journals)
-        if field == "priority":
-            # BUG #19 FIX: Skip no-change mappings
-            if from_value == to_value:
-                return None
-            return {op_field: [from_value, to_value]}
-
-        # BUG #17 FIX: Handle time estimate fields - convert Jira seconds to OpenProject hours
-        if field in ["timeestimate", "timeoriginalestimate"]:
-            from_seconds = item.get("from")
-            to_seconds = item.get("to")
-
-            def seconds_to_hours(seconds_str: str | None) -> float | None:
-                """Convert Jira time (seconds) to OpenProject hours."""
-                if not seconds_str:
-                    return None
-                try:
-                    seconds = int(seconds_str)
-                    return round(seconds / 3600, 2)  # Convert to hours with 2 decimal places
-                except (
-                    ValueError,
-                    TypeError,
-                ):
-                    return None
-
-            from_hours = seconds_to_hours(from_seconds)
-            to_hours = seconds_to_hours(to_seconds)
-
-            self.logger.info(
-                f"[BUG17-TIME] {field} change: from={from_seconds}s ({from_hours}h) -> to={to_seconds}s ({to_hours}h)",
-            )
-
-            # BUG #19 FIX: Skip no-change mappings
-            if from_hours == to_hours:
-                return None
-
-            return {op_field: [from_hours, to_hours]}
-
-        # Generic field change (subject, description, etc.)
-        # BUG #19 FIX: Skip no-change mappings
-        if from_value == to_value:
-            return None
-        return {op_field: [from_value, to_value]}
+        """Delegate to :meth:`IssueTransformer.process_changelog_item`."""
+        return self._transformer.process_changelog_item(item)
 
     def _extract_changelog_histories(self, issue: Any) -> list[Any]:
-        """Return changelog histories from either jira.Issue or dict payloads."""
-        if hasattr(issue, "changelog") and issue.changelog:
-            histories = getattr(issue.changelog, "histories", None)
-            if histories:
-                return list(histories)
-
-        raw = getattr(issue, "raw", None)
-        if isinstance(raw, dict):
-            histories = raw.get("changelog", {}).get("histories")
-            if isinstance(histories, list):
-                return histories
-
-        if isinstance(issue, dict):
-            histories = issue.get("changelog", {}).get("histories")
-            if isinstance(histories, list):
-                return histories
-
-        return []
+        """Delegate to :meth:`IssueTransformer.extract_changelog_histories`."""
+        return IssueTransformer.extract_changelog_histories(issue)
 
     @staticmethod
     def _is_in_progress_category(category: dict[str, Any]) -> bool:
-        """Return True when the status category represents 'In Progress'."""
-        if not category:
-            return False
-
-        key = str(category.get("key", "")).lower()
-        name = str(category.get("name", "")).lower()
-        cat_id = str(category.get("id", "")).lower()
-
-        in_progress_keys = {"indeterminate", "in_progress", "in-progress"}
-        if key in in_progress_keys:
-            return True
-        if name == "in progress":
-            return True
-        if cat_id == "4":  # Jira default id for In Progress category
-            return True
-        return False
+        """Delegate to :meth:`IssueTransformer.is_in_progress_category`."""
+        return IssueTransformer.is_in_progress_category(category)
 
     def _extract_issue_meta(self, issue: Any) -> dict[str, Any]:
-        """Extract non-AR metadata from a Jira issue for reporting.
-
-        Safe best-effort extraction from either jira.Issue or dict-like payloads.
-        Does not mutate inputs and never raises.
-        """
-        meta: dict[str, Any] = {}
-        try:
-            start_date = self._resolve_start_date(issue)
-            if start_date:
-                meta["start_date"] = start_date
-            # Handle jira.Issue style
-            if hasattr(issue, "key") and hasattr(issue, "fields"):
-                f = getattr(issue, "fields", None)
-                meta["jira_key"] = getattr(issue, "key", None)
-                meta["jira_id"] = getattr(issue, "id", None)
-                if f is not None:
-
-                    def _name(obj: Any) -> Any:
-                        try:
-                            return getattr(obj, "name", None)
-                        except Exception:
-                            return None
-
-                    meta["issuetype_id"] = getattr(getattr(f, "issuetype", None), "id", None)
-                    meta["issuetype_name"] = _name(getattr(f, "issuetype", None))
-                    meta["status_id"] = getattr(getattr(f, "status", None), "id", None)
-                    meta["status_name"] = _name(getattr(f, "status", None))
-                    meta["priority_id"] = getattr(getattr(f, "priority", None), "id", None)
-                    meta["priority_name"] = _name(getattr(f, "priority", None))
-                    meta["reporter"] = getattr(getattr(f, "reporter", None), "name", None)
-                    meta["assignee"] = getattr(getattr(f, "assignee", None), "name", None)
-                    meta["created"] = getattr(f, "created", None)
-                    meta["updated"] = getattr(f, "updated", None)
-                    meta["duedate"] = getattr(f, "duedate", None)
-                    try:
-                        labels = list(getattr(f, "labels", []) or [])
-                    except Exception:
-                        labels = []
-                    meta["labels"] = labels
-                    try:
-                        comps = getattr(f, "components", []) or []
-                        meta["components"] = [getattr(c, "name", None) for c in comps if c]
-                    except Exception:
-                        meta["components"] = []
-                    # Optional relations
-                    try:
-                        parent = getattr(f, "parent", None)
-                        if parent is not None:
-                            meta["parent_key"] = getattr(parent, "key", None)
-                    except Exception:
-                        pass
-            else:
-                # Dict-like payloads (tests / fallback)
-                d = issue or {}
-                fields = d.get("fields") if isinstance(d, dict) else {}
-                meta["jira_key"] = d.get("key") if isinstance(d, dict) else None
-                meta["jira_id"] = d.get("id") if isinstance(d, dict) else None
-
-                def _get(path_keys: list[str]) -> Any:
-                    cur: Any = fields if isinstance(fields, dict) else {}
-                    for k in path_keys:
-                        if not isinstance(cur, dict):
-                            return None
-                        cur = cur.get(k)
-                    return cur
-
-                meta["issuetype_id"] = _get(["issuetype", "id"])
-                meta["issuetype_name"] = _get(["issuetype", "name"])
-                meta["status_id"] = _get(["status", "id"])
-                meta["status_name"] = _get(["status", "name"])
-                meta["priority_id"] = _get(["priority", "id"])
-                meta["priority_name"] = _get(["priority", "name"])
-                meta["reporter"] = _get(["reporter", "name"]) or _get(["reporter", "displayName"])
-                meta["assignee"] = _get(["assignee", "name"]) or _get(["assignee", "displayName"])
-                meta["created"] = _get(["created"]) or d.get("created")
-                meta["updated"] = _get(["updated"]) or d.get("updated")
-                meta["duedate"] = _get(["duedate"]) or d.get("duedate")
-                labels = _get(["labels"]) or []
-                if not isinstance(labels, list):
-                    labels = []
-                meta["labels"] = labels
-                comps = _get(["components"]) or []
-                if isinstance(comps, list):
-                    meta["components"] = [c.get("name") for c in comps if isinstance(c, dict)]
-                else:
-                    meta["components"] = []
-                parent = _get(["parent"]) or {}
-                if isinstance(parent, dict):
-                    meta["parent_key"] = parent.get("key")
-        except Exception:
-            # Never fail migration because of meta extraction
-            pass
-        return meta
+        """Delegate to :meth:`IssueTransformer.extract_issue_meta`."""
+        return self._transformer.extract_issue_meta(issue)
 
     def prepare_work_package(
         self,
@@ -3710,106 +3179,20 @@ class WorkPackageMigration(BaseMigration):
         type_id: str | None = None,
         type_name: str | None = None,
     ) -> int:
-        """Map Jira issue type to OpenProject type ID."""
-        if not type_id and not type_name:
-            msg = "Either type_id or type_name must be provided for issue type mapping"
-            raise ValueError(
-                msg,
-            )
-
-        # Try to find in mapping by ID
-        if type_id and self.issue_type_id_mapping and str(type_id) in self.issue_type_id_mapping:
-            return self.issue_type_id_mapping[str(type_id)]
-
-        # Try to find in mapping by ID in issue_type_mapping
-        if type_id and str(type_id) in self.issue_type_mapping:
-            mapped_id = self.issue_type_mapping[str(type_id)].get("openproject_id")
-            if mapped_id:
-                return mapped_id
-
-        # Default to Task (typically ID 1 in OpenProject)
-        type_display = type_name or "Unknown"
-        self.logger.warning(
-            f"No mapping found for issue type {type_display} (ID: {type_id}), defaulting to Task",
-        )
-        return 1
+        """Delegate to :meth:`IssueTransformer.map_issue_type`."""
+        return self._transformer.map_issue_type(type_id, type_name)
 
     def _map_status(
         self,
         status_id: str | None = None,
         status_name: str | None = None,
     ) -> int:
-        """Map Jira status to OpenProject status ID."""
-        if not status_id and not status_name:
-            msg = "Either status_id or status_name must be provided for status mapping"
-            raise ValueError(
-                msg,
-            )
-
-        # Try to find in mapping by ID
-        if status_id and self.status_mapping and str(status_id) in self.status_mapping:
-            mapped_id = self.status_mapping[str(status_id)].get("openproject_id")
-            if mapped_id:
-                return mapped_id
-
-        # Default to "New" status (typically ID 1 in OpenProject)
-        status_display = status_name or "Unknown"
-        self.logger.warning(
-            f"No mapping found for status {status_display} (ID: {status_id}), defaulting to New",
-        )
-        return 1
+        """Delegate to :meth:`IssueTransformer.map_status`."""
+        return self._transformer.map_status(status_id, status_name)
 
     def _sanitize_wp_dict(self, wp: dict[str, Any]) -> None:
-        """Sanitize a prepared work package dict in-place for AR compatibility.
-
-        - Extract type_id and status_id from API-style _links if provided
-        - Remove the _links key entirely to avoid unknown attribute errors
-        - Ensure string fields are properly escaped
-        """
-        # Ensure string values for certain fields
-        if "subject" in wp:
-            try:
-                wp["subject"] = str(wp["subject"]).replace('"', '\\"').replace("'", "\\'")
-            except Exception:
-                wp["subject"] = str(wp.get("subject", ""))
-        if "description" in wp:
-            try:
-                wp["description"] = str(wp["description"]).replace('"', '\\"').replace("'", "\\'")
-            except Exception:
-                wp["description"] = str(wp.get("description", ""))
-
-        # Sanitize OpenProject API-style links that are not valid AR attributes
-        links = wp.get("_links")
-        if isinstance(links, dict):
-            # Extract type_id from links if present and not already provided
-            try:
-                if "type_id" not in wp and isinstance(links.get("type"), dict):
-                    href = links["type"].get("href")
-                    if isinstance(href, str) and href.strip():
-                        type_id_str = href.rstrip("/").split("/")[-1]
-                        if type_id_str.isdigit():
-                            wp["type_id"] = int(type_id_str)
-            except Exception:
-                pass
-
-            # Extract status_id from links if present and not already provided
-            try:
-                if "status_id" not in wp and isinstance(links.get("status"), dict):
-                    href = links["status"].get("href")
-                    if isinstance(href, str) and href.strip():
-                        status_id_str = href.rstrip("/").split("/")[-1]
-                        if status_id_str.isdigit():
-                            wp["status_id"] = int(status_id_str)
-            except Exception:
-                pass
-
-        # Remove _links entirely to avoid AR unknown attribute errors
-        wp.pop("_links", None)
-        # Remove non-AR/meta keys that must not reach Rails mass-assignment
-        wp.pop("watcher_ids", None)
-        wp.pop("jira_id", None)
-        wp.pop("jira_key", None)
-        wp.pop("type_name", None)
+        """Delegate to :meth:`IssueTransformer.sanitize_wp_dict`."""
+        return IssueTransformer.sanitize_wp_dict(wp)
 
     def _get_current_entities_for_type(self, entity_type: str) -> list[dict[str, Any]]:
         """Get current entities of the specified type from Jira.

--- a/src/application/transformers/__init__.py
+++ b/src/application/transformers/__init__.py
@@ -1,0 +1,7 @@
+"""Application-layer transformers.
+
+Pure mapping logic extracted from migration components so that the data
+shape transformations can be unit-tested in isolation from I/O clients.
+
+See ``claudedocs/refactoring/work-package-migration-decomposition-plan.md``.
+"""

--- a/src/application/transformers/issue_transformer.py
+++ b/src/application/transformers/issue_transformer.py
@@ -1,0 +1,872 @@
+"""Pure mapping logic extracted from :mod:`work_package_migration`.
+
+This module is **Phase 1** of the ``WorkPackageMigration`` god-class
+decomposition (see
+``claudedocs/refactoring/work-package-migration-decomposition-plan.md``).
+
+Sixteen methods that perform Jira → OpenProject data shape transformations
+have been moved here verbatim. The original
+:class:`~src.application.components.work_package_migration.WorkPackageMigration`
+keeps thin delegate methods that forward to an :class:`IssueTransformer`
+instance constructed at the end of its ``__init__`` so that **behaviour is
+unchanged**.
+
+Why an owner reference rather than constructor injection of every value?
+=======================================================================
+Several of the values these methods read are reassigned (not just mutated)
+on the Service after construction — most notably
+``WorkPackageMigration.markdown_converter`` is rebuilt by
+``_update_markdown_converter_mappings``. To preserve the historical
+behaviour where the live Service attribute is read at call time, the
+transformer keeps a back-reference to its owner and reads
+``self._owner.<attr>`` on demand.
+
+The transformer remains independently testable: tests can construct an
+:class:`IssueTransformer` directly with a lightweight stand-in owner
+(``types.SimpleNamespace`` is sufficient — see
+``tests/unit/test_issue_transformer.py``) without instantiating the full
+``WorkPackageMigration``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.domain.enums import JournalEntryType
+
+
+class IssueTransformer:
+    """Pure mapping logic extracted from ``WorkPackageMigration``.
+
+    Sixteen pure-mapping methods (see module docstring) live here so they
+    can be unit-tested without instantiating the full migration component.
+    The implementation is a verbatim move from the original class — only
+    ``self.<attr>`` reads have been rewired to ``self._owner.<attr>`` for
+    Service-owned mutable state.
+    """
+
+    # Default fallback user id used when a journal author cannot be resolved
+    # from the user mapping. See ``resolve_journal_author_id`` (BUG #32).
+    _BUG32_FALLBACK_USER_ID = 148941
+
+    # Probe order for resolving Jira changelog/comment authors against the
+    # owner's ``user_mapping``. Mirrors the multi-key fallback documented in
+    # BUG #32 — the user_mapping is augmented with secondary indices on
+    # ``name`` / ``displayName`` / ``emailAddress`` (and others) so any of
+    # these raw Jira fields will resolve to the same OP user when present.
+    _JOURNAL_AUTHOR_PROBE_KEYS: tuple[str, ...] = ("name", "displayName", "emailAddress")
+
+    def __init__(self, owner: Any) -> None:
+        """Bind the transformer to its owning migration service.
+
+        Args:
+            owner: The :class:`WorkPackageMigration` instance whose live
+                attributes (``user_mapping``, ``status_mapping``,
+                ``enhanced_timestamp_migrator``,
+                ``markdown_converter``, ``logger``, etc.) the transformer
+                reads on every call. Tests may pass a
+                ``types.SimpleNamespace`` exposing the same attributes.
+
+        """
+        self._owner = owner
+
+    # ------------------------------------------------------------------ #
+    # Helpers / convenience accessors
+    # ------------------------------------------------------------------ #
+
+    @property
+    def logger(self) -> Any:
+        """Live logger from the owning service."""
+        return self._owner.logger
+
+    # ------------------------------------------------------------------ #
+    # Journal author resolution (BUG #32)
+    # ------------------------------------------------------------------ #
+
+    def resolve_journal_author_id(
+        self,
+        author_data: dict[str, Any],
+        jira_key: str,
+        kind: JournalEntryType,
+    ) -> int:
+        """Resolve a journal-entry author to an OpenProject user id.
+
+        Walks ``author_data`` against the owner's ``user_mapping`` using
+        the canonical probe order in
+        :attr:`_JOURNAL_AUTHOR_PROBE_KEYS` and returns the first matching
+        ``openproject_id``. If no probe key resolves, returns
+        :attr:`_BUG32_FALLBACK_USER_ID` and logs a ``[BUG32]`` warning
+        listing every probe field that was present on ``author_data`` so
+        unresolved authors are diagnosable from production logs.
+
+        Args:
+            author_data: Raw Jira author payload from a comment or
+                changelog entry. Tolerates ``None``/empty inputs by
+                resolving to the fallback user.
+            jira_key: Jira issue key, used purely for log context.
+            kind: Discriminator for the journal entry (``COMMENT`` or
+                ``CHANGELOG``) used to distinguish the warning message
+                between callers.
+
+        Returns:
+            The resolved ``openproject_id`` (int) or the BUG #32
+            fallback user id when the author cannot be resolved.
+
+        """
+        if not isinstance(author_data, dict):
+            author_data = {}
+        user_mapping = self._owner.user_mapping
+        for key in self._JOURNAL_AUTHOR_PROBE_KEYS:
+            value = author_data.get(key)
+            if not value:
+                continue
+            user_dict = user_mapping.get(value)
+            if not user_dict:
+                continue
+            op_id = user_dict.get("openproject_id")
+            if op_id:
+                self.logger.debug(
+                    f"{jira_key}: Found user via {key}: {value} → {op_id}",
+                )
+                return int(op_id)
+
+        # No probe key resolved — fall back to the BUG #32 admin user.
+        attempted_fields = {k: author_data.get(k) for k in self._JOURNAL_AUTHOR_PROBE_KEYS if k in author_data}
+        fallback_id = self._BUG32_FALLBACK_USER_ID
+        self.logger.warning(
+            f"[BUG32] {jira_key}: User not found in mapping for {kind} (tried: {attempted_fields}), "
+            f"using fallback user {fallback_id}",
+        )
+        return fallback_id
+
+    # ------------------------------------------------------------------ #
+    # Mention tracking
+    # ------------------------------------------------------------------ #
+
+    def track_mentioned_users(self, text: str | None, project_id: int) -> None:
+        """Extract mentioned user IDs from text and track them for membership assignment.
+
+        Args:
+            text: Jira markup text that may contain user mentions.
+            project_id: OpenProject project ID where mentions were found.
+
+        """
+        if not text or not project_id:
+            return
+
+        owner = self._owner
+        if not hasattr(owner, "markdown_converter") or not owner.markdown_converter:
+            return
+
+        try:
+            mentioned_ids = owner.markdown_converter.extract_mentioned_user_ids(text)
+            if mentioned_ids:
+                if project_id not in owner._mentioned_users_by_project:
+                    owner._mentioned_users_by_project[project_id] = set()
+                owner._mentioned_users_by_project[project_id].update(mentioned_ids)
+        except Exception as e:
+            self.logger.debug(f"Error extracting mentioned users: {e}")
+
+    # ------------------------------------------------------------------ #
+    # Workflow extraction
+    # ------------------------------------------------------------------ #
+
+    def extract_final_workflow(self, jira_issue: Any) -> str | None:
+        """Extract the final/current workflow scheme name from Jira changelog.
+
+        The Jira "Workflow" field in changelog represents workflow scheme changes
+        (not status changes). We extract the most recent "toString" value to get
+        the current workflow scheme name.
+
+        Args:
+            jira_issue: The Jira issue object.
+
+        Returns:
+            Final workflow scheme name, or None if not found.
+
+        """
+        try:
+            # Access changelog from issue
+            changelog = getattr(jira_issue, "changelog", None)
+            if not changelog:
+                return None
+
+            histories = getattr(changelog, "histories", None)
+            if not histories:
+                return None
+
+            # Find all Workflow field changes, sorted by date (most recent last)
+            workflow_changes = []
+            for history in histories:
+                items = getattr(history, "items", [])
+                for item in items:
+                    field = getattr(item, "field", None) or (item.get("field") if isinstance(item, dict) else None)
+                    if field == "Workflow":
+                        to_string = getattr(item, "toString", None) or (
+                            item.get("toString") if isinstance(item, dict) else None
+                        )
+                        if to_string:
+                            created = getattr(history, "created", "")
+                            workflow_changes.append((created, to_string))
+
+            if workflow_changes:
+                # Sort by timestamp and get the most recent
+                workflow_changes.sort(key=lambda x: x[0])
+                final_workflow = workflow_changes[-1][1]
+                self.logger.debug(f"[WORKFLOW] Extracted final workflow scheme: {final_workflow}")
+                return str(final_workflow)
+
+        except Exception as e:
+            self.logger.debug(f"[WORKFLOW] Error extracting workflow: {e}")
+
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Datetime parsing
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def parse_datetime(value: Any) -> datetime | None:
+        """Best-effort parsing for Jira/ISO datetime payloads."""
+        if isinstance(value, datetime):
+            if value.tzinfo:
+                return value.astimezone(UTC)
+            return value.replace(tzinfo=UTC)
+
+        if not isinstance(value, str):
+            return None
+
+        candidate = value.strip()
+        if not candidate:
+            return None
+
+        # Normalize Z suffix to ISO compatible form
+        candidate_iso = candidate.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(candidate_iso)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            else:
+                parsed = parsed.astimezone(UTC)
+            return parsed
+        except ValueError:
+            pass
+
+        patterns = [
+            "%Y-%m-%dT%H:%M:%S.%f%z",
+            "%Y-%m-%dT%H:%M:%S%z",
+            "%Y-%m-%d %H:%M:%S.%f%z",
+            "%Y-%m-%d %H:%M:%S%z",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d %H:%M",
+            "%Y-%m-%dT%H:%M",
+        ]
+        for pattern in patterns:
+            try:
+                parsed = datetime.strptime(candidate, pattern)
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=UTC)
+                else:
+                    parsed = parsed.astimezone(UTC)
+                return parsed
+            except ValueError:
+                continue
+        return None
+
+    def derive_snapshot_timestamp(self, snapshot: list[dict[str, Any]]) -> datetime | None:
+        """Derive the most recent migration timestamp from existing OpenProject rows."""
+        latest: datetime | None = None
+        for entry in snapshot or []:
+            if not isinstance(entry, dict):
+                continue
+            for key in ("jira_migration_date", "updated_at", "updated_at_utc"):
+                candidate = entry.get(key)
+                parsed = self.parse_datetime(candidate)
+                if parsed and (latest is None or parsed > latest):
+                    latest = parsed
+        return latest
+
+    @staticmethod
+    def build_key_exclusion_clause(existing_keys: set[str]) -> str | None:
+        """Return a JQL fragment for excluding already-migrated issue keys."""
+        if not existing_keys:
+            return None
+        limited = [key for key in sorted({k.strip() for k in existing_keys if k and k.strip()}) if key][
+            :200
+        ]  # Keep under 8KB URL limit (200 keys × ~10 chars = ~2KB)
+        if not limited:
+            return None
+        return f"key NOT IN ({','.join(limited)})"
+
+    # ------------------------------------------------------------------ #
+    # Start date resolution
+    # ------------------------------------------------------------------ #
+
+    def resolve_start_date(self, issue: Any) -> str | None:
+        """Resolve start date from configured Jira custom fields."""
+        owner = self._owner
+        candidates: list[str] = list(owner.start_date_fields)
+
+        # jira.Issue style access
+        if hasattr(issue, "fields"):
+            fields_obj = getattr(issue, "fields", None)
+            for field_id in candidates:
+                try:
+                    value = getattr(fields_obj, field_id)
+                except AttributeError:
+                    value = None
+                if value:
+                    normalized = owner.enhanced_timestamp_migrator._normalize_timestamp(str(value))
+                    if normalized:
+                        return normalized.split("T", 1)[0]
+
+        # Raw dict fields from jira.Issue
+        raw_fields = {}
+        if hasattr(issue, "raw"):
+            raw_fields = getattr(issue, "raw", {}).get("fields", {})
+        if isinstance(issue, dict):
+            raw_fields = issue.get("fields", issue)
+
+        if isinstance(raw_fields, dict):
+            for field_id in candidates:
+                value = raw_fields.get(field_id)
+                if value:
+                    normalized = owner.enhanced_timestamp_migrator._normalize_timestamp(str(value))
+                    if normalized:
+                        return normalized.split("T", 1)[0]
+
+        # Fallback: derive start date from Jira status history
+        history_start = self.resolve_start_date_from_history(issue)
+        if history_start:
+            return history_start
+
+        return None
+
+    def resolve_start_date_from_history(self, issue: Any) -> str | None:
+        """Infer start date from the first transition into an 'In Progress' category."""
+        owner = self._owner
+        histories = self.extract_changelog_histories(issue)
+        if not histories:
+            return None
+
+        # Sort histories chronologically (oldest first) using their created timestamp
+        normalized_histories: list[tuple[str, Any]] = []
+        for history in histories:
+            created_raw = self.get_attr(history, "created")
+            if not created_raw:
+                continue
+            normalized = owner.enhanced_timestamp_migrator._normalize_timestamp(str(created_raw))
+            if not normalized:
+                continue
+            normalized_histories.append((normalized, history))
+
+        normalized_histories.sort(key=lambda pair: pair[0])
+
+        for normalized, history in normalized_histories:
+            items = self.get_attr(history, "items") or []
+            for item in items:
+                field_name = str(self.get_attr(item, "field") or "").lower()
+                if field_name != "status":
+                    continue
+
+                status_id = str(self.get_attr(item, "to") or "").strip()
+                status_name = str(self.get_attr(item, "toString") or "").strip().lower()
+
+                category: dict[str, Any] = {}
+                if status_id and status_id in owner.status_category_by_id:
+                    category = owner.status_category_by_id[status_id] or {}
+                elif status_name and status_name in owner.status_category_by_name:
+                    category = owner.status_category_by_name[status_name] or {}
+
+                if not category and status_name:
+                    # Attempt loose lookup by name if exact match missing
+                    category = next(
+                        (val for key, val in owner.status_category_by_name.items() if key == status_name),
+                        {},
+                    )
+
+                if self.is_in_progress_category(category):
+                    return normalized.split("T", 1)[0]
+
+        return None
+
+    @staticmethod
+    def get_attr(obj: Any, key: str) -> Any:
+        """Safely fetch attribute/key from Jira objects or dicts."""
+        if isinstance(obj, dict):
+            return obj.get(key)
+        return getattr(obj, key, None)
+
+    # ------------------------------------------------------------------ #
+    # Changelog processing
+    # ------------------------------------------------------------------ #
+
+    def process_changelog_item(self, item: dict[str, Any]) -> dict[str, list[Any]] | None:
+        """Process a single changelog item into OpenProject field changes.
+
+        Bug #28 fix: Transform Jira changelog entries into structured field changes
+        for journal.data instead of text-only comments.
+
+        Args:
+            item: Jira changelog item with 'field', 'fromString', 'toString'.
+
+        Returns:
+            Dictionary mapping OpenProject field names to [old_value, new_value] or None.
+
+        """
+        owner = self._owner
+        field = item.get("field")
+        if not field:
+            return None
+
+        # Field mapping from Jira to OpenProject
+        # BUG #32 FIX (REGRESSION #3): Only map fields that exist in Journal::WorkPackageJournal
+        # BUG #17 FIX: Added timeestimate and timeoriginalestimate mappings
+        # fixVersion: Enabled with on-the-fly version creation
+        field_mappings = {
+            "summary": "subject",
+            "description": "description",
+            "status": "status_id",
+            "assignee": "assigned_to_id",
+            "priority": "priority_id",
+            "issuetype": "type_id",
+            # "resolution": "resolution",  # NOT a valid Journal::WorkPackageJournal attribute  # noqa: ERA001
+            # "labels": "tags",  # NOT a valid Journal::WorkPackageJournal attribute  # noqa: ERA001
+            "Fix Version": "version_id",  # On-the-fly version creation enabled
+            # "component": "category_id",  # Requires category_mapping - falls through to Bug #16 notes for now
+            "reporter": "author_id",
+            # BUG #17 FIX: Time estimate fields (Jira stores in seconds, OpenProject in hours)
+            "timeestimate": "remaining_hours",
+            "timeoriginalestimate": "estimated_hours",
+        }
+
+        # BUG #32 FIX (REGRESSION #3): Skip unmapped fields to prevent invalid Journal::WorkPackageJournal attributes
+        if field not in field_mappings:
+            return None
+
+        op_field = field_mappings[field]
+
+        # Get values from changelog item
+        from_value = item.get("fromString") or item.get("from")
+        to_value = item.get("toString") or item.get("to")
+
+        # Special handling for user fields (assignee, reporter)
+        if field in ["assignee", "reporter"]:
+            # BUG #20 FIX: Use 'from'/'to' (username) not 'fromString'/'toString' (display name)
+            # Jira changelog provides:
+            #   - from/to: username (e.g., "enrico.tischendorf")
+            #   - fromString/toString: display name (e.g., "Enrico Tischendorf")
+            # Our user_mapping is keyed by username, so we must use from/to
+            from_username = item.get("from")
+            to_username = item.get("to")
+
+            # Map usernames to OpenProject IDs
+            from_id = None
+            to_id = None
+
+            if from_username and owner.user_mapping:
+                user_dict = owner.user_mapping.get(from_username)
+                from_id = user_dict.get("openproject_id") if user_dict else None
+                if not user_dict:
+                    self.logger.debug(f"[BUG20] User not found in mapping: {from_username}")
+
+            if to_username and owner.user_mapping:
+                user_dict = owner.user_mapping.get(to_username)
+                to_id = user_dict.get("openproject_id") if user_dict else None
+                if not user_dict:
+                    self.logger.debug(f"[BUG20] User not found in mapping: {to_username}")
+
+            # BUG #19 FIX: Skip no-change mappings (from == to, including both None)
+            # This prevents "retracted" phantom journals from operations with no actual change
+            if from_id == to_id:
+                return None
+
+            return {op_field: [from_id, to_id]}
+
+        # BUG #11 FIX: Map Jira IDs to OpenProject IDs for status, issuetype
+        # The progressive state building needs OpenProject integer IDs, not Jira string values
+        if field == "issuetype":
+            # Get Jira type IDs (not string names)
+            from_jira_id = item.get("from")  # e.g., "3" for Task
+            to_jira_id = item.get("to")  # e.g., "10404" for Access
+
+            # Map to OpenProject type IDs
+            from_op_id = None
+            to_op_id = None
+
+            if from_jira_id and owner.issue_type_id_mapping:
+                from_op_id = owner.issue_type_id_mapping.get(str(from_jira_id))
+            if to_jira_id and owner.issue_type_id_mapping:
+                to_op_id = owner.issue_type_id_mapping.get(str(to_jira_id))
+
+            # BUG #11 DEBUG: Log type mapping results
+            self.logger.info(
+                f"[BUG11-TYPE] issuetype change: from_jira={from_jira_id} -> from_op={from_op_id}, to_jira={to_jira_id} -> to_op={to_op_id}",
+            )
+
+            # BUG #19 FIX: Skip no-change mappings
+            if from_op_id == to_op_id:
+                return None
+
+            return {op_field: [from_op_id, to_op_id]}
+
+        if field == "status":
+            # Get Jira status IDs (not string names)
+            from_jira_id = item.get("from")  # e.g., "1" for Open
+            to_jira_id = item.get("to")  # e.g., "6" for Closed
+
+            # Map to OpenProject status IDs
+            from_op_id = None
+            to_op_id = None
+
+            if from_jira_id and owner.status_mapping:
+                mapping = owner.status_mapping.get(str(from_jira_id))
+                from_op_id = mapping.get("openproject_id") if mapping else None
+            if to_jira_id and owner.status_mapping:
+                mapping = owner.status_mapping.get(str(to_jira_id))
+                to_op_id = mapping.get("openproject_id") if mapping else None
+
+            # BUG #11 DEBUG: Log status mapping results
+            self.logger.info(
+                f"[BUG11-STATUS] status change: from_jira={from_jira_id} -> from_op={from_op_id}, to_jira={to_jira_id} -> to_op={to_op_id}",
+            )
+
+            # BUG #19 FIX: Skip no-change mappings
+            if from_op_id == to_op_id:
+                return None
+
+            return {op_field: [from_op_id, to_op_id]}
+
+        # Handle Fix Version -> version_id with on-the-fly version creation
+        if field == "Fix Version":
+            # Version names are in fromString/toString (like user display names)
+            from_version_name = item.get("fromString")
+            to_version_name = item.get("toString")
+
+            # Map to OpenProject version IDs (create if needed)
+            from_version_id = None
+            to_version_id = None
+
+            if owner._current_project_id:
+                if from_version_name:
+                    from_version_id = owner._get_or_create_version(from_version_name, owner._current_project_id)
+                if to_version_name:
+                    to_version_id = owner._get_or_create_version(to_version_name, owner._current_project_id)
+
+            self.logger.info(
+                f"[FIXVERSION] project_id={owner._current_project_id}, from='{from_version_name}' -> {from_version_id}, to='{to_version_name}' -> {to_version_id}",
+            )
+
+            # Skip no-change mappings
+            if from_version_id == to_version_id:
+                return None
+
+            return {op_field: [from_version_id, to_version_id]}
+
+        # For priority, keep string values for now (mapping not critical for journals)
+        if field == "priority":
+            # BUG #19 FIX: Skip no-change mappings
+            if from_value == to_value:
+                return None
+            return {op_field: [from_value, to_value]}
+
+        # BUG #17 FIX: Handle time estimate fields - convert Jira seconds to OpenProject hours
+        if field in ["timeestimate", "timeoriginalestimate"]:
+            from_seconds = item.get("from")
+            to_seconds = item.get("to")
+
+            def seconds_to_hours(seconds_str: str | None) -> float | None:
+                """Convert Jira time (seconds) to OpenProject hours."""
+                if not seconds_str:
+                    return None
+                try:
+                    seconds = int(seconds_str)
+                    return round(seconds / 3600, 2)  # Convert to hours with 2 decimal places
+                except (
+                    ValueError,
+                    TypeError,
+                ):
+                    return None
+
+            from_hours = seconds_to_hours(from_seconds)
+            to_hours = seconds_to_hours(to_seconds)
+
+            self.logger.info(
+                f"[BUG17-TIME] {field} change: from={from_seconds}s ({from_hours}h) -> to={to_seconds}s ({to_hours}h)",
+            )
+
+            # BUG #19 FIX: Skip no-change mappings
+            if from_hours == to_hours:
+                return None
+
+            return {op_field: [from_hours, to_hours]}
+
+        # Generic field change (subject, description, etc.)
+        # BUG #19 FIX: Skip no-change mappings
+        if from_value == to_value:
+            return None
+        return {op_field: [from_value, to_value]}
+
+    @staticmethod
+    def extract_changelog_histories(issue: Any) -> list[Any]:
+        """Return changelog histories from either jira.Issue or dict payloads."""
+        if hasattr(issue, "changelog") and issue.changelog:
+            histories = getattr(issue.changelog, "histories", None)
+            if histories:
+                return list(histories)
+
+        raw = getattr(issue, "raw", None)
+        if isinstance(raw, dict):
+            histories = raw.get("changelog", {}).get("histories")
+            if isinstance(histories, list):
+                return histories
+
+        if isinstance(issue, dict):
+            histories = issue.get("changelog", {}).get("histories")
+            if isinstance(histories, list):
+                return histories
+
+        return []
+
+    @staticmethod
+    def is_in_progress_category(category: dict[str, Any]) -> bool:
+        """Return True when the status category represents 'In Progress'."""
+        if not category:
+            return False
+
+        key = str(category.get("key", "")).lower()
+        name = str(category.get("name", "")).lower()
+        cat_id = str(category.get("id", "")).lower()
+
+        in_progress_keys = {"indeterminate", "in_progress", "in-progress"}
+        if key in in_progress_keys:
+            return True
+        if name == "in progress":
+            return True
+        if cat_id == "4":  # Jira default id for In Progress category
+            return True
+        return False
+
+    # ------------------------------------------------------------------ #
+    # Issue meta
+    # ------------------------------------------------------------------ #
+
+    def extract_issue_meta(self, issue: Any) -> dict[str, Any]:
+        """Extract non-AR metadata from a Jira issue for reporting.
+
+        Safe best-effort extraction from either jira.Issue or dict-like payloads.
+        Does not mutate inputs and never raises.
+        """
+        meta: dict[str, Any] = {}
+        try:
+            start_date = self.resolve_start_date(issue)
+            if start_date:
+                meta["start_date"] = start_date
+            # Handle jira.Issue style
+            if hasattr(issue, "key") and hasattr(issue, "fields"):
+                f = getattr(issue, "fields", None)
+                meta["jira_key"] = getattr(issue, "key", None)
+                meta["jira_id"] = getattr(issue, "id", None)
+                if f is not None:
+
+                    def _name(obj: Any) -> Any:
+                        try:
+                            return getattr(obj, "name", None)
+                        except Exception:
+                            return None
+
+                    meta["issuetype_id"] = getattr(getattr(f, "issuetype", None), "id", None)
+                    meta["issuetype_name"] = _name(getattr(f, "issuetype", None))
+                    meta["status_id"] = getattr(getattr(f, "status", None), "id", None)
+                    meta["status_name"] = _name(getattr(f, "status", None))
+                    meta["priority_id"] = getattr(getattr(f, "priority", None), "id", None)
+                    meta["priority_name"] = _name(getattr(f, "priority", None))
+                    meta["reporter"] = getattr(getattr(f, "reporter", None), "name", None)
+                    meta["assignee"] = getattr(getattr(f, "assignee", None), "name", None)
+                    meta["created"] = getattr(f, "created", None)
+                    meta["updated"] = getattr(f, "updated", None)
+                    meta["duedate"] = getattr(f, "duedate", None)
+                    try:
+                        labels = list(getattr(f, "labels", []) or [])
+                    except Exception:
+                        labels = []
+                    meta["labels"] = labels
+                    try:
+                        comps = getattr(f, "components", []) or []
+                        meta["components"] = [getattr(c, "name", None) for c in comps if c]
+                    except Exception:
+                        meta["components"] = []
+                    # Optional relations
+                    try:
+                        parent = getattr(f, "parent", None)
+                        if parent is not None:
+                            meta["parent_key"] = getattr(parent, "key", None)
+                    except Exception:
+                        pass
+            else:
+                # Dict-like payloads (tests / fallback)
+                d = issue or {}
+                fields = d.get("fields") if isinstance(d, dict) else {}
+                meta["jira_key"] = d.get("key") if isinstance(d, dict) else None
+                meta["jira_id"] = d.get("id") if isinstance(d, dict) else None
+
+                def _get(path_keys: list[str]) -> Any:
+                    cur: Any = fields if isinstance(fields, dict) else {}
+                    for k in path_keys:
+                        if not isinstance(cur, dict):
+                            return None
+                        cur = cur.get(k)
+                    return cur
+
+                meta["issuetype_id"] = _get(["issuetype", "id"])
+                meta["issuetype_name"] = _get(["issuetype", "name"])
+                meta["status_id"] = _get(["status", "id"])
+                meta["status_name"] = _get(["status", "name"])
+                meta["priority_id"] = _get(["priority", "id"])
+                meta["priority_name"] = _get(["priority", "name"])
+                meta["reporter"] = _get(["reporter", "name"]) or _get(["reporter", "displayName"])
+                meta["assignee"] = _get(["assignee", "name"]) or _get(["assignee", "displayName"])
+                meta["created"] = _get(["created"]) or d.get("created")
+                meta["updated"] = _get(["updated"]) or d.get("updated")
+                meta["duedate"] = _get(["duedate"]) or d.get("duedate")
+                labels = _get(["labels"]) or []
+                if not isinstance(labels, list):
+                    labels = []
+                meta["labels"] = labels
+                comps = _get(["components"]) or []
+                if isinstance(comps, list):
+                    meta["components"] = [c.get("name") for c in comps if isinstance(c, dict)]
+                else:
+                    meta["components"] = []
+                parent = _get(["parent"]) or {}
+                if isinstance(parent, dict):
+                    meta["parent_key"] = parent.get("key")
+        except Exception:
+            # Never fail migration because of meta extraction
+            pass
+        return meta
+
+    # ------------------------------------------------------------------ #
+    # Issue-type / status mapping
+    # ------------------------------------------------------------------ #
+
+    def map_issue_type(
+        self,
+        type_id: str | None = None,
+        type_name: str | None = None,
+    ) -> int:
+        """Map Jira issue type to OpenProject type ID."""
+        if not type_id and not type_name:
+            msg = "Either type_id or type_name must be provided for issue type mapping"
+            raise ValueError(
+                msg,
+            )
+
+        owner = self._owner
+
+        # Try to find in mapping by ID
+        if type_id and owner.issue_type_id_mapping and str(type_id) in owner.issue_type_id_mapping:
+            return owner.issue_type_id_mapping[str(type_id)]
+
+        # Try to find in mapping by ID in issue_type_mapping
+        if type_id and str(type_id) in owner.issue_type_mapping:
+            mapped_id = owner.issue_type_mapping[str(type_id)].get("openproject_id")
+            if mapped_id:
+                return mapped_id
+
+        # Default to Task (typically ID 1 in OpenProject)
+        type_display = type_name or "Unknown"
+        self.logger.warning(
+            f"No mapping found for issue type {type_display} (ID: {type_id}), defaulting to Task",
+        )
+        return 1
+
+    def map_status(
+        self,
+        status_id: str | None = None,
+        status_name: str | None = None,
+    ) -> int:
+        """Map Jira status to OpenProject status ID."""
+        if not status_id and not status_name:
+            msg = "Either status_id or status_name must be provided for status mapping"
+            raise ValueError(
+                msg,
+            )
+
+        owner = self._owner
+
+        # Try to find in mapping by ID
+        if status_id and owner.status_mapping and str(status_id) in owner.status_mapping:
+            mapped_id = owner.status_mapping[str(status_id)].get("openproject_id")
+            if mapped_id:
+                return mapped_id
+
+        # Default to "New" status (typically ID 1 in OpenProject)
+        status_display = status_name or "Unknown"
+        self.logger.warning(
+            f"No mapping found for status {status_display} (ID: {status_id}), defaulting to New",
+        )
+        return 1
+
+    # ------------------------------------------------------------------ #
+    # WP dict sanitisation
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def sanitize_wp_dict(wp: dict[str, Any]) -> None:
+        """Sanitize a prepared work package dict in-place for AR compatibility.
+
+        - Extract type_id and status_id from API-style _links if provided.
+        - Remove the _links key entirely to avoid unknown attribute errors.
+        - Ensure string fields are properly escaped.
+        """
+        # Ensure string values for certain fields
+        if "subject" in wp:
+            try:
+                wp["subject"] = str(wp["subject"]).replace('"', '\\"').replace("'", "\\'")
+            except Exception:
+                wp["subject"] = str(wp.get("subject", ""))
+        if "description" in wp:
+            try:
+                wp["description"] = str(wp["description"]).replace('"', '\\"').replace("'", "\\'")
+            except Exception:
+                wp["description"] = str(wp.get("description", ""))
+
+        # Sanitize OpenProject API-style links that are not valid AR attributes
+        links = wp.get("_links")
+        if isinstance(links, dict):
+            # Extract type_id from links if present and not already provided
+            try:
+                if "type_id" not in wp and isinstance(links.get("type"), dict):
+                    href = links["type"].get("href")
+                    if isinstance(href, str) and href.strip():
+                        type_id_str = href.rstrip("/").split("/")[-1]
+                        if type_id_str.isdigit():
+                            wp["type_id"] = int(type_id_str)
+            except Exception:
+                pass
+
+            # Extract status_id from links if present and not already provided
+            try:
+                if "status_id" not in wp and isinstance(links.get("status"), dict):
+                    href = links["status"].get("href")
+                    if isinstance(href, str) and href.strip():
+                        status_id_str = href.rstrip("/").split("/")[-1]
+                        if status_id_str.isdigit():
+                            wp["status_id"] = int(status_id_str)
+            except Exception:
+                pass
+
+        # Remove _links entirely to avoid AR unknown attribute errors
+        wp.pop("_links", None)
+        # Remove non-AR/meta keys that must not reach Rails mass-assignment
+        wp.pop("watcher_ids", None)
+        wp.pop("jira_id", None)
+        wp.pop("jira_key", None)
+        wp.pop("type_name", None)
+
+
+__all__ = ["IssueTransformer"]

--- a/src/application/transformers/issue_transformer.py
+++ b/src/application/transformers/issue_transformer.py
@@ -1,8 +1,9 @@
-"""Pure mapping logic extracted from :mod:`work_package_migration`.
+"""Pure mapping logic extracted from :mod:`src.application.components.work_package_migration`.
 
 This module is **Phase 1** of the ``WorkPackageMigration`` god-class
-decomposition (see
-``claudedocs/refactoring/work-package-migration-decomposition-plan.md``).
+decomposition: pure Jira → OpenProject data shape transformations live
+here so they can be tested in isolation, while the service module keeps
+its orchestration role.
 
 Sixteen methods that perform Jira → OpenProject data shape transformations
 have been moved here verbatim. The original
@@ -87,7 +88,7 @@ class IssueTransformer:
 
     def resolve_journal_author_id(
         self,
-        author_data: dict[str, Any],
+        author_data: dict[str, Any] | None,
         jira_key: str,
         kind: JournalEntryType,
     ) -> int:
@@ -276,7 +277,7 @@ class IssueTransformer:
                 continue
         return None
 
-    def derive_snapshot_timestamp(self, snapshot: list[dict[str, Any]]) -> datetime | None:
+    def derive_snapshot_timestamp(self, snapshot: list[dict[str, Any]] | None) -> datetime | None:
         """Derive the most recent migration timestamp from existing OpenProject rows."""
         latest: datetime | None = None
         for entry in snapshot or []:

--- a/tests/unit/test_issue_transformer.py
+++ b/tests/unit/test_issue_transformer.py
@@ -1,0 +1,827 @@
+"""Unit tests for :class:`IssueTransformer`.
+
+These tests exercise the 16 pure-mapping methods extracted from
+``WorkPackageMigration`` in Phase 1 of the decomposition (see
+``claudedocs/refactoring/work-package-migration-decomposition-plan.md``).
+
+The transformer is constructed against a lightweight stand-in owner
+(``types.SimpleNamespace``) so that no Jira/OpenProject clients are
+instantiated.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.application.transformers.issue_transformer import IssueTransformer
+from src.domain.enums import JournalEntryType
+
+
+class _RecordingLogger:
+    """Drop-in logger replacement that records calls for inspection."""
+
+    def __init__(self) -> None:
+        self.debug_calls: list[str] = []
+        self.info_calls: list[str] = []
+        self.warning_calls: list[str] = []
+
+    def debug(self, msg: object, *args: object, **kwargs: object) -> None:
+        self.debug_calls.append(str(msg))
+
+    def info(self, msg: object, *args: object, **kwargs: object) -> None:
+        self.info_calls.append(str(msg))
+
+    def warning(self, msg: object, *args: object, **kwargs: object) -> None:
+        self.warning_calls.append(str(msg))
+
+
+class _IdentityNormalizer:
+    """Stand-in for ``EnhancedTimestampMigrator``: returns input unchanged."""
+
+    def _normalize_timestamp(self, value: str | None) -> str | None:
+        return value
+
+
+class _RecordingMarkdownConverter:
+    """Stand-in for ``MarkdownConverter`` returning configured mention ids."""
+
+    def __init__(self, mention_ids: list[int] | None = None) -> None:
+        self._mention_ids = mention_ids or []
+        self.last_text: str | None = None
+
+    def extract_mentioned_user_ids(self, text: str) -> list[int]:
+        self.last_text = text
+        return list(self._mention_ids)
+
+
+def _make_owner(
+    *,
+    user_mapping: dict[str, Any] | None = None,
+    issue_type_id_mapping: dict[str, Any] | None = None,
+    issue_type_mapping: dict[str, Any] | None = None,
+    status_mapping: dict[str, Any] | None = None,
+    status_category_by_id: dict[str, dict[str, Any]] | None = None,
+    status_category_by_name: dict[str, dict[str, Any]] | None = None,
+    start_date_fields: list[str] | None = None,
+    enhanced_timestamp_migrator: Any | None = None,
+    markdown_converter: Any | None = None,
+    mentioned_users_by_project: dict[int, set[int]] | None = None,
+    current_project_id: int | None = None,
+    version_resolver: Any | None = None,
+    logger: Any | None = None,
+) -> SimpleNamespace:
+    """Build a minimal owner namespace exposing the live attributes."""
+    owner = SimpleNamespace(
+        user_mapping=user_mapping if user_mapping is not None else {},
+        issue_type_id_mapping=issue_type_id_mapping if issue_type_id_mapping is not None else {},
+        issue_type_mapping=issue_type_mapping if issue_type_mapping is not None else {},
+        status_mapping=status_mapping if status_mapping is not None else {},
+        status_category_by_id=status_category_by_id if status_category_by_id is not None else {},
+        status_category_by_name=status_category_by_name if status_category_by_name is not None else {},
+        start_date_fields=start_date_fields if start_date_fields is not None else [],
+        enhanced_timestamp_migrator=enhanced_timestamp_migrator or _IdentityNormalizer(),
+        markdown_converter=markdown_converter,
+        _mentioned_users_by_project=mentioned_users_by_project if mentioned_users_by_project is not None else {},
+        _current_project_id=current_project_id,
+        _get_or_create_version=version_resolver
+        or (lambda name, project_id: None),
+        logger=logger or _RecordingLogger(),
+    )
+    return owner
+
+
+# ---------------------------------------------------------------------- #
+# resolve_journal_author_id (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestResolveJournalAuthorId:
+    def test_resolves_via_name_probe(self) -> None:
+        owner = _make_owner(
+            user_mapping={"jdoe": {"openproject_id": 42}},
+        )
+        transformer = IssueTransformer(owner=owner)
+
+        result = transformer.resolve_journal_author_id(
+            {"name": "jdoe", "displayName": "John Doe"},
+            "ABC-1",
+            JournalEntryType.COMMENT,
+        )
+
+        assert result == 42
+
+    def test_resolves_via_email_probe_when_name_missing(self) -> None:
+        owner = _make_owner(
+            user_mapping={"john@example.com": {"openproject_id": 99}},
+        )
+        transformer = IssueTransformer(owner=owner)
+
+        result = transformer.resolve_journal_author_id(
+            {"emailAddress": "john@example.com"},
+            "XYZ-9",
+            JournalEntryType.CHANGELOG,
+        )
+
+        assert result == 99
+
+    def test_falls_back_to_bug32_user_when_unresolved(self) -> None:
+        recorded = _RecordingLogger()
+        owner = _make_owner(user_mapping={}, logger=recorded)
+        transformer = IssueTransformer(owner=owner)
+
+        result = transformer.resolve_journal_author_id(
+            {"name": "ghost"},
+            "ABC-2",
+            JournalEntryType.COMMENT,
+        )
+
+        assert result == IssueTransformer._BUG32_FALLBACK_USER_ID
+        assert any("[BUG32]" in msg for msg in recorded.warning_calls)
+
+    def test_tolerates_non_dict_author_payload(self) -> None:
+        owner = _make_owner(user_mapping={})
+        transformer = IssueTransformer(owner=owner)
+
+        result = transformer.resolve_journal_author_id(
+            None,  # type: ignore[arg-type]
+            "ABC-3",
+            JournalEntryType.COMMENT,
+        )
+
+        assert result == IssueTransformer._BUG32_FALLBACK_USER_ID
+
+
+# ---------------------------------------------------------------------- #
+# track_mentioned_users (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestTrackMentionedUsers:
+    def test_records_mentioned_ids_on_owner(self) -> None:
+        converter = _RecordingMarkdownConverter(mention_ids=[7, 8])
+        owner = _make_owner(markdown_converter=converter)
+        transformer = IssueTransformer(owner=owner)
+
+        transformer.track_mentioned_users("Hi [~jdoe]!", project_id=11)
+
+        assert owner._mentioned_users_by_project == {11: {7, 8}}
+
+    def test_noop_when_text_empty(self) -> None:
+        converter = _RecordingMarkdownConverter(mention_ids=[1])
+        owner = _make_owner(markdown_converter=converter)
+        transformer = IssueTransformer(owner=owner)
+
+        transformer.track_mentioned_users("", project_id=5)
+
+        assert owner._mentioned_users_by_project == {}
+        assert converter.last_text is None
+
+    def test_noop_when_project_id_zero(self) -> None:
+        converter = _RecordingMarkdownConverter(mention_ids=[1])
+        owner = _make_owner(markdown_converter=converter)
+        transformer = IssueTransformer(owner=owner)
+
+        transformer.track_mentioned_users("hello", project_id=0)
+
+        assert owner._mentioned_users_by_project == {}
+        assert converter.last_text is None
+
+    def test_swallows_extractor_exceptions(self) -> None:
+        class _Boom:
+            def extract_mentioned_user_ids(self, text: str) -> list[int]:
+                msg = "kaboom"
+                raise RuntimeError(msg)
+
+        recorded = _RecordingLogger()
+        owner = _make_owner(markdown_converter=_Boom(), logger=recorded)
+        transformer = IssueTransformer(owner=owner)
+
+        transformer.track_mentioned_users("anything", project_id=1)
+
+        assert owner._mentioned_users_by_project == {}
+        assert any("Error extracting" in m for m in recorded.debug_calls)
+
+
+# ---------------------------------------------------------------------- #
+# extract_final_workflow (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestExtractFinalWorkflow:
+    def test_returns_latest_workflow_to_string(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+        history_old = SimpleNamespace(
+            created="2024-01-01T00:00:00",
+            items=[SimpleNamespace(field="Workflow", toString="OldFlow")],
+        )
+        history_new = SimpleNamespace(
+            created="2024-06-01T00:00:00",
+            items=[SimpleNamespace(field="Workflow", toString="NewFlow")],
+        )
+        issue = SimpleNamespace(
+            changelog=SimpleNamespace(histories=[history_old, history_new]),
+        )
+
+        assert transformer.extract_final_workflow(issue) == "NewFlow"
+
+    def test_returns_none_when_no_changelog(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+        issue = SimpleNamespace(changelog=None)
+
+        assert transformer.extract_final_workflow(issue) is None
+
+    def test_ignores_non_workflow_items(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+        history = SimpleNamespace(
+            created="2024-06-01T00:00:00",
+            items=[SimpleNamespace(field="status", toString="Done")],
+        )
+        issue = SimpleNamespace(changelog=SimpleNamespace(histories=[history]))
+
+        assert transformer.extract_final_workflow(issue) is None
+
+
+# ---------------------------------------------------------------------- #
+# parse_datetime (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestParseDatetime:
+    def test_parses_isoformat_with_z_suffix(self) -> None:
+        result = IssueTransformer.parse_datetime("2024-07-01T12:34:56Z")
+
+        assert result == datetime(2024, 7, 1, 12, 34, 56, tzinfo=UTC)
+
+    def test_returns_naive_datetime_with_utc_tzinfo(self) -> None:
+        naive = datetime(2024, 7, 1, 12, 0, 0)
+        result = IssueTransformer.parse_datetime(naive)
+
+        assert result is not None
+        assert result.tzinfo is UTC
+
+    def test_returns_none_for_garbage_input(self) -> None:
+        assert IssueTransformer.parse_datetime("not a date") is None
+        assert IssueTransformer.parse_datetime(None) is None
+        assert IssueTransformer.parse_datetime(12345) is None
+
+    def test_parses_jira_pattern(self) -> None:
+        # Jira-style timestamp like ``2024-09-10T08:00:00.000+0200``
+        result = IssueTransformer.parse_datetime("2024-09-10T08:00:00.000+0200")
+
+        assert result is not None
+        assert result.tzinfo is UTC
+
+
+# ---------------------------------------------------------------------- #
+# derive_snapshot_timestamp (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestDeriveSnapshotTimestamp:
+    def test_returns_latest_across_keys(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+        snapshot = [
+            {"jira_migration_date": "2024-01-01T00:00:00Z"},
+            {"updated_at": "2024-06-15T00:00:00Z"},
+            {"updated_at_utc": "2024-03-01T00:00:00Z"},
+        ]
+
+        result = transformer.derive_snapshot_timestamp(snapshot)
+
+        assert result == datetime(2024, 6, 15, 0, 0, 0, tzinfo=UTC)
+
+    def test_returns_none_for_empty_snapshot(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+
+        assert transformer.derive_snapshot_timestamp([]) is None
+        assert transformer.derive_snapshot_timestamp(None) is None  # type: ignore[arg-type]
+
+    def test_skips_non_dict_entries(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+        snapshot: list[Any] = [
+            "garbage",
+            123,
+            {"jira_migration_date": "2024-05-05T00:00:00Z"},
+        ]
+
+        result = transformer.derive_snapshot_timestamp(snapshot)
+
+        assert result == datetime(2024, 5, 5, 0, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------- #
+# build_key_exclusion_clause (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestBuildKeyExclusionClause:
+    def test_returns_jql_clause_for_keys(self) -> None:
+        result = IssueTransformer.build_key_exclusion_clause({"ABC-1", "ABC-2"})
+
+        assert result == "key NOT IN (ABC-1,ABC-2)"
+
+    def test_returns_none_for_empty_input(self) -> None:
+        assert IssueTransformer.build_key_exclusion_clause(set()) is None
+
+    def test_caps_at_200_keys(self) -> None:
+        keys = {f"PROJ-{i}" for i in range(500)}
+
+        result = IssueTransformer.build_key_exclusion_clause(keys)
+
+        assert result is not None
+        assert result.startswith("key NOT IN (")
+        # 200 keys joined by commas
+        assert result.count(",") == 199
+
+    def test_strips_whitespace_and_dedups(self) -> None:
+        result = IssueTransformer.build_key_exclusion_clause({"  ABC-1 ", "ABC-1", " "})
+
+        assert result == "key NOT IN (ABC-1)"
+
+
+# ---------------------------------------------------------------------- #
+# resolve_start_date (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestResolveStartDate:
+    def test_uses_first_configured_field(self) -> None:
+        owner = _make_owner(start_date_fields=["customfield_18690", "customfield_12590"])
+        transformer = IssueTransformer(owner=owner)
+        issue = SimpleNamespace(
+            fields=SimpleNamespace(
+                customfield_18690="2024-07-01T08:00:00+00:00",
+                customfield_12590="2024-07-02T08:00:00+00:00",
+            ),
+            raw={
+                "fields": {
+                    "customfield_18690": "2024-07-01T08:00:00+00:00",
+                    "customfield_12590": "2024-07-02T08:00:00+00:00",
+                },
+            },
+        )
+
+        assert transformer.resolve_start_date(issue) == "2024-07-01"
+
+    def test_falls_back_to_secondary_field(self) -> None:
+        owner = _make_owner(start_date_fields=["customfield_18690", "customfield_12590"])
+        transformer = IssueTransformer(owner=owner)
+        issue = SimpleNamespace(
+            fields=SimpleNamespace(customfield_18690=None, customfield_12590="2024-08-05T08:00:00+00:00"),
+            raw={"fields": {"customfield_18690": None, "customfield_12590": "2024-08-05T08:00:00+00:00"}},
+        )
+
+        assert transformer.resolve_start_date(issue) == "2024-08-05"
+
+    def test_returns_none_when_no_data_anywhere(self) -> None:
+        owner = _make_owner(start_date_fields=["customfield_18690"])
+        transformer = IssueTransformer(owner=owner)
+        issue: dict[str, Any] = {"fields": {"customfield_18690": None}}
+
+        assert transformer.resolve_start_date(issue) is None
+
+
+# ---------------------------------------------------------------------- #
+# resolve_start_date_from_history (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestResolveStartDateFromHistory:
+    def test_returns_first_in_progress_transition(self) -> None:
+        owner = _make_owner(
+            status_category_by_id={"3": {"id": 4, "key": "indeterminate", "name": "In Progress"}},
+            status_category_by_name={"in progress": {"id": 4, "key": "indeterminate", "name": "In Progress"}},
+        )
+        transformer = IssueTransformer(owner=owner)
+        issue = {
+            "changelog": {
+                "histories": [
+                    {
+                        "created": "2024-09-10T08:00:00.000+0200",
+                        "items": [{"field": "status", "to": "3", "toString": "In Progress"}],
+                    },
+                ],
+            },
+        }
+
+        assert transformer.resolve_start_date_from_history(issue) == "2024-09-10"
+
+    def test_returns_none_when_only_done_transitions(self) -> None:
+        owner = _make_owner(
+            status_category_by_id={"5": {"id": 5, "key": "done", "name": "Done"}},
+            status_category_by_name={"done": {"id": 5, "key": "done", "name": "Done"}},
+        )
+        transformer = IssueTransformer(owner=owner)
+        issue = {
+            "changelog": {
+                "histories": [
+                    {
+                        "created": "2024-09-10T08:00:00.000+0200",
+                        "items": [{"field": "status", "to": "5", "toString": "Done"}],
+                    },
+                ],
+            },
+        }
+
+        assert transformer.resolve_start_date_from_history(issue) is None
+
+    def test_returns_none_when_no_changelog(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+
+        assert transformer.resolve_start_date_from_history({"changelog": {"histories": []}}) is None
+
+
+# ---------------------------------------------------------------------- #
+# get_attr (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestGetAttr:
+    def test_reads_dict_key(self) -> None:
+        assert IssueTransformer.get_attr({"foo": "bar"}, "foo") == "bar"
+
+    def test_reads_object_attribute(self) -> None:
+        obj = SimpleNamespace(foo="baz")
+
+        assert IssueTransformer.get_attr(obj, "foo") == "baz"
+
+    def test_returns_none_for_missing_key(self) -> None:
+        assert IssueTransformer.get_attr({"foo": 1}, "missing") is None
+        assert IssueTransformer.get_attr(SimpleNamespace(foo=1), "missing") is None
+
+
+# ---------------------------------------------------------------------- #
+# process_changelog_item (3+ tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestProcessChangelogItem:
+    def test_assignee_change_resolves_user_ids(self) -> None:
+        owner = _make_owner(
+            user_mapping={
+                "alice": {"openproject_id": 1},
+                "bob": {"openproject_id": 2},
+            },
+        )
+        transformer = IssueTransformer(owner=owner)
+
+        result = transformer.process_changelog_item(
+            {
+                "field": "assignee",
+                "from": "alice",
+                "to": "bob",
+                "fromString": "Alice",
+                "toString": "Bob",
+            },
+        )
+
+        assert result == {"assigned_to_id": [1, 2]}
+
+    def test_status_change_resolves_via_status_mapping(self) -> None:
+        owner = _make_owner(
+            status_mapping={
+                "1": {"openproject_id": 100},
+                "6": {"openproject_id": 600},
+            },
+        )
+        transformer = IssueTransformer(owner=owner)
+
+        result = transformer.process_changelog_item(
+            {"field": "status", "from": "1", "to": "6"},
+        )
+
+        assert result == {"status_id": [100, 600]}
+
+    def test_skips_unmapped_field(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+
+        # Sprint is in IGNORED_CHANGELOG_FIELDS at the service layer; here we
+        # just confirm any field absent from the transformer's mapping table
+        # returns None.
+        assert transformer.process_changelog_item({"field": "Sprint", "from": "1", "to": "2"}) is None
+
+    def test_skips_no_change_value(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+
+        result = transformer.process_changelog_item(
+            {"field": "summary", "fromString": "Same", "toString": "Same"},
+        )
+
+        assert result is None
+
+    def test_time_estimate_converts_seconds_to_hours(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+
+        result = transformer.process_changelog_item(
+            {"field": "timeestimate", "from": "3600", "to": "7200"},
+        )
+
+        assert result == {"remaining_hours": [1.0, 2.0]}
+
+
+# ---------------------------------------------------------------------- #
+# extract_changelog_histories (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestExtractChangelogHistories:
+    def test_extracts_from_jira_issue_object(self) -> None:
+        h = SimpleNamespace(items=[])
+        issue = SimpleNamespace(changelog=SimpleNamespace(histories=[h]))
+
+        assert IssueTransformer.extract_changelog_histories(issue) == [h]
+
+    def test_extracts_from_raw_dict(self) -> None:
+        issue = SimpleNamespace(
+            changelog=None,
+            raw={"changelog": {"histories": [{"items": []}]}},
+        )
+
+        result = IssueTransformer.extract_changelog_histories(issue)
+
+        assert result == [{"items": []}]
+
+    def test_extracts_from_dict_payload(self) -> None:
+        issue = {"changelog": {"histories": [{"items": []}]}}
+
+        assert IssueTransformer.extract_changelog_histories(issue) == [{"items": []}]
+
+    def test_returns_empty_when_no_changelog(self) -> None:
+        assert IssueTransformer.extract_changelog_histories({}) == []
+        assert IssueTransformer.extract_changelog_histories(SimpleNamespace(changelog=None, raw=None)) == []
+
+
+# ---------------------------------------------------------------------- #
+# is_in_progress_category (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestIsInProgressCategory:
+    def test_matches_indeterminate_key(self) -> None:
+        assert IssueTransformer.is_in_progress_category({"key": "indeterminate"}) is True
+
+    def test_matches_in_progress_name_case_insensitive(self) -> None:
+        assert IssueTransformer.is_in_progress_category({"name": "IN PROGRESS"}) is True
+
+    def test_matches_jira_default_id_4(self) -> None:
+        assert IssueTransformer.is_in_progress_category({"id": 4}) is True
+
+    def test_does_not_match_done(self) -> None:
+        assert IssueTransformer.is_in_progress_category({"key": "done", "name": "Done"}) is False
+
+    def test_returns_false_for_empty_dict(self) -> None:
+        assert IssueTransformer.is_in_progress_category({}) is False
+
+
+# ---------------------------------------------------------------------- #
+# extract_issue_meta (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestExtractIssueMeta:
+    def test_extracts_meta_from_jira_issue_object(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+        fields = SimpleNamespace(
+            issuetype=SimpleNamespace(id="10001", name="Task"),
+            status=SimpleNamespace(id="3", name="In Progress"),
+            priority=SimpleNamespace(id="2", name="High"),
+            reporter=SimpleNamespace(name="alice"),
+            assignee=SimpleNamespace(name="bob"),
+            created="2024-01-01T00:00:00Z",
+            updated="2024-02-01T00:00:00Z",
+            duedate=None,
+            labels=["urgent", "security"],
+            components=[SimpleNamespace(name="auth"), SimpleNamespace(name="api")],
+            parent=SimpleNamespace(key="ABC-100"),
+        )
+        issue = SimpleNamespace(key="ABC-1", id="10001", fields=fields)
+
+        meta = transformer.extract_issue_meta(issue)
+
+        assert meta["jira_key"] == "ABC-1"
+        assert meta["jira_id"] == "10001"
+        assert meta["issuetype_name"] == "Task"
+        assert meta["status_name"] == "In Progress"
+        assert meta["labels"] == ["urgent", "security"]
+        assert meta["components"] == ["auth", "api"]
+        assert meta["parent_key"] == "ABC-100"
+
+    def test_extracts_meta_from_dict_payload(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+        issue = {
+            "key": "DEF-2",
+            "id": "20002",
+            "fields": {
+                "issuetype": {"id": "1", "name": "Bug"},
+                "status": {"id": "5", "name": "Closed"},
+                "priority": {"id": "3", "name": "Medium"},
+                "reporter": {"name": "carol"},
+                "assignee": {"displayName": "Dan"},
+                "created": "2024-01-01",
+                "labels": ["x"],
+                "components": [{"name": "core"}],
+                "parent": {"key": "DEF-1"},
+            },
+        }
+
+        meta = transformer.extract_issue_meta(issue)
+
+        assert meta["jira_key"] == "DEF-2"
+        assert meta["assignee"] == "Dan"
+        assert meta["components"] == ["core"]
+        assert meta["parent_key"] == "DEF-1"
+
+    def test_never_raises_on_garbage(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+
+        # Both of these would historically blow up — meta extraction must
+        # always succeed (returns whatever it could gather, possibly empty).
+        result_int = transformer.extract_issue_meta(12345)
+        result_str = transformer.extract_issue_meta("not an issue")
+
+        assert isinstance(result_int, dict)
+        assert isinstance(result_str, dict)
+
+
+# ---------------------------------------------------------------------- #
+# map_issue_type (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestMapIssueType:
+    def test_maps_via_id_mapping(self) -> None:
+        owner = _make_owner(issue_type_id_mapping={"10001": 5})
+        transformer = IssueTransformer(owner=owner)
+
+        assert transformer.map_issue_type(type_id="10001") == 5
+
+    def test_falls_back_to_issue_type_mapping_by_id(self) -> None:
+        owner = _make_owner(
+            issue_type_id_mapping={},
+            issue_type_mapping={"10001": {"openproject_id": 7}},
+        )
+        transformer = IssueTransformer(owner=owner)
+
+        assert transformer.map_issue_type(type_id="10001") == 7
+
+    def test_defaults_to_one_when_unmapped_and_warns(self) -> None:
+        recorded = _RecordingLogger()
+        owner = _make_owner(logger=recorded)
+        transformer = IssueTransformer(owner=owner)
+
+        result = transformer.map_issue_type(type_id="999", type_name="Mystery")
+
+        assert result == 1
+        assert any("No mapping found for issue type Mystery" in m for m in recorded.warning_calls)
+
+    def test_raises_when_neither_id_nor_name_provided(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+
+        with pytest.raises(ValueError, match="Either type_id or type_name"):
+            transformer.map_issue_type()
+
+
+# ---------------------------------------------------------------------- #
+# map_status (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestMapStatus:
+    def test_maps_via_status_mapping(self) -> None:
+        owner = _make_owner(status_mapping={"3": {"openproject_id": 13}})
+        transformer = IssueTransformer(owner=owner)
+
+        assert transformer.map_status(status_id="3") == 13
+
+    def test_defaults_to_one_when_unmapped(self) -> None:
+        recorded = _RecordingLogger()
+        owner = _make_owner(logger=recorded)
+        transformer = IssueTransformer(owner=owner)
+
+        result = transformer.map_status(status_id="x", status_name="Mystery")
+
+        assert result == 1
+        assert any("No mapping found for status Mystery" in m for m in recorded.warning_calls)
+
+    def test_raises_when_neither_id_nor_name_provided(self) -> None:
+        owner = _make_owner()
+        transformer = IssueTransformer(owner=owner)
+
+        with pytest.raises(ValueError, match="Either status_id or status_name"):
+            transformer.map_status()
+
+
+# ---------------------------------------------------------------------- #
+# sanitize_wp_dict (3 tests)
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestSanitizeWpDict:
+    def test_extracts_type_and_status_from_links(self) -> None:
+        wp: dict[str, Any] = {
+            "subject": "S",
+            "_links": {
+                "type": {"href": "/api/v3/types/7"},
+                "status": {"href": "/api/v3/statuses/9"},
+            },
+        }
+
+        IssueTransformer.sanitize_wp_dict(wp)
+
+        assert wp["type_id"] == 7
+        assert wp["status_id"] == 9
+        assert "_links" not in wp
+
+    def test_strips_non_ar_keys(self) -> None:
+        wp: dict[str, Any] = {
+            "subject": "S",
+            "watcher_ids": [1, 2],
+            "jira_id": "10001",
+            "jira_key": "ABC-1",
+            "type_name": "Task",
+        }
+
+        IssueTransformer.sanitize_wp_dict(wp)
+
+        for k in ("watcher_ids", "jira_id", "jira_key", "type_name"):
+            assert k not in wp
+
+    def test_escapes_subject_and_description(self) -> None:
+        wp: dict[str, Any] = {
+            "subject": 'with "quote" and \'apostrophe\'',
+            "description": 'desc with "x"',
+        }
+
+        IssueTransformer.sanitize_wp_dict(wp)
+
+        assert '\\"' in wp["subject"]
+        assert "\\'" in wp["subject"]
+        assert '\\"' in wp["description"]
+
+
+# ---------------------------------------------------------------------- #
+# Lazy property smoke test on the migration class
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_work_package_migration_delegates_via_lazy_transformer() -> None:
+    """Tests using ``WorkPackageMigration.__new__`` (no ``__init__``) still work.
+
+    Several existing test files instantiate the migration via ``__new__`` to
+    bypass the heavyweight ``__init__``. The transformer must be created
+    lazily on first access so those tests continue to call delegate methods
+    like ``_sanitize_wp_dict`` and ``_resolve_start_date`` directly.
+    """
+    from src.application.components.work_package_migration import WorkPackageMigration
+
+    migration = WorkPackageMigration.__new__(WorkPackageMigration)
+    migration.logger = logging.getLogger("test")
+    migration.start_date_fields = ["customfield_18690"]
+    migration.enhanced_timestamp_migrator = _IdentityNormalizer()
+    migration.status_category_by_id = {}
+    migration.status_category_by_name = {}
+
+    # Static delegate
+    wp = {"subject": "S", "_links": {"type": {"href": "/api/v3/types/3"}}}
+    migration._sanitize_wp_dict(wp)
+    assert wp.get("type_id") == 3
+
+    # Instance-bound delegate (accesses ``self.start_date_fields``)
+    issue = {"fields": {"customfield_18690": "2024-07-01T00:00:00+00:00"}}
+    assert migration._resolve_start_date(issue) == "2024-07-01"

--- a/tests/unit/test_issue_transformer.py
+++ b/tests/unit/test_issue_transformer.py
@@ -88,8 +88,7 @@ def _make_owner(
         markdown_converter=markdown_converter,
         _mentioned_users_by_project=mentioned_users_by_project if mentioned_users_by_project is not None else {},
         _current_project_id=current_project_id,
-        _get_or_create_version=version_resolver
-        or (lambda name, project_id: None),
+        _get_or_create_version=version_resolver or (lambda name, project_id: None),
         logger=logger or _RecordingLogger(),
     )
     return owner
@@ -783,7 +782,7 @@ class TestSanitizeWpDict:
 
     def test_escapes_subject_and_description(self) -> None:
         wp: dict[str, Any] = {
-            "subject": 'with "quote" and \'apostrophe\'',
+            "subject": "with \"quote\" and 'apostrophe'",
             "description": 'desc with "x"',
         }
 


### PR DESCRIPTION
## Summary

Phase 1 of the [`WorkPackageMigration` god-class decomposition plan](../blob/main/claudedocs/refactoring/work-package-migration-decomposition-plan.md). Extracts 16 pure-mapping methods from `WorkPackageMigration` into a new `IssueTransformer` class so they can be unit-tested in isolation. **Zero behaviour change** — the service keeps thin delegates that forward to the transformer.

- New module: `src/application/transformers/issue_transformer.py` (16 pure-mapping methods)
- Service shrinks from ~4,728 LOC to ~4,111 LOC; 693 lines of mapping logic moved out
- New tests: `tests/unit/test_issue_transformer.py` (59 unit tests, 3+ per method, no client mocks needed)

## What was moved

The transformer owns the following methods (renamed to drop the leading underscore now that they're crossing a class boundary):

| WorkPackageMigration delegate | IssueTransformer method |
|---|---|
| `_resolve_journal_author_id` | `resolve_journal_author_id` |
| `_track_mentioned_users` | `track_mentioned_users` |
| `_extract_final_workflow` | `extract_final_workflow` |
| `_parse_datetime` (static) | `parse_datetime` (static) |
| `_derive_snapshot_timestamp` | `derive_snapshot_timestamp` |
| `_build_key_exclusion_clause` (static) | `build_key_exclusion_clause` (static) |
| `_resolve_start_date` | `resolve_start_date` |
| `_resolve_start_date_from_history` | `resolve_start_date_from_history` |
| `_get_attr` (static) | `get_attr` (static) |
| `_process_changelog_item` | `process_changelog_item` |
| `_extract_changelog_histories` | `extract_changelog_histories` (static) |
| `_is_in_progress_category` (static) | `is_in_progress_category` (static) |
| `_extract_issue_meta` | `extract_issue_meta` |
| `_map_issue_type` | `map_issue_type` |
| `_map_status` | `map_status` |
| `_sanitize_wp_dict` | `sanitize_wp_dict` (static) |

## Design notes for reviewers

- **Owner-reference pattern**: the transformer holds `self._owner: WorkPackageMigration` and reads live attributes (`user_mapping`, `status_mapping`, `markdown_converter`, …) on demand. This preserves historical semantics where the service rebuilds its `markdown_converter` mid-`__init__` via `_update_markdown_converter_mappings`.
- **Lazy property**: `WorkPackageMigration._transformer` is a property that creates the transformer on first access. Required because several existing tests construct migrations via `WorkPackageMigration.__new__(WorkPackageMigration)` (bypassing `__init__`) and then call delegate methods directly.
- **Class constants preserved**: `_BUG32_FALLBACK_USER_ID` and `_JOURNAL_AUTHOR_PROBE_KEYS` remain on `WorkPackageMigration` as aliases pointing at the canonical values now living on `IssueTransformer`.
- **`_get_or_create_version` stays on the service**: the I/O dependency is pulled in via `owner._get_or_create_version` from inside `process_changelog_item` (the only caller) — no behaviour change.
- **Reviewer focus**: every body is a verbatim cut-and-paste with `self.<attr>` → `self._owner.<attr>` for service-owned mutable state; no logic edits. Easiest review path is the diff of `src/application/components/work_package_migration.py` (see how each method body collapsed to a one-liner delegate) plus a side-by-side read of the transformer module.

## Out of scope (Phase 3)

- `_prepare_work_package` (the 804-LOC monster), `_build_rails_ops_for_issue`, `_update_existing_work_package` — these contain interleaved I/O and mapping; they are decomposed in later phases.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `mypy src/` passes (0 errors)
- [x] `lint-imports` passes (Cosmic Python contract kept)
- [x] `pytest tests/unit/` passes — **1599 passed** (was 1540 before; +59 new transformer tests)
- [x] All existing unit tests that exercise the migration via `WorkPackageMigration.__new__` continue to pass through delegates