### PR TITLE
fix(mapping-repo): silence 16 startup WARNINGs for list-shaped raw API cache files

### DIFF
--- a/src/infrastructure/persistence/mapping_repo.py
+++ b/src/infrastructure/persistence/mapping_repo.py
@@ -206,7 +206,15 @@ class JsonFileMappingRepository:
             return {}
 
         if not isinstance(raw, dict):
-            self._logger.warning(
+            # Log at DEBUG, not WARNING. The data directory is shared
+            # with raw API cache files (jira_custom_fields.json,
+            # jira_groups.json, …) that are legitimately list-shaped.
+            # When Mappings.get_all_mappings() enumerates all_names() it
+            # calls get() on every stem, including those raw-cache stems.
+            # A WARNING here produces a flood of 16 identical lines on
+            # every startup; DEBUG is sufficient for diagnostics because
+            # the caller already handles the returned empty-dict safely.
+            self._logger.debug(
                 "Mapping file %s has unexpected top-level shape %s; expected dict.",
                 path,
                 type(raw).__name__,

--- a/tests/unit/test_repositories_mapping_repo.py
+++ b/tests/unit/test_repositories_mapping_repo.py
@@ -111,14 +111,22 @@ class TestGet:
             encoding="utf-8",
         )
 
-        with caplog.at_level(logging.WARNING):
+        # Scope the caplog assertion to the mapping_repo logger so unrelated
+        # WARNINGs from other libraries / fixtures cannot make this test flaky.
+        repo_logger = "src.infrastructure.persistence.mapping_repo"
+        with caplog.at_level(logging.WARNING, logger=repo_logger):
             result = repo.get("jira_custom_fields")
 
         assert result == {}
-        # Must not emit a WARNING — only DEBUG is acceptable for a
-        # list-shaped file that simply isn't a mapping dict.
-        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
-        assert warning_records == [], f"Unexpected WARNING(s) emitted: {[r.message for r in warning_records]}"
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.name == repo_logger and r.levelno >= logging.WARNING
+        ]
+        assert warning_records == [], (
+            f"Unexpected WARNING(s) from {repo_logger}: "
+            f"{[r.message for r in warning_records]}"
+        )
 
     def test_non_dict_top_level_returns_empty_and_logs_at_debug(
         self,

--- a/tests/unit/test_repositories_mapping_repo.py
+++ b/tests/unit/test_repositories_mapping_repo.py
@@ -87,15 +87,49 @@ class TestGet:
         assert result == {}
         assert any("malformed JSON" in record.message for record in caplog.records)
 
-    def test_non_dict_top_level_returns_empty_and_warns(
+    def test_non_dict_top_level_returns_empty_without_warning(
         self,
         repo: JsonFileMappingRepository,
         data_dir: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        (data_dir / "list_mapping.json").write_text("[1, 2, 3]", encoding="utf-8")
+        """List-shaped JSON files in the data dir must not emit a WARNING.
+
+        The mapping repository shares its data directory with raw API
+        cache files (e.g. ``jira_custom_fields.json``) that are
+        legitimately list-shaped.  When ``Mappings.get_all_mappings()``
+        enumerates all names via ``all_names()`` it will call ``get()``
+        on every stem, including those raw-cache stems.  A WARNING here
+        causes a flood of 16 identical log lines on every startup.
+
+        The correct behaviour is: return ``{}`` (already the case) and
+        log only at DEBUG so operators can diagnose unexpected files
+        without being spammed on normal runs.
+        """
+        (data_dir / "jira_custom_fields.json").write_text(
+            '[{"id": 1, "name": "cf"}]',
+            encoding="utf-8",
+        )
 
         with caplog.at_level(logging.WARNING):
+            result = repo.get("jira_custom_fields")
+
+        assert result == {}
+        # Must not emit a WARNING — only DEBUG is acceptable for a
+        # list-shaped file that simply isn't a mapping dict.
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warning_records == [], f"Unexpected WARNING(s) emitted: {[r.message for r in warning_records]}"
+
+    def test_non_dict_top_level_returns_empty_and_logs_at_debug(
+        self,
+        repo: JsonFileMappingRepository,
+        data_dir: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """List-shaped files log the shape mismatch at DEBUG, not WARNING."""
+        (data_dir / "list_mapping.json").write_text("[1, 2, 3]", encoding="utf-8")
+
+        with caplog.at_level(logging.DEBUG):
             result = repo.get("list_mapping")
 
         assert result == {}

--- a/tests/unit/test_repositories_mapping_repo.py
+++ b/tests/unit/test_repositories_mapping_repo.py
@@ -118,14 +118,9 @@ class TestGet:
             result = repo.get("jira_custom_fields")
 
         assert result == {}
-        warning_records = [
-            r
-            for r in caplog.records
-            if r.name == repo_logger and r.levelno >= logging.WARNING
-        ]
+        warning_records = [r for r in caplog.records if r.name == repo_logger and r.levelno >= logging.WARNING]
         assert warning_records == [], (
-            f"Unexpected WARNING(s) from {repo_logger}: "
-            f"{[r.message for r in warning_records]}"
+            f"Unexpected WARNING(s) from {repo_logger}: {[r.message for r in warning_records]}"
         )
 
     def test_non_dict_top_level_returns_empty_and_logs_at_debug(


### PR DESCRIPTION
## Symptom

Every migration run emitted 16 identical WARNING lines at startup, one per raw API cache file in `var/data/`:

```
src.infrastructure.persistence.mapping_repo - WARNING - Mapping file /…/jira_custom_fields.json has unexpected top-level shape list; expected dict.
src.infrastructure.persistence.mapping_repo - WARNING - Mapping file /…/jira_groups.json has unexpected top-level shape list; expected dict.
… (14 more)
```

## Root cause

`migration.py` calls `config.mappings.get_all_mappings()` once at startup to prime the in-memory cache. `Mappings.get_all_mappings()` iterates `self._repo.all_names()`, which enumerates **every** `.json` file in the shared data directory — including the 16 raw API cache files (`jira_custom_fields.json`, `jira_groups.json`, `jira_issue_types.json`, …) that are legitimately list-shaped. For each of those stems, `_read_from_disk()` loaded the file, found a JSON list instead of a dict, and logged a WARNING before returning `{}`.

The data directory is shared between mapping files (dict-shaped, owned by the repository) and raw API cache files (list-shaped, written directly by migration components via `JsonStore`). The repository does not own the directory exclusively, so encountering a list-shaped file is a normal operating condition, not an error.

## Fix

In `JsonFileMappingRepository._read_from_disk`, demote the log call for a non-dict top-level shape from `WARNING` to `DEBUG`. The return value (`{}`) and all downstream behaviour are unchanged — the diagnostic message is still reachable under DEBUG-level logging for operators who need it, but it no longer floods the operator log on every startup.

The malformed-JSON warning (for `JSONDecodeError`) is intentionally left at WARNING since corrupted JSON is a genuine error condition.

## Test plan

- **New regression test** `test_non_dict_top_level_returns_empty_without_warning`: writes a list-shaped `jira_custom_fields.json` into a temp data dir, calls `repo.get("jira_custom_fields")` with `caplog` at WARNING level, asserts the result is `{}` and that zero WARNING records are emitted. This test failed before the fix and passes after.
- **New diagnostic test** `test_non_dict_top_level_returns_empty_and_logs_at_debug`: same setup with `caplog` at DEBUG level, asserts the "unexpected top-level shape" message still appears (diagnostic preserved).
- Full module suite: `pytest tests/unit/test_repositories_mapping_repo.py tests/unit/test_fake_mapping_repository.py -W error -q` — 38 passed, 0 failed.
- `ruff check .` and `ruff format --check .` — all checks passed.
- `mypy src/` — no issues found in 161 source files.