### PR TITLE
test: address post-merge review feedback on PR #232

### DIFF
--- a/tests/unit/test_reporting_migration.py
+++ b/tests/unit/test_reporting_migration.py
@@ -121,8 +121,18 @@ def test_reporting_migration_end_to_end_creates_query_and_wiki(_mock_mappings: N
 
 def test_reporting_migration_dashboard_without_share_uses_reporting_project(
     _mock_mappings: None,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Dashboard with no share + ensure_reporting_project succeeds → falls back to reporting project."""
+    # Isolate from any developer .env.local that pre-configures
+    # reporting_wiki_project / reporting_wiki_project_name in
+    # config.openproject_config — those would override the
+    # ensure_reporting_project() fallback (555) and break the assertion.
+    import src.config as cfg
+
+    monkeypatch.setitem(cfg.openproject_config, "reporting_wiki_project", "")
+    monkeypatch.setitem(cfg.openproject_config, "reporting_wiki_project_name", "")
+
     dashboards = [{"id": 30, "name": "Lonely", "sharePermissions": []}]
     op = DummyOp()
     mig = ReportingMigration(

--- a/tests/unit/test_time_entry_migration.py
+++ b/tests/unit/test_time_entry_migration.py
@@ -46,6 +46,15 @@ def _make_mig(
     # Patch TimeEntryMigrator so __init__ doesn't probe the OP client.
     monkeypatch.setattr(tem, "TimeEntryMigrator", MagicMock())
 
+    # Isolate from any J2O_JIRA_PROJECTS env override the developer may have
+    # set: TimeEntryMigration._load_migrated_work_packages() filters by
+    # config.jira_config['projects'] when non-empty, which can silently drop
+    # the seeded PROJ-1 mapping and route the test through the
+    # "no_migrated_work_packages" skip path.
+    import src.config as cfg
+
+    monkeypatch.setitem(cfg.jira_config, "projects", [])
+
     jira = MagicMock()
     op = MagicMock()
     if rails_present:
@@ -98,7 +107,7 @@ def test_run_zero_created_with_input_fails_loud(
     mapping = {
         "1001": {"jira_key": "PROJ-1", "openproject_id": 5001},
     }
-    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping), encoding="utf-8")
 
     mig = _make_mig(tmp_path, monkeypatch, rails_present=True)
 
@@ -124,7 +133,7 @@ def test_run_returns_success_when_migrator_creates_entries(
 ) -> None:
     """Happy path: migrator reports migrated entries → success."""
     mapping = {"1001": {"jira_key": "PROJ-1", "openproject_id": 5001}}
-    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping), encoding="utf-8")
 
     mig = _make_mig(tmp_path, monkeypatch, rails_present=True)
     mig.time_entry_migrator.migrate_time_entries_for_issues.return_value = {

--- a/tests/unit/test_work_package_content_migration.py
+++ b/tests/unit/test_work_package_content_migration.py
@@ -79,7 +79,7 @@ def test_load_work_package_mapping_builds_jira_key_lookup(
         "1001": {"jira_key": "PROJ-1", "openproject_id": 5001},
         "1002": {"jira_key": "PROJ-2", "openproject_id": 5002},
     }
-    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping), encoding="utf-8")
 
     mig = _build_mig(tmp_path)
     # Re-trigger load against the seeded file.
@@ -96,7 +96,7 @@ def test_load_work_package_mapping_skips_bare_int_legacy_rows(
         "1001": {"jira_key": "PROJ-1", "openproject_id": 5001},
         "1002": 9999,  # legacy bare-int row
     }
-    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping), encoding="utf-8")
 
     mig = _build_mig(tmp_path)
     assert mig._load_work_package_mapping() is True
@@ -116,7 +116,7 @@ def test_convert_jira_links_rewrites_known_keys(
     embedded in the output — the exact decoration is a converter concern.
     """
     mapping = {"1001": {"jira_key": "PROJ-1", "openproject_id": 5001}}
-    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping), encoding="utf-8")
 
     mig = _build_mig(tmp_path)
     mig._load_work_package_mapping()
