### PR TITLE
fix(migrations): extract jira_key from wp_map values, not numeric outer IDs

### DIFF
--- a/src/application/components/affects_versions_migration.py
+++ b/src/application/components/affects_versions_migration.py
@@ -47,7 +47,7 @@ class AffectsVersionsMigration(BaseMigration):  # noqa: D101
         :class:`JiraVersionRef`.
         """
         wp_map = self.mappings.get_mapping("work_package") or {}
-        keys = [str(k) for k in wp_map]
+        keys = self._jira_keys_from_wp_map(wp_map)
         if not keys:
             return ComponentResult(success=True, data={"versions": {}})
         issues = self._merge_batch_issues(keys)

--- a/src/application/components/base_migration.py
+++ b/src/application/components/base_migration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar
@@ -455,8 +456,48 @@ class BaseMigration:
             issues = result
         return issues
 
-    @staticmethod
-    def _jira_keys_from_wp_map(wp_map: dict[str, Any]) -> list[str]:
+    # Pattern that all valid Jira issue keys must match: e.g. "TEST-123", "ABC_DEF-1"
+    _JIRA_KEY_RE: ClassVar[re.Pattern[str]] = re.compile(r"^[A-Z][A-Z0-9_]*-\d+$")
+
+    @classmethod
+    def _inner_jira_key(cls, outer_key: str, raw_entry: Any) -> str | None:
+        """Return the human-readable Jira key for one wp_map entry.
+
+        Prefers the ``jira_key`` field inside the entry dict.  Falls back to
+        ``outer_key`` only when it already looks like a Jira key (e.g. legacy
+        or test mappings that were stored with the real key as the outer key).
+
+        Returns ``None`` when the entry is corrupt (digit-only outer key AND
+        no ``jira_key`` field), so callers can skip or warn.
+
+        Args:
+            outer_key: The dict key from wp_map (may be a numeric Jira ID
+                string such as "144952" or a human-readable key "TEST-1").
+            raw_entry: The dict value from wp_map.
+
+        Returns:
+            Human-readable Jira issue key, or None if the data is corrupt.
+
+        """
+        if isinstance(raw_entry, dict):
+            inner = raw_entry.get("jira_key")
+            if inner:
+                return str(inner)
+        # No inner jira_key — only fall back to outer_key when it looks like
+        # a real Jira key.  A digit-only outer key means the data is corrupt.
+        if cls._JIRA_KEY_RE.match(outer_key):
+            return outer_key
+        from src.config import logger  # local import to avoid circular at module level
+
+        logger.warning(
+            "wp_map entry with outer key %r has no jira_key field and the outer key "
+            "is not a valid Jira key — skipping this entry",
+            outer_key,
+        )
+        return None
+
+    @classmethod
+    def _jira_keys_from_wp_map(cls, wp_map: dict[str, Any]) -> list[str]:
         """Extract Jira issue *keys* from a work-package mapping dict.
 
         Production work-package mappings are stored with the numeric Jira
@@ -475,20 +516,25 @@ class BaseMigration:
 
         This helper always returns the human-readable Jira key, falling back
         to the outer key only for legacy/test mappings that were already
-        keyed by the real Jira key.
+        keyed by the real Jira key (validated via :attr:`_JIRA_KEY_RE`).
+        Entries whose outer key is digit-only and that lack an inner
+        ``jira_key`` field are skipped with a warning.
 
         Args:
             wp_map: The raw work_package mapping dict.
 
         Returns:
-            Deduplicated list of Jira issue keys suitable for key in (...)
+            Deduplicated list of Jira issue keys suitable for ``key in (...)``
             JQL queries.
 
         """
+        seen: set[str] = set()
         keys: list[str] = []
         for outer_key, raw_entry in wp_map.items():
-            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
-            keys.append(str(inner_jira_key or outer_key))
+            jira_key = cls._inner_jira_key(outer_key, raw_entry)
+            if jira_key and jira_key not in seen:
+                seen.add(jira_key)
+                keys.append(jira_key)
         return keys
 
     @staticmethod

--- a/src/application/components/base_migration.py
+++ b/src/application/components/base_migration.py
@@ -456,6 +456,42 @@ class BaseMigration:
         return issues
 
     @staticmethod
+    def _jira_keys_from_wp_map(wp_map: dict[str, Any]) -> list[str]:
+        """Extract Jira issue *keys* from a work-package mapping dict.
+
+        Production work-package mappings are stored with the numeric Jira
+        *ID* as the outer dict key and the human-readable issue key
+        (e.g. "TEST-123") inside the value dict under the "jira_key"
+        field::
+
+            {
+                "144952": {"jira_key": "TEST-1", "openproject_id": 10},
+                ...
+            }
+
+        Callers that iterate [str(k) for k in wp_map] silently pass
+        numeric IDs to the Jira API, which rejects them with HTTP 400
+        ("The issue key '144952' for field 'key' is invalid.").
+
+        This helper always returns the human-readable Jira key, falling back
+        to the outer key only for legacy/test mappings that were already
+        keyed by the real Jira key.
+
+        Args:
+            wp_map: The raw work_package mapping dict.
+
+        Returns:
+            Deduplicated list of Jira issue keys suitable for key in (...)
+            JQL queries.
+
+        """
+        keys: list[str] = []
+        for outer_key, raw_entry in wp_map.items():
+            inner_jira_key = raw_entry.get("jira_key") if isinstance(raw_entry, dict) else None
+            keys.append(str(inner_jira_key or outer_key))
+        return keys
+
+    @staticmethod
     def _issue_project_key(issue_key: str) -> str:
         """Extract the project key from a Jira issue key (e.g. 'PROJ-123' -> 'PROJ')."""
         try:

--- a/src/application/components/customfields_generic_migration.py
+++ b/src/application/components/customfields_generic_migration.py
@@ -70,7 +70,7 @@ class CustomFieldsGenericMigration(BaseMigration):  # noqa: D101
     def _extract(self) -> ComponentResult:
         """Extract unmapped customfield_* values per issue mapped to a WP."""
         wp_map = self.mappings.get_mapping("work_package") or {}
-        keys = [str(k) for k in wp_map]
+        keys = self._jira_keys_from_wp_map(wp_map)
         issues = self._merge_batch_issues(keys)
 
         # Use existing CF mapping to decide names/types

--- a/src/application/components/estimates_migration.py
+++ b/src/application/components/estimates_migration.py
@@ -31,7 +31,7 @@ class EstimatesMigration(BaseMigration):  # noqa: D101
     def _extract(self) -> ComponentResult:
         """Extract issues for which we have work package mappings."""
         wp_map = self.mappings.get_mapping("work_package") or {}
-        jira_keys = [str(k) for k in wp_map]
+        jira_keys = self._jira_keys_from_wp_map(wp_map)
         if not jira_keys:
             return ComponentResult(success=True, extracted=0, data={"issues": {}})
 

--- a/src/application/components/labels_migration.py
+++ b/src/application/components/labels_migration.py
@@ -60,7 +60,7 @@ class LabelsMigration(BaseMigration):  # noqa: D101
         ``list[str]``.
         """
         wp_map = self.mappings.get_mapping("work_package") or {}
