### PR TITLE
docs: refresh README, supported versions, and repo metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
 
-A robust, modular migration toolset for transferring project management data from Jira Server 9.x to OpenProject 15+/16.x. Built with Python 3.14, this tool handles users, projects, work packages, custom fields, statuses, workflows, and attachments.
+A robust, modular migration toolset for transferring project management data from Jira Server 9.x to OpenProject 17.3+. Built with Python 3.14, this tool handles users, projects, work packages, custom fields, statuses, workflows, and attachments.
 
 ## Features
 
@@ -39,23 +39,31 @@ A robust, modular migration toolset for transferring project management data fro
 ### Supported Targets
 
 - Jira Server/Data Center 9.x (validated on 9.11)
-- OpenProject 16.x (validated on 16.0)
+- OpenProject 17.3+ (currently tested against 17.3)
 
 Earlier or later releases may work, but they are not part of the supported/tested matrix.
 
 ### Installation
 
+The project uses [uv](https://docs.astral.sh/uv/) for dependency management and Python 3.14+.
+
 ```bash
-# Clone and setup
-git clone <repository-url>
-cd jira-to-openproject-migration
-python -m venv .venv
-source .venv/bin/activate  # or activate.sh
-pip install -e .
+# Clone
+git clone https://github.com/netresearch/jira-to-openproject.git
+cd jira-to-openproject
+
+# Install dependencies (creates .venv automatically)
+uv sync --frozen --extra dev --extra test
 
 # Configure environment
 cp .env.example .env
 # Edit .env with your Jira and OpenProject credentials
+
+# Verify installation
+uv run pytest tests/unit -q          # ~1600 unit tests
+uv run ruff check .                  # lint
+uv run mypy src/                     # type check
+uv run lint-imports                  # architecture contract
 ```
 
 ### Development Environment
@@ -154,6 +162,19 @@ OpenProject Container
 OpenProject Application
 ```
 
+### Source Layout (Cosmic Python layers)
+
+The Python source follows a [Cosmic Python](https://www.cosmicpython.com/) layered structure, enforced in CI by [import-linter](https://import-linter.readthedocs.io/):
+
+| Layer | Path | Responsibility |
+|---|---|---|
+| Entrypoints | `src/main.py`, `src/dashboard/` | CLI and FastAPI dashboard — argument parsing, request handling |
+| Services | `src/application/components/`, `src/application/transformers/` | Migration orchestration, ETL pipelines, pure data transformations |
+| Adapters | `src/infrastructure/jira/`, `src/infrastructure/openproject/`, `src/infrastructure/persistence/` | I/O: Jira/OpenProject clients, SSH, Rails console, persistence |
+| Models | `src/domain/`, `src/models/` | Domain abstractions (Protocols, IDs, results) and data classes |
+
+The `architecture` job in CI (`uv run lint-imports`) enforces the dependency direction: higher layers may import from lower layers, never the reverse.
+
 ### Client Components
 
 - **OpenProjectClient**: High-level orchestration and API
@@ -223,6 +244,7 @@ logging:
 - **[Configuration Guide](docs/configuration.md)** - Detailed configuration options
 - **[Workflow & Status Guide](docs/WORKFLOW_STATUS_GUIDE.md)** - Status migration and workflow setup
 - **[Architecture Decisions](docs/adr/)** - ADRs documenting key technical decisions
+- **[Decision Records](docs/decisions/)** - Long-form rationale for non-trivial design choices
 
 ### Quick Reference
 
@@ -251,7 +273,8 @@ python src/main.py migrate --components all --verbose
 
 ### Prerequisites
 
-- **Python 3.13+**
+- **Python 3.14+**
+- **uv** (`pip install uv` or [install instructions](https://docs.astral.sh/uv/getting-started/installation/))
 - **Docker & Docker Compose** (for development environment)
 - **SSH access** to OpenProject server (for production migration)
 - **tmux** (for Rails console interaction)
@@ -281,11 +304,12 @@ tests/
 | Command | Description |
 |---------|-------------|
 | `make dev-test` | Unit tests locally (fastest feedback) |
-| `make container-test` | Unit tests in Docker (full deps, ~79 tests) |
-| `make container-test-integration` | Integration tests in Docker (~156 tests, mocked) |
+| `make container-test` | Unit tests in Docker (full deps, ~1600 tests) |
+| `make container-test-integration` | Integration tests in Docker (live-service-gated, mostly skipped without env flags) |
 | `make test-slow` | Integration + E2E tests in Docker |
 | `make test-verbose` | Tests with verbose output |
 | `make lint` | Run linting (ruff + mypy) |
+| `make check-architecture` | Enforce Cosmic Python layered architecture (import-linter) |
 
 **Test environment variables:**
 - `J2O_RUN_INTEGRATION=true` — Enable integration tests locally

--- a/docs/KNOWLEDGE_BASE.md
+++ b/docs/KNOWLEDGE_BASE.md
@@ -26,7 +26,7 @@
 **→ [Quick Start Guide](QUICK_START.md)** - Developer onboarding and first migration
 
 **Prerequisites**:
-- Python 3.13+
+- Python 3.14+
 - Docker & Docker Compose
 - SSH access to OpenProject server
 - tmux for Rails console
@@ -70,7 +70,7 @@ uv run python -m src.main migrate --components users --dry-run --no-confirm
 
 **Architecture Diagrams**:
 ```
-Local Migration Tool (Python 3.13)
+Local Migration Tool (Python 3.14)
     ↓ SSH Connection
 Remote OpenProject Server
     ↓ Docker Commands
@@ -732,7 +732,7 @@ pytest -k "test_jira_client"
 **Official Documentation**:
 - [Jira Server REST API](https://docs.atlassian.com/software/jira/docs/api/REST/)
 - [OpenProject API](https://www.openproject.org/docs/api/)
-- [Python 3.13 Documentation](https://docs.python.org/3.13/)
+- [Python 3.14 Documentation](https://docs.python.org/3.14/)
 
 **Related Projects**:
 - [tmux](https://github.com/tmux/tmux/wiki)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2,7 +2,7 @@
 
 **Target Audience**: Developers new to the j2o migration tool
 **Time**: 30-45 minutes
-**Prerequisites**: Python 3.13+, Docker, SSH access to OpenProject
+**Prerequisites**: Python 3.14+, Docker, SSH access to OpenProject
 
 ---
 
@@ -33,7 +33,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv sync --frozen
 
 # Verify installation
-uv run python --version  # Should show Python 3.13+
+uv run python --version  # Should show Python 3.14+
 ```
 
 ### Step 2: Configure Environment

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -93,7 +93,7 @@
 - Flagged cleanup script as legacy to steer new work toward migration abstractions.
 - Limited mypy coverage to `src/config_loader.py` pending broader cleanup of type errors across migrations and clients.
 - Host sandbox lacks PyPI connectivity, so run pytest targets inside the project containers instead of locally.
-- Target environment tested against Jira Server 9.x and OpenProject 15+/16.x; other versions are "best effort".
+- Target environment tested against Jira Server 9.x and OpenProject 17.3+; other versions are "best effort".
 - Journal creation changed from `journals.create!` to `journal_notes`/`journal_user` + `save!` for OP 15+ compatibility (2026-01).
 - Watcher migration rewritten to use batch `insert_all` with pre-fetched ID sets (`pluck(:id).to_set`) for 100x+ speedup (2026-01).
 - Rails runner timeout increased from 120s to 300s for large projects like ADKP (872 WPs) (2026-01).


### PR DESCRIPTION
## Summary

Brings README, contributor docs, and GitHub repo metadata back in sync with the current state of the codebase.

### Code/docs changes
- **Install instructions** — switch from `python -m venv && pip install -e .` to `uv sync --frozen --extra dev --extra test` (the project's actual workflow); list the four CI gates new contributors can run locally
- **Source layout** — new section documenting the [Cosmic Python](https://www.cosmicpython.com/) layered architecture and the import-linter contract added in #231 that enforces it in CI
- **Supported targets** — bumped to OpenProject 17.3+ (was 16.x) per the current validation environment
- **Python version** — bumped to 3.14+ across README, `docs/KNOWLEDGE_BASE.md`, `docs/QUICK_START.md`, and `src/AGENTS.md` (was lingering at 3.13+, but `pyproject.toml` already requires 3.14)
- **Test counts** — replaced stale `~79` / `~156` numbers in the make-target table with `~1600` (1599 unit tests on `main` today)
- **Decision Records link** — added pointer to `docs/decisions/` (already existed; just unlinked)

### GitHub repo metadata (already applied)
- **Description**: replaced the generic 4-word string with a one-sentence summary of what the tool actually does
- **Topics**: was `["application"]` (effectively unsearchable) → `[automation, data-migration, docker, etl, fastapi, jira, migration, migration-tool, netresearch, openproject, project-management, pydantic, python, python314, rails-console, ssh]`

## Test plan
- [x] No production code touched
- [x] `ruff check .` — clean
- [ ] CI green