@@ -142,7 +142,7 @@ def test_run_returns_success_on_clean_migration(
     only assert the run() wrapper produces the expected ComponentResult shape.
     """
     mapping = {"1001": {"jira_key": "PROJ-1", "openproject_id": 5001}}
-    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping))
+    (tmp_path / "work_package_mapping.json").write_text(json.dumps(mapping), encoding="utf-8")
 
     mig = _build_mig(tmp_path)
     mig._load_work_package_mapping()

--- a/tests/unit/test_work_package_skeleton_migration.py
+++ b/tests/unit/test_work_package_skeleton_migration.py
@@ -65,7 +65,7 @@ def test_save_mapping_persists_to_disk(tmp_path: Path, _mock_mappings: None) -> 
     assert mig._save_mapping() is True
     assert mig._last_save_succeeded is True
 
-    on_disk = json.loads(mig.work_package_mapping_file.read_text())
+    on_disk = json.loads(mig.work_package_mapping_file.read_text(encoding="utf-8"))
     assert on_disk == mig.work_package_mapping
 
 
@@ -88,6 +88,7 @@ def test_save_mapping_records_failure_when_write_fails(
 def test_load_existing_mapping_for_incremental_run(
     tmp_path: Path,
     _mock_mappings: None,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A pre-existing mapping file is loaded by the constructor for incremental runs."""
     from src.application.components.work_package_skeleton_migration import (
@@ -101,14 +102,16 @@ def test_load_existing_mapping_for_incremental_run(
 
     monkeypatch_data_dir = tmp_path / "var_data"
     monkeypatch_data_dir.mkdir()
-    (monkeypatch_data_dir / "work_package_mapping.json").write_text(json.dumps(seeded))
+    (monkeypatch_data_dir / "work_package_mapping.json").write_text(json.dumps(seeded), encoding="utf-8")
 
+    # Use monkeypatch so cfg.get_path is restored automatically even on failure.
     original_get_path = cfg.get_path
-    cfg.get_path = lambda key: monkeypatch_data_dir if key == "data" else original_get_path(key)
-    try:
-        mig = WorkPackageSkeletonMigration(jira_client=MagicMock(), op_client=MagicMock())
-    finally:
-        cfg.get_path = original_get_path
+    monkeypatch.setattr(
+        cfg,
+        "get_path",
+        lambda key: monkeypatch_data_dir if key == "data" else original_get_path(key),
+    )
+    mig = WorkPackageSkeletonMigration(jira_client=MagicMock(), op_client=MagicMock())
 
     assert mig.work_package_mapping == seeded
 


### PR DESCRIPTION
## Summary
Follow-up to the merged [PR #232](https://github.com/netresearch/jira-to-openproject/pull/232) addressing seven review comments that landed after merge. Tests-only changes; no production code touched.

## Per-comment

- **gemini × 5** (encoding): every `read_text`/`write_text(json.dumps(...))` call in the four files now passes `encoding="utf-8"` for cross-platform determinism.
- **gemini × 1** (skeleton): `test_load_existing_mapping_for_incremental_run` switches from a manual `try/finally` around `cfg.get_path` to `monkeypatch.setattr(...)` — auto-restored on teardown.
- **copilot × 1** (time_entry): `_make_mig` now clears `cfg.jira_config["projects"]` so a developer with `J2O_JIRA_PROJECTS` set can't accidentally filter out the seeded `PROJ-1` mapping.
- **copilot × 1** (reporting): the no-share dashboard test clears `cfg.openproject_config["reporting_wiki_project"]` / `["reporting_wiki_project_name"]` so a developer with `.env.local` overrides can't break the fallback assertion (555).

The atomic-write wrapper gemini suggested for the test fixtures was deliberately **not** applied — `tmp_path` files have no concurrent reader so the overhead has no payoff in unit tests; the encoding part is the load-bearing fix.

## Test plan
- [x] `ruff check tests/` — clean
- [x] `ruff format --check tests/` — clean
- [x] `pytest tests/unit/test_time_entry_migration.py tests/unit/test_work_package_content_migration.py tests/unit/test_work_package_skeleton_migration.py tests/unit/test_reporting_migration.py` — 19 passed
- [ ] CI green