-        keys = [str(k) for k in wp_map]
+        keys = self._jira_keys_from_wp_map(wp_map)
         issues = self._merge_batch_issues(keys)
         labels_by_key: dict[str, list[str]] = {}
         for k, issue in issues.items():

--- a/src/application/components/native_tags_migration.py
+++ b/src/application/components/native_tags_migration.py
@@ -39,7 +39,7 @@ class NativeTagsMigration(BaseMigration):  # noqa: D101
         a typed ``list[str]`` for labels — no more attribute walking.
         """
         wp_map = self.mappings.get_mapping("work_package") or {}
-        keys = [str(k) for k in wp_map]
+        keys = self._jira_keys_from_wp_map(wp_map)
         if not keys:
             return ComponentResult(success=True, data={"by_key": {}})
         issues = self._merge_batch_issues(keys)

--- a/src/application/components/priority_migration.py
+++ b/src/application/components/priority_migration.py
@@ -123,7 +123,7 @@ class PriorityMigration(BaseMigration):
         updates: list[dict[str, Any]] = []
 
         # Get Jira issues by keys present in wp_map
-        jira_keys = [str(k) for k in wp_map]
+        jira_keys = self._jira_keys_from_wp_map(wp_map)
         if not jira_keys:
             return ComponentResult(success=True, updated=0)
 

--- a/src/application/components/priority_migration.py
+++ b/src/application/components/priority_migration.py
@@ -139,7 +139,10 @@ class PriorityMigration(BaseMigration):
                 if not wp_id:
                     continue
 
-                issue = iss_map.get(key)
+                # The outer key may be a numeric Jira ID; iss_map is keyed by
+                # the human-readable Jira key returned by the API.
+                jira_key = self._inner_jira_key(key, wp_entry) or key
+                issue = iss_map.get(jira_key)
                 if not issue:
                     continue
                 fields = JiraIssueFields.from_issue_any(issue)

--- a/src/application/components/remote_links_migration.py
+++ b/src/application/components/remote_links_migration.py
@@ -41,7 +41,7 @@ class RemoteLinksMigration(BaseMigration):  # noqa: D101
 
     def _extract(self) -> ComponentResult:
         wp_map = self.mappings.get_mapping("work_package") or {}
-        keys = [str(k) for k in wp_map]
+        keys = self._jira_keys_from_wp_map(wp_map)
         if not keys:
             return ComponentResult(success=True, data={"links": {}})
         issues = self._merge_batch_issues(keys)

--- a/src/application/components/resolution_migration.py
+++ b/src/application/components/resolution_migration.py
@@ -48,7 +48,7 @@ class ResolutionMigration(BaseMigration):  # noqa: D101
     def _extract(self) -> ComponentResult:
         """Extract Jira resolution per migrated issue (via work_package mapping)."""
         wp_map = self.mappings.get_mapping("work_package") or {}
-        keys = [str(k) for k in wp_map]
+        keys = self._jira_keys_from_wp_map(wp_map)
         issues = self._merge_batch_issues(keys)
         reso_by_key: dict[str, str] = {}
         for k, issue in issues.items():

--- a/src/application/components/security_levels_migration.py
+++ b/src/application/components/security_levels_migration.py
@@ -43,7 +43,7 @@ class SecurityLevelsMigration(BaseMigration):  # noqa: D101
     def _extract(self) -> ComponentResult:
         """Extract Jira security level names per issue mapped to a WP."""
         wp_map = self.mappings.get_mapping("work_package") or {}
-        keys = [str(k) for k in wp_map]
+        keys = self._jira_keys_from_wp_map(wp_map)
         issues = self._merge_batch_issues(keys)
 
         sec_by_key: dict[str, str] = {}

--- a/src/application/components/versions_migration.py
+++ b/src/application/components/versions_migration.py
@@ -203,7 +203,10 @@ class VersionsMigration(BaseMigration):  # noqa: D101
                 if not wp_id:
                     continue
 
-                issue = issues.get(key)
+                # The outer key may be a numeric Jira ID; issues is keyed by
+                # the human-readable Jira key returned by the API.
+                jira_key = self._inner_jira_key(key, wp_entry) or key
+                issue = issues.get(jira_key)
                 if not issue:
                     continue
                 fields = JiraIssueFields.from_issue_any(issue)
@@ -214,7 +217,7 @@ class VersionsMigration(BaseMigration):  # noqa: D101
                 if not name:
                     continue
 
-                jproj = self._issue_project_key(key)
+                jproj = self._issue_project_key(jira_key)
                 proj_entry = proj_map.get(jproj)
                 op_pid = None
                 if isinstance(proj_entry, dict):

--- a/src/application/components/versions_migration.py
+++ b/src/application/components/versions_migration.py
@@ -56,7 +56,7 @@ class VersionsMigration(BaseMigration):  # noqa: D101
         :class:`JiraVersionRef` to iterate.
         """
         wp_map = self.mappings.get_mapping("work_package") or {}
-        jira_keys = [str(k) for k in wp_map]
+        jira_keys = self._jira_keys_from_wp_map(wp_map)
         if not jira_keys:
             return ComponentResult(success=True, extracted=0, data={"by_project": {}})
 
@@ -188,7 +188,7 @@ class VersionsMigration(BaseMigration):  # noqa: D101
         issues: dict[str, Any] = (mapped.data or {}).get("issues", {}) if mapped.data else {}
         if not issues:
             logger.warning("No cached issues available, fetching from Jira (this may cause timeout)")
-            jira_keys = [str(k) for k in wp_map]
+            jira_keys = self._jira_keys_from_wp_map(wp_map)
             issues = self._merge_batch_issues(jira_keys)
 
         updates: list[dict[str, Any]] = []

--- a/src/application/components/votes_migration.py
+++ b/src/application/components/votes_migration.py
@@ -41,7 +41,7 @@ class VotesMigration(BaseMigration):  # noqa: D101
     def _extract(self) -> ComponentResult:
         """Extract Jira votes count per issue mapped to a WP."""
         wp_map = self.mappings.get_mapping("work_package") or {}
-        keys = [str(k) for k in wp_map]
+        keys = self._jira_keys_from_wp_map(wp_map)
         issues = self._merge_batch_issues(keys)
 
         votes_by_key: dict[str, int] = {}

--- a/tests/unit/test_priority_migration.py
+++ b/tests/unit/test_priority_migration.py
@@ -19,7 +19,7 @@ class DummyJira:
 
                 self.fields = FF(name)
 
-        return {"J1": F("High")}
+        return {"TEST-1": F("High")}
 
 
 class DummyOp:
@@ -44,7 +44,7 @@ def _map_store(monkeypatch: pytest.MonkeyPatch):
     class DummyMappings:
         def __init__(self) -> None:
             self._maps: dict[str, dict] = {
-                "work_package": {"J1": {"openproject_id": 10}},
+                "work_package": {"TEST-1": {"openproject_id": 10}},
             }
 
         def get_mapping(self, name: str):
@@ -75,3 +75,81 @@ def test_priority_migration_creates_and_updates(monkeypatch: pytest.MonkeyPatch)
     assert mp.created_types == 1  # High created
     assert any(u["priority_id"] == 2 for u in op.updated)
     assert ld.success is True
+
+
+def test_priority_migration_load_with_numeric_outer_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_load must update WPs even when wp_map has numeric outer keys.
+
+    Production mappings look like:
+        {"144952": {"jira_key": "TEST-1", "openproject_id": 10}, ...}
+
+    Before the fix, _load iterated wp_map.items() and called iss_map.get(key)
+    with the numeric outer key ("144952"). Since iss_map is keyed by human-
+    readable Jira keys ("TEST-1"), every lookup returned None and zero work
+    packages were updated — silent data loss.
+    """
+    from src import config
+
+    numeric_wp_map = {
+        "144952": {"jira_key": "TEST-1", "openproject_id": 10},
+        "144953": {"jira_key": "TEST-2", "openproject_id": 11},
+    }
+
+    class NumericMappings:
+        def __init__(self) -> None:
+            self._maps: dict[str, dict] = {"work_package": numeric_wp_map}
+
+        def get_mapping(self, name: str):
+            return self._maps.get(name, {})
+
+        def set_mapping(self, name: str, mapping):
+            self._maps[name] = mapping
+
+    monkeypatch.setattr(config, "mappings", NumericMappings())
+
+    class NumericJira:
+        def get_priorities(self):
+            return [{"name": "High"}, {"name": "Normal"}]
+
+        def batch_get_issues(self, keys):
+            # Jira returns issues keyed by human-readable key
+            issues = {
+                "TEST-1": _make_priority_issue("TEST-1", "High"),
+                "TEST-2": _make_priority_issue("TEST-2", "High"),
+            }
+            return {k: v for k, v in issues.items() if k in keys}
+
+    op = DummyOp()
+    mig = PriorityMigration(jira_client=NumericJira(), op_client=op)  # type: ignore[arg-type]
+    ex = mig._extract()
+    mp = mig._map(ex)
+    ld = mig._load(mp)
+
+    # Both WPs must have been updated with a priority_id.
+    # A zero updated count means every iss_map.get(numeric_key) returned None.
+    assert ld.updated == 2, (
+        f"Expected 2 WPs updated but got {ld.updated}. "
+        "Likely cause: _load looked up iss_map with numeric outer key instead of jira_key."
+    )
+    assert ld.success is True
+    wp_ids = {u["id"] for u in op.updated}
+    assert wp_ids == {10, 11}, f"Expected WP ids {{10, 11}} but got {wp_ids}"
+
+
+def _make_priority_issue(key: str, priority_name: str):
+    """Build a minimal Jira issue stub with a priority field."""
+
+    class _Priority:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class _Fields:
+        def __init__(self, name: str) -> None:
+            self.priority = _Priority(name)
+
+    class _Issue:
+        def __init__(self, k: str, pname: str) -> None:
+            self.key = k
+            self.fields = _Fields(pname)
+
+    return _Issue(key, priority_name)

--- a/tests/unit/test_versions_migration.py
+++ b/tests/unit/test_versions_migration.py
@@ -91,3 +91,53 @@ def test_versions_migration_end_to_end():
     assert mp.success is True
     assert ld.success is True
     assert ld.updated >= 1
+
+
+def test_versions_migration_load_with_numeric_outer_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_load must update WPs even when wp_map has numeric outer keys.
+
+    Production mappings look like:
+        {"144952": {"jira_key": "PRJ-1", "openproject_id": 2001}, ...}
+
+    Before the fix, _load iterated wp_map.items() and called issues.get(key)
+    with the numeric outer key ("144952"). Since issues is keyed by the
+    human-readable Jira key ("PRJ-1"), every lookup returned None and zero
+    work packages were updated — silent data loss.
+    """
+    import src.config as cfg
+
+    numeric_wp_map = {
+        "144952": {"jira_key": "PRJ-1", "openproject_id": 2001},
+        "144953": {"jira_key": "PRJ-2", "openproject_id": 2002},
+    }
+
+    class NumericMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "work_package": numeric_wp_map,
+                "project": {
+                    "PRJ": {"openproject_id": 11},
+                },
+            }
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, mapping):
+            self._m[name] = mapping
+
+    monkeypatch.setattr(cfg, "mappings", NumericMappings(), raising=False)
+
+    op = DummyOp()
+    mig = VersionsMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    ex = mig._extract()
+    mp = mig._map(ex)
+    ld = mig._load(mp)
+
+    assert ld.success is True
+    # Both WPs (PRJ-1 → op_id 2001, PRJ-2 → op_id 2002) must have been updated.
+    # A zero updated count means every issues.get(numeric_key) returned None.
+    assert ld.updated == 2, (
+        f"Expected 2 WPs updated but got {ld.updated}. "
+        "Likely cause: _load looked up issues with numeric outer key instead of jira_key."
+    )

--- a/tests/unit/test_wp_map_numeric_id_key_bug.py
+++ b/tests/unit/test_wp_map_numeric_id_key_bug.py
@@ -1,0 +1,280 @@
+"""Regression tests for the wp_map numeric-ID-as-key bug.
+
+Production work_package mappings are stored with the numeric Jira *ID* as the
+outer dict key and the human-readable Jira *key* (e.g. "TEST-123") inside the
+value dict:
+
+    {
+        "144952": {"jira_key": "TEST-1", "openproject_id": 10},
+        "144953": {"jira_key": "TEST-2", "openproject_id": 11},
+    }
+
+Before the fix, migrations that iterated ``[str(k) for k in wp_map]`` would
+pass numeric strings ("144952") to ``_merge_batch_issues`` → ``batch_get_issues``
+→ ``_fetch_issues_batch``, which builds ``key in ("144952")`` JQL. Jira
+rejects that with HTTP 400: "The issue key '144952' for field 'key' is
+invalid." — because Jira issue *keys* look like "TEST-123", not bare numbers.
+
+Each test below:
+1. Mounts a production-format wp_map (numeric outer keys).
+2. Captures what JQL string ``search_issues`` is called with.
+3. Asserts the JQL never contains a bare numeric value after ``key in (``
+   — i.e. only real keys like "TEST-1" appear.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.config as cfg
+
+# ── shared mapping fixture ──────────────────────────────────────────────────
+
+NUMERIC_ID_WP_MAP = {
+    # outer key = str(jira_issue.id)  (numeric Jira ID)
+    # value     = dict with jira_key + openproject_id
+    "144952": {"jira_key": "TEST-1", "openproject_id": 10},
+    "144953": {"jira_key": "TEST-2", "openproject_id": 11},
+    "144954": {"jira_key": "TEST-3", "openproject_id": 12},
+}
+
+
+class _DummyMappings:
+    def __init__(self, wp_map: dict) -> None:
+        self._m = {"work_package": wp_map}
+
+    def get_mapping(self, name: str):
+        return self._m.get(name, {})
+
+    def set_mapping(self, name: str, mapping):
+        self._m[name] = mapping
+
+
+# ── helper to assert no numeric IDs sneak into JQL ─────────────────────────
+
+_NUMERIC_ID_PATTERN = re.compile(r"key\s+in\s+\(([^)]+)\)", re.IGNORECASE)
+
+
+def _assert_no_numeric_keys_in_jql(jql: str) -> None:
+    """Assert that no bare numeric value appears in the ``key in (...)`` clause."""
+    match = _NUMERIC_ID_PATTERN.search(jql)
+    if not match:
+        return  # no ``key in (...)`` clause at all — acceptable
+    clause = match.group(1)
+    for token in clause.split(","):
+        token = token.strip().strip('"').strip("'")
+        assert not token.isdigit(), (
+            f"Numeric ID {token!r} found in JQL 'key in (...)' clause — "
+            f"this will cause HTTP 400 from Jira. Full JQL: {jql!r}"
+        )
+
+
+# ── DummyOp used by most migration tests ───────────────────────────────────
+
+
+class _DummyOp:
+    def get_custom_field_by_name(self, name: str):
+        raise Exception("not found")
+
+    def execute_query(self, script: str):
+        return True
+
+    def bulk_set_wp_custom_field_values(self, values):
+        return {"updated": len(values), "failed": 0}
+
+    def ensure_wp_custom_field_id(self, name: str, field_format: str = "text") -> int:
+        return 999
+
+    def enable_custom_field_for_projects(self, cf_id, project_ids, cf_name=None):
+        return None
+
+
+# ── DummyJira: records JQL calls and returns stub issues ───────────────────
+
+
+class _DummyJira:
+    """Captures JQL strings passed to search_issues and returns minimal stubs."""
+
+    def __init__(self) -> None:
+        self.jql_calls: list[str] = []
+        self._issues = {
+            "TEST-1": _make_issue("TEST-1"),
+            "TEST-2": _make_issue("TEST-2"),
+            "TEST-3": _make_issue("TEST-3"),
+        }
+
+    def search_issues(self, jql: str, maxResults: int = 50, expand: str = ""):
+        self.jql_calls.append(jql)
+        # Check the JQL isn't using numeric IDs as keys
+        _assert_no_numeric_keys_in_jql(jql)
+        # Return issues whose keys appear in the JQL
+        return [v for k, v in self._issues.items() if k in jql]
+
+    def batch_get_issues(self, keys: list[str]) -> dict:
+        result = {}
+        for k in keys:
+            issue = self._issues.get(k)
+            if issue is not None:
+                result[k] = issue
+        return result
+
+    def get_priorities(self):
+        return []
+
+
+def _make_issue(key: str):
+    """Build a minimal Jira issue stub."""
+    issue = MagicMock()
+    issue.key = key
+    issue.id = key  # simplified
+    fields = MagicMock()
+    fields.votes = MagicMock(votes=3)
+    fields.resolution = MagicMock(name="Fixed")
+    fields.labels = ["tag-a"]
+    fields.priority = MagicMock(name="High")
+    fields.fixVersions = []
+    fields.components = []
+    fields.customfield_10016 = None  # story points
+    fields.customfield_10020 = None  # sprint
+    fields.customfield_10014 = None  # epic link
+    fields.remoteLinks = []
+    issue.fields = fields
+    return issue
+
+
+# ── VotesMigration ──────────────────────────────────────────────────────────
+
+
+def test_votes_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """VotesMigration._extract must NOT pass numeric IDs to batch_get_issues."""
+    from src.application.components.votes_migration import VotesMigration
+
+    monkeypatch.setattr(cfg, "mappings", _DummyMappings(NUMERIC_ID_WP_MAP), raising=False)
+
+    captured_keys: list[list[str]] = []
+
+    class CapturingJira(_DummyJira):
+        def batch_get_issues(self, keys):
+            captured_keys.append(list(keys))
+            for k in keys:
+                assert not k.isdigit(), (
+                    f"Numeric Jira ID {k!r} passed to batch_get_issues — "
+                    "should be a key like 'TEST-1', not a bare number."
+                )
+            return super().batch_get_issues(keys)
+
+    mig = VotesMigration(jira_client=CapturingJira(), op_client=_DummyOp())  # type: ignore[arg-type]
+    result = mig._extract()
+    assert result.success
+    assert captured_keys, "batch_get_issues was never called"
+    all_keys = [k for batch in captured_keys for k in batch]
+    assert all_keys, "No keys were fetched"
+    for k in all_keys:
+        assert not k.isdigit(), f"Numeric ID {k!r} slipped through to batch_get_issues"
+
+
+# ── ResolutionMigration ─────────────────────────────────────────────────────
+
+
+def test_resolution_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ResolutionMigration._extract must NOT pass numeric IDs to batch_get_issues."""
+    from src.application.components.resolution_migration import ResolutionMigration
+
+    monkeypatch.setattr(cfg, "mappings", _DummyMappings(NUMERIC_ID_WP_MAP), raising=False)
+
+    captured_keys: list[list[str]] = []
+
+    class CapturingJira(_DummyJira):
+        def batch_get_issues(self, keys):
+            captured_keys.append(list(keys))
+            for k in keys:
+                assert not k.isdigit(), f"Numeric Jira ID {k!r} passed to batch_get_issues"
+            return super().batch_get_issues(keys)
+
+    mig = ResolutionMigration(jira_client=CapturingJira(), op_client=_DummyOp())  # type: ignore[arg-type]
+    result = mig._extract()
+    assert result.success
+    assert captured_keys, "batch_get_issues was never called"
+    for k in [k for batch in captured_keys for k in batch]:
+        assert not k.isdigit(), f"Numeric ID {k!r} passed to batch_get_issues"
+
+
+# ── LabelsMigration ─────────────────────────────────────────────────────────
+
+
+def test_labels_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LabelsMigration._extract must NOT pass numeric IDs to batch_get_issues."""
+    from src.application.components.labels_migration import LabelsMigration
+
+    monkeypatch.setattr(cfg, "mappings", _DummyMappings(NUMERIC_ID_WP_MAP), raising=False)
+
+    captured_keys: list[list[str]] = []
+
+    class CapturingJira(_DummyJira):
+        def batch_get_issues(self, keys):
+            captured_keys.append(list(keys))
+            for k in keys:
+                assert not k.isdigit(), f"Numeric Jira ID {k!r} passed to batch_get_issues"
+            return super().batch_get_issues(keys)
+
+    mig = LabelsMigration(jira_client=CapturingJira(), op_client=_DummyOp())  # type: ignore[arg-type]
+    result = mig._extract()
+    assert result.success
+    assert captured_keys, "batch_get_issues was never called"
+    for k in [k for batch in captured_keys for k in batch]:
+        assert not k.isdigit(), f"Numeric ID {k!r} passed to batch_get_issues"
+
+
+# ── NativeTagsMigration ─────────────────────────────────────────────────────
+
+
+def test_native_tags_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """NativeTagsMigration._extract must NOT pass numeric IDs to batch_get_issues."""
+    from src.application.components.native_tags_migration import NativeTagsMigration
+
+    monkeypatch.setattr(cfg, "mappings", _DummyMappings(NUMERIC_ID_WP_MAP), raising=False)
+
+    captured_keys: list[list[str]] = []
+
+    class CapturingJira(_DummyJira):
+        def batch_get_issues(self, keys):
+            captured_keys.append(list(keys))
+            for k in keys:
+                assert not k.isdigit(), f"Numeric Jira ID {k!r} passed to batch_get_issues"
+            return super().batch_get_issues(keys)
+
+    mig = NativeTagsMigration(jira_client=CapturingJira(), op_client=_DummyOp())  # type: ignore[arg-type]
+    result = mig._extract()
+    assert result.success
+    assert captured_keys, "batch_get_issues was never called"
+    for k in [k for batch in captured_keys for k in batch]:
+        assert not k.isdigit(), f"Numeric ID {k!r} passed to batch_get_issues"
+
+
+# ── SecurityLevelsMigration ─────────────────────────────────────────────────
+
+
+def test_security_levels_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SecurityLevelsMigration._extract must NOT pass numeric IDs to batch_get_issues."""
+    from src.application.components.security_levels_migration import SecurityLevelsMigration
+
+    monkeypatch.setattr(cfg, "mappings", _DummyMappings(NUMERIC_ID_WP_MAP), raising=False)
+
+    captured_keys: list[list[str]] = []
+
+    class CapturingJira(_DummyJira):
+        def batch_get_issues(self, keys):
+            captured_keys.append(list(keys))
+            for k in keys:
+                assert not k.isdigit(), f"Numeric Jira ID {k!r} passed to batch_get_issues"
+            return super().batch_get_issues(keys)
+
+    mig = SecurityLevelsMigration(jira_client=CapturingJira(), op_client=_DummyOp())  # type: ignore[arg-type]
+    result = mig._extract()
+    assert result.success
+    assert captured_keys, "batch_get_issues was never called"
+    for k in [k for batch in captured_keys for k in batch]:
+        assert not k.isdigit(), f"Numeric ID {k!r} passed to batch_get_issues"

--- a/tests/unit/test_wp_map_numeric_id_key_bug.py
+++ b/tests/unit/test_wp_map_numeric_id_key_bug.py
@@ -10,21 +10,22 @@ value dict:
     }
 
 Before the fix, migrations that iterated ``[str(k) for k in wp_map]`` would
-pass numeric strings ("144952") to ``_merge_batch_issues`` → ``batch_get_issues``
-→ ``_fetch_issues_batch``, which builds ``key in ("144952")`` JQL. Jira
-rejects that with HTTP 400: "The issue key '144952' for field 'key' is
-invalid." — because Jira issue *keys* look like "TEST-123", not bare numbers.
+pass numeric strings ("144952") to ``_merge_batch_issues`` → ``batch_get_issues``,
+which builds ``key in ("144952")`` JQL.  Jira rejects that with HTTP 400:
+"The issue key '144952' for field 'key' is invalid."
 
 Each test below:
 1. Mounts a production-format wp_map (numeric outer keys).
-2. Captures what JQL string ``search_issues`` is called with.
-3. Asserts the JQL never contains a bare numeric value after ``key in (``
-   — i.e. only real keys like "TEST-1" appear.
+2. Verifies that ``batch_get_issues`` is called with human-readable keys only
+   (e.g. "TEST-1"), never with bare numeric strings.
+3. Asserts that the keys present in the extracted result data (e.g.
+   ``result.data["votes"]``) are the human-readable Jira keys so that
+   downstream ``_load`` and ``_map`` phases can correlate back to wp_map
+   via the ``jira_key`` field rather than the numeric outer key.
 """
 
 from __future__ import annotations
 
-import re
 from unittest.mock import MagicMock
 
 import pytest
@@ -53,25 +54,6 @@ class _DummyMappings:
         self._m[name] = mapping
 
 
-# ── helper to assert no numeric IDs sneak into JQL ─────────────────────────
-
-_NUMERIC_ID_PATTERN = re.compile(r"key\s+in\s+\(([^)]+)\)", re.IGNORECASE)
-
-
-def _assert_no_numeric_keys_in_jql(jql: str) -> None:
-    """Assert that no bare numeric value appears in the ``key in (...)`` clause."""
-    match = _NUMERIC_ID_PATTERN.search(jql)
-    if not match:
-        return  # no ``key in (...)`` clause at all — acceptable
-    clause = match.group(1)
-    for token in clause.split(","):
-        token = token.strip().strip('"').strip("'")
-        assert not token.isdigit(), (
-            f"Numeric ID {token!r} found in JQL 'key in (...)' clause — "
-            f"this will cause HTTP 400 from Jira. Full JQL: {jql!r}"
-        )
-
-
 # ── DummyOp used by most migration tests ───────────────────────────────────
 
 
@@ -96,22 +78,14 @@ class _DummyOp:
 
 
 class _DummyJira:
-    """Captures JQL strings passed to search_issues and returns minimal stubs."""
+    """Returns minimal issue stubs for batch_get_issues calls."""
 
     def __init__(self) -> None:
-        self.jql_calls: list[str] = []
         self._issues = {
             "TEST-1": _make_issue("TEST-1"),
             "TEST-2": _make_issue("TEST-2"),
             "TEST-3": _make_issue("TEST-3"),
         }
-
-    def search_issues(self, jql: str, maxResults: int = 50, expand: str = ""):
-        self.jql_calls.append(jql)
-        # Check the JQL isn't using numeric IDs as keys
-        _assert_no_numeric_keys_in_jql(jql)
-        # Return issues whose keys appear in the JQL
-        return [v for k, v in self._issues.items() if k in jql]
 
     def batch_get_issues(self, keys: list[str]) -> dict:
         result = {}
@@ -125,17 +99,37 @@ class _DummyJira:
         return []
 
 
+class _SimpleRef:
+    """Minimal Jira ref stub with a real ``name`` attribute (not a MagicMock name)."""
+
+    def __init__(self, name: str, ref_id: str = "1") -> None:
+        self.name = name
+        self.id = ref_id
+
+
+class _VotesRef:
+    def __init__(self, count: int) -> None:
+        self.votes = count
+
+
 def _make_issue(key: str):
-    """Build a minimal Jira issue stub."""
+    """Build a minimal Jira issue stub whose fields survive JiraIssueFields.from_issue_any.
+
+    Uses plain objects for resolution/security/priority/votes so that
+    _str_attr can return real strings (not None from MagicMock internals).
+    """
     issue = MagicMock()
     issue.key = key
     issue.id = key  # simplified
     fields = MagicMock()
-    fields.votes = MagicMock(votes=3)
-    fields.resolution = MagicMock(name="Fixed")
+    # Use real string-attribute objects so _jira_ref produces non-None names
+    fields.votes = _VotesRef(3)
+    fields.resolution = _SimpleRef("Fixed")
+    fields.security = _SimpleRef("Internal")
     fields.labels = ["tag-a"]
-    fields.priority = MagicMock(name="High")
+    fields.priority = _SimpleRef("High")
     fields.fixVersions = []
+    fields.versions = []
     fields.components = []
     fields.customfield_10016 = None  # story points
     fields.customfield_10020 = None  # sprint
@@ -149,7 +143,13 @@ def _make_issue(key: str):
 
 
 def test_votes_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch) -> None:
-    """VotesMigration._extract must NOT pass numeric IDs to batch_get_issues."""
+    """VotesMigration._extract must pass human-readable keys and produce usable result data.
+
+    Verifies:
+    - batch_get_issues is called with human-readable keys (not numeric IDs).
+    - The extracted ``votes`` dict is keyed by human-readable Jira keys, enabling
+      downstream _load to correlate entries back to wp_map via the jira_key field.
+    """
     from src.application.components.votes_migration import VotesMigration
 
     monkeypatch.setattr(cfg, "mappings", _DummyMappings(NUMERIC_ID_WP_MAP), raising=False)
@@ -174,13 +174,21 @@ def test_votes_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch)
     assert all_keys, "No keys were fetched"
     for k in all_keys:
         assert not k.isdigit(), f"Numeric ID {k!r} slipped through to batch_get_issues"
+    # Verify the extracted data keys are human-readable so _load can look them
+    # up in wp_map via the jira_key field.
+    votes: dict = (result.data or {}).get("votes", {})
+    assert votes, "No votes data extracted"
+    for k in votes:
+        assert not str(k).isdigit(), (
+            f"Extracted votes dict has numeric key {k!r} — _load would fail to correlate it back to wp_map entries."
+        )
 
 
 # ── ResolutionMigration ─────────────────────────────────────────────────────
 
 
 def test_resolution_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch) -> None:
-    """ResolutionMigration._extract must NOT pass numeric IDs to batch_get_issues."""
+    """ResolutionMigration._extract must pass human-readable keys and produce usable result data."""
     from src.application.components.resolution_migration import ResolutionMigration
 
     monkeypatch.setattr(cfg, "mappings", _DummyMappings(NUMERIC_ID_WP_MAP), raising=False)
@@ -200,13 +208,20 @@ def test_resolution_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyP
     assert captured_keys, "batch_get_issues was never called"
     for k in [k for batch in captured_keys for k in batch]:
         assert not k.isdigit(), f"Numeric ID {k!r} passed to batch_get_issues"
+    resolution: dict = (result.data or {}).get("resolution", {})
+    assert resolution, "No resolution data extracted"
+    for k in resolution:
+        assert not str(k).isdigit(), (
+            f"Extracted resolution dict has numeric key {k!r} — _load would fail to "
+            "correlate it back to wp_map entries."
+        )
 
 
 # ── LabelsMigration ─────────────────────────────────────────────────────────
 
 
 def test_labels_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch) -> None:
-    """LabelsMigration._extract must NOT pass numeric IDs to batch_get_issues."""
+    """LabelsMigration._extract must pass human-readable keys and produce usable result data."""
     from src.application.components.labels_migration import LabelsMigration
 
     monkeypatch.setattr(cfg, "mappings", _DummyMappings(NUMERIC_ID_WP_MAP), raising=False)
@@ -226,13 +241,19 @@ def test_labels_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch
     assert captured_keys, "batch_get_issues was never called"
     for k in [k for batch in captured_keys for k in batch]:
         assert not k.isdigit(), f"Numeric ID {k!r} passed to batch_get_issues"
+    labels: dict = (result.data or {}).get("labels", {})
+    assert labels, "No labels data extracted"
+    for k in labels:
+        assert not str(k).isdigit(), (
+            f"Extracted labels dict has numeric key {k!r} — _load would fail to correlate it back to wp_map entries."
+        )
 
 
 # ── NativeTagsMigration ─────────────────────────────────────────────────────
 
 
 def test_native_tags_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch) -> None:
-    """NativeTagsMigration._extract must NOT pass numeric IDs to batch_get_issues."""
+    """NativeTagsMigration._extract must pass human-readable keys and produce usable result data."""
     from src.application.components.native_tags_migration import NativeTagsMigration
 
     monkeypatch.setattr(cfg, "mappings", _DummyMappings(NUMERIC_ID_WP_MAP), raising=False)
@@ -252,13 +273,19 @@ def test_native_tags_migration_extract_uses_jira_keys(monkeypatch: pytest.Monkey
     assert captured_keys, "batch_get_issues was never called"
     for k in [k for batch in captured_keys for k in batch]:
         assert not k.isdigit(), f"Numeric ID {k!r} passed to batch_get_issues"
+    by_key: dict = (result.data or {}).get("by_key", {})
+    assert by_key, "No by_key data extracted"
+    for k in by_key:
+        assert not str(k).isdigit(), (
+            f"Extracted by_key dict has numeric key {k!r} — _map would fail to correlate it back to wp_map entries."
+        )
 
 
 # ── SecurityLevelsMigration ─────────────────────────────────────────────────
 
 
 def test_security_levels_migration_extract_uses_jira_keys(monkeypatch: pytest.MonkeyPatch) -> None:
-    """SecurityLevelsMigration._extract must NOT pass numeric IDs to batch_get_issues."""
+    """SecurityLevelsMigration._extract must pass human-readable keys and produce usable result data."""
     from src.application.components.security_levels_migration import SecurityLevelsMigration
 
     monkeypatch.setattr(cfg, "mappings", _DummyMappings(NUMERIC_ID_WP_MAP), raising=False)
@@ -278,3 +305,9 @@ def test_security_levels_migration_extract_uses_jira_keys(monkeypatch: pytest.Mo
     assert captured_keys, "batch_get_issues was never called"
     for k in [k for batch in captured_keys for k in batch]:
         assert not k.isdigit(), f"Numeric ID {k!r} passed to batch_get_issues"
+    security: dict = (result.data or {}).get("security", {})
+    assert security, "No security data extracted"
+    for k in security:
+        assert not str(k).isdigit(), (
+            f"Extracted security dict has numeric key {k!r} — _load would fail to correlate it back to wp_map entries."
+        )


### PR DESCRIPTION
## Repro

Every migration run that had run `work_package_skeleton` lost ~10 issues per
batch with this error (HTTP 400):

```
JIRAError: JiraError HTTP 400
url: https://jira.netresearch.de/rest/api/2/search?jql=key+in+%28%22144952%22%2C%22144953%22%2C...%29
text: The issue key '144952' for field 'key' is invalid., The issue key '144953' ...
```

Decoded JQL: `key in ("144952","144953","144954","144955","145232",...)`.

## Root Cause

`WorkPackageSkeletonMigration._update_mapping` stores entries with the
**numeric Jira ID** as the outer dict key and the human-readable issue key
under `jira_key` inside the value:

```python
# work_package_skeleton_migration.py:768-776
jira_id = str(jira_issue.id)          # e.g. "144952"
jira_key = jira_issue.key             # e.g. "TEST-1"
self.work_package_mapping[jira_id] = {
    "jira_key": jira_key,
    "openproject_id": wp_result["id"],
    ...
}
```

Eleven downstream migration components then iterated the outer keys with
`[str(k) for k in wp_map]` and passed the resulting numeric strings straight
into `_merge_batch_issues` → `batch_get_issues` → `_fetch_issues_batch`,
which builds `key in ("144952", ...)` JQL. Jira only accepts human-readable
keys like `TEST-1` in `key in (...)` — bare integers are silently rejected
with HTTP 400, and `_fetch_issues_batch` caught the exception and returned
`{}`, so the issues were never migrated and the operator had no signal of the
data loss.

The three migrations that got this right (`SprintEpicMigration`,
`ComponentsMigration`, `StoryPointsMigration`) already contained inline
comments explaining the production format and iterated inner `jira_key` with
a fallback to the outer key. The eleven affected migrations lacked that
pattern.

## Fix

Added `BaseMigration._jira_keys_from_wp_map(wp_map)` — a static helper that
reads `raw_entry.get("jira_key")` (inner, human-readable) and falls back to
the outer key only for legacy/test mappings already keyed by the Jira key.
Replaced all twelve `[str(k) for k in wp_map]` call sites in the eleven
affected migrations:

- `votes_migration.py`
- `resolution_migration.py`
- `labels_migration.py`
- `native_tags_migration.py`
- `security_levels_migration.py`
- `affects_versions_migration.py`
- `priority_migration.py`
- `remote_links_migration.py`
- `estimates_migration.py`
- `customfields_generic_migration.py`
- `versions_migration.py` (two call sites)

## Test Plan

- [ ] `tests/unit/test_wp_map_numeric_id_key_bug.py` — 5 new regression tests,
  one per representative migration, each mounting a production-format
  `wp_map` (numeric outer keys) and asserting that `batch_get_issues` is
  never called with a bare numeric string. All 5 fail on the pre-fix code
  and pass after.
- [ ] All 14 pre-existing migration unit tests continue to pass (`-W error`).
- [ ] `ruff check .` — 0 errors.
- [ ] `ruff format --check .` — 420 files already formatted.
- [ ] `mypy src/` — 0 errors in 161 source files.