### PR TITLE
fix(workflow): suppress 404 JIRAError as DEBUG instead of ERROR

### DIFF
--- a/src/infrastructure/jira/jira_workflow_service.py
+++ b/src/infrastructure/jira/jira_workflow_service.py
@@ -27,6 +27,31 @@ from src.infrastructure.jira.jira_client import (
 )
 
 
+def _is_workflow_404(exc: BaseException) -> bool:
+    """Return True if *exc* or any exception in its ``__cause__`` chain is a Jira 404.
+
+    In production ``JiraClient._patch_jira_client`` wraps every exception
+    (including ``JIRAError``) into ``JiraApiError`` so the outer exception is
+    never a ``JIRAError`` directly.  The original ``JIRAError(status_code=404)``
+    is stored as ``exc.__cause__``.  Walking the chain makes the check work
+    for both the bare-``JIRAError`` path (unit-test stub, some alternate code
+    paths) and the production-wrapping path.
+
+    The *seen* set guards against pathological cycles where ``__cause__`` is
+    set to the exception itself.
+    """
+    from jira.exceptions import JIRAError as _JIRAError
+
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, _JIRAError) and getattr(current, "status_code", None) == HTTP_NOT_FOUND:
+            return True
+        current = current.__cause__
+    return False
+
+
 class JiraWorkflowService:
     """Workflow-domain queries for ``JiraClient``."""
 
@@ -191,9 +216,12 @@ class JiraWorkflowService:
             # never fires for real 404s.  Catch it here instead and suppress at
             # DEBUG level — these endpoints do not exist on many Server/DC versions
             # and 404 is expected, not an error worth alarming on.
-            from jira.exceptions import JIRAError as _JIRAError
-
-            if isinstance(exc, _JIRAError) and getattr(exc, "status_code", None) == HTTP_NOT_FOUND:
+            #
+            # In production JiraClient._patch_jira_client wraps every exception
+            # into JiraApiError, so exc is never a JIRAError directly — the
+            # original JIRAError(status_code=404) lives in exc.__cause__.
+            # _is_workflow_404 walks the __cause__ chain to handle both paths.
+            if _is_workflow_404(exc):
                 self._logger.debug(
                     "Workflow '%s' transitions endpoint returned 404 (not available on this server); treating as empty",
                     workflow_name,
@@ -244,9 +272,12 @@ class JiraWorkflowService:
             # never fires for real 404s.  Catch it here instead and suppress at
             # DEBUG level — these endpoints do not exist on many Server/DC versions
             # and 404 is expected, not an error worth alarming on.
-            from jira.exceptions import JIRAError as _JIRAError
-
-            if isinstance(exc, _JIRAError) and getattr(exc, "status_code", None) == HTTP_NOT_FOUND:
+            #
+            # In production JiraClient._patch_jira_client wraps every exception
+            # into JiraApiError, so exc is never a JIRAError directly — the
+            # original JIRAError(status_code=404) lives in exc.__cause__.
+            # _is_workflow_404 walks the __cause__ chain to handle both paths.
+            if _is_workflow_404(exc):
                 self._logger.debug(
                     "Workflow '%s' definition endpoint returned 404 (not available on this server); treating as empty",
                     workflow_name,

--- a/src/infrastructure/jira/jira_workflow_service.py
+++ b/src/infrastructure/jira/jira_workflow_service.py
@@ -163,11 +163,11 @@ class JiraWorkflowService:
 
         try:
             response = client.jira._session.get(url)
-            # The per-workflow transitions endpoint isn't part of the public
-            # Jira REST API in many Server/DC versions and returns 404. The
-            # caller treats absence as an empty list, so don't raise (would
-            # only generate noise). Other HTTP errors still raise normally.
-            if getattr(response, "status_code", None) == 404:
+            # Defensive check for callers that return a response object
+            # with status_code rather than raising.  The ``jira`` library's
+            # ResilientSession raises JIRAError before reaching this point,
+            # so this branch is a belt-and-suspenders guard only.
+            if getattr(response, "status_code", None) == HTTP_NOT_FOUND:
                 self._logger.debug(
                     "Workflow '%s' returned 404 for transitions; treating as empty",
                     workflow_name,
@@ -186,6 +186,19 @@ class JiraWorkflowService:
             )
             return transitions
         except Exception as exc:
+            # The ``jira`` library's ResilientSession raises JIRAError(status_code=404)
+            # before returning any response object, so the status-code check above
+            # never fires for real 404s.  Catch it here instead and suppress at
+            # DEBUG level — these endpoints do not exist on many Server/DC versions
+            # and 404 is expected, not an error worth alarming on.
+            from jira.exceptions import JIRAError as _JIRAError
+
+            if isinstance(exc, _JIRAError) and getattr(exc, "status_code", None) == HTTP_NOT_FOUND:
+                self._logger.debug(
+                    "Workflow '%s' transitions endpoint returned 404 (not available on this server); treating as empty",
+                    workflow_name,
+                )
+                return []
             error_msg = f"Failed to fetch transitions for workflow '{workflow_name}': {exc!s}"
             self._logger.exception(error_msg)
             raise JiraApiError(error_msg) from exc
@@ -203,11 +216,11 @@ class JiraWorkflowService:
 
         try:
             response = client.jira._session.get(url)
-            # See ``get_workflow_transitions``: the per-workflow definition
-            # endpoint is not part of the public Jira REST API in many
-            # Server/DC versions and returns 404. Caller already tolerates
-            # an empty list, so suppress 404 silently.
-            if getattr(response, "status_code", None) == 404:
+            # Defensive check for callers that return a response object
+            # with status_code rather than raising.  The ``jira`` library's
+            # ResilientSession raises JIRAError before reaching this point,
+            # so this branch is a belt-and-suspenders guard only.
+            if getattr(response, "status_code", None) == HTTP_NOT_FOUND:
                 self._logger.debug(
                     "Workflow '%s' returned 404 for definition; treating as empty",
                     workflow_name,
@@ -226,6 +239,19 @@ class JiraWorkflowService:
             )
             return []
         except Exception as exc:
+            # The ``jira`` library's ResilientSession raises JIRAError(status_code=404)
+            # before returning any response object, so the status-code check above
+            # never fires for real 404s.  Catch it here instead and suppress at
+            # DEBUG level — these endpoints do not exist on many Server/DC versions
+            # and 404 is expected, not an error worth alarming on.
+            from jira.exceptions import JIRAError as _JIRAError
+
+            if isinstance(exc, _JIRAError) and getattr(exc, "status_code", None) == HTTP_NOT_FOUND:
+                self._logger.debug(
+                    "Workflow '%s' definition endpoint returned 404 (not available on this server); treating as empty",
+                    workflow_name,
+                )
+                return []
             error_msg = f"Failed to fetch workflow definition for '{workflow_name}': {exc!s}"
             self._logger.exception(error_msg)
             raise JiraApiError(error_msg) from exc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,10 @@ if "jira" not in sys.modules:
     exceptions_module = types.ModuleType("jira.exceptions")
 
     class _CTestJIRAError(Exception):
-        pass
+        def __init__(self, text=None, status_code=None, url=None, **kwargs):
+            super().__init__(text)
+            self.status_code = status_code
+            self.url = url
 
     exceptions_module.JIRAError = _CTestJIRAError
     jira_module.exceptions = exceptions_module

--- a/tests/unit/test_jira_workflow_404_silent.py
+++ b/tests/unit/test_jira_workflow_404_silent.py
@@ -16,10 +16,18 @@ straight into the ``except Exception as exc`` handler which calls
 ``self._logger.exception(...)`` — printing a full traceback at ERROR
 level for each of the 55 workflows.
 
-Fix: catch ``JIRAError`` explicitly in the ``except`` block; when
+Fix (initial): catch ``JIRAError`` explicitly in the ``except`` block; when
 ``exc.status_code == 404`` log at DEBUG and return ``[]``. For all other
 status codes / exception types keep the existing raise behaviour so real
 failures are still visible.
+
+Fix (production-complete): In production ``JiraClient._patch_jira_client``
+wraps the ``jira`` SDK session so that *all* exceptions (including
+``JIRAError``) are re-raised as ``JiraApiError`` with the original
+``JIRAError`` stored as ``exc.__cause__``. Therefore the ``isinstance(exc,
+JIRAError)`` check is always ``False`` in production. The fix must walk the
+``__cause__`` chain so that a ``JiraApiError`` whose cause is a
+``JIRAError(status_code=404)`` is also treated silently.
 """
 
 from __future__ import annotations
@@ -65,7 +73,7 @@ def _make_service_returning(status_code: int = 200, json_body: Any | None = None
 
 
 def _make_service_raising_jira_error(status_code: int) -> JiraWorkflowService:
-    """Session raises JIRAError with the given status_code — the real production path."""
+    """Session raises JIRAError directly — bare path (no production wrapping)."""
     from jira.exceptions import JIRAError
 
     fake_session = MagicMock()
@@ -74,6 +82,42 @@ def _make_service_raising_jira_error(status_code: int) -> JiraWorkflowService:
         status_code=status_code,
         url="https://jira.example.com/rest/api/2/workflow/Some%20Workflow",
     )
+
+    fake_jira = MagicMock()
+    fake_jira._session = fake_session
+
+    fake_client = MagicMock()
+    fake_client.jira = fake_jira
+    fake_client.base_url = "https://jira.example.com"
+
+    return JiraWorkflowService(fake_client)
+
+
+def _make_service_raising_wrapped_jira_error(status_code: int) -> JiraWorkflowService:
+    """Session raises JiraApiError whose __cause__ is a JIRAError.
+
+    This simulates the PRODUCTION path: ``JiraClient._patch_jira_client``
+    installs a ``patched_request`` shim that catches *all* exceptions and
+    re-raises them as ``JiraApiError(msg) from original_exc``.  So the
+    ``JIRAError(status_code=404)`` raised by the ``jira`` SDK's
+    ``ResilientSession`` never reaches the service directly — instead the
+    service sees a ``JiraApiError`` with the original ``JIRAError`` stored
+    as ``__cause__``.
+    """
+    from jira.exceptions import JIRAError
+
+    from src.infrastructure.jira.jira_client import JiraApiError
+
+    cause = JIRAError(
+        text="Not Found",
+        status_code=status_code,
+        url="https://jira.example.com/rest/api/2/workflow/Some%20Workflow",
+    )
+    wrapper = JiraApiError(f"Error during API request: {cause!s}")
+    wrapper.__cause__ = cause
+
+    fake_session = MagicMock()
+    fake_session.get.side_effect = wrapper
 
     fake_jira = MagicMock()
     fake_jira._session = fake_session
@@ -133,6 +177,65 @@ def test_get_workflow_statuses_raises_on_jira_500(
     from src.infrastructure.jira.jira_client import JiraApiError
 
     service = _make_service_raising_jira_error(status_code=500)
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(JiraApiError):
+            service.get_workflow_statuses("X")
+
+
+# ---------------------------------------------------------------------------
+# Tests: production path — JiraApiError wrapping a JIRAError(status_code=404)
+#
+# In production JiraClient._patch_jira_client wraps the SDK session so every
+# exception (including JIRAError) is re-raised as JiraApiError with the
+# original JIRAError stored as __cause__.  The isinstance(exc, JIRAError)
+# check is therefore always False in production.  _is_workflow_404 must walk
+# the __cause__ chain to detect this case.
+# ---------------------------------------------------------------------------
+
+
+def test_get_workflow_transitions_no_error_log_when_wrapped_404(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JiraApiError wrapping JIRAError(404) must be handled quietly — no ERROR log, returns []."""
+    service = _make_service_raising_wrapped_jira_error(status_code=404)
+    with caplog.at_level(logging.DEBUG):
+        result = service.get_workflow_transitions("Sales + Accounting: Customer Epic")
+    assert result == [], "expected empty list on production-wrapped 404"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records == [], f"Got unexpected ERROR log entries: {error_records}"
+
+
+def test_get_workflow_statuses_no_error_log_when_wrapped_404(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JiraApiError wrapping JIRAError(404) must be handled quietly — no ERROR log, returns []."""
+    service = _make_service_raising_wrapped_jira_error(status_code=404)
+    with caplog.at_level(logging.DEBUG):
+        result = service.get_workflow_statuses("DXP: Management tasks workflow")
+    assert result == [], "expected empty list on production-wrapped 404"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records == [], f"Got unexpected ERROR log entries: {error_records}"
+
+
+def test_get_workflow_transitions_raises_on_wrapped_500(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JiraApiError wrapping JIRAError(500) must still propagate — real failures must surface."""
+    from src.infrastructure.jira.jira_client import JiraApiError
+
+    service = _make_service_raising_wrapped_jira_error(status_code=500)
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(JiraApiError):
+            service.get_workflow_transitions("X")
+
+
+def test_get_workflow_statuses_raises_on_wrapped_500(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JiraApiError wrapping JIRAError(500) must still propagate — real failures must surface."""
+    from src.infrastructure.jira.jira_client import JiraApiError
+
+    service = _make_service_raising_wrapped_jira_error(status_code=500)
     with caplog.at_level(logging.DEBUG):
         with pytest.raises(JiraApiError):
             service.get_workflow_statuses("X")

--- a/tests/unit/test_jira_workflow_404_silent.py
+++ b/tests/unit/test_jira_workflow_404_silent.py
@@ -8,8 +8,18 @@ in ``workflow_migration.py`` already swallows the exception and uses an
 empty list, so logging at ERROR with a stack trace per workflow (55 such
 records on the live NRS run) is pure noise.
 
-Fix: short-circuit on 404 and return ``[]`` silently. Real (non-404)
-errors still surface as warnings + JiraApiError so they're not buried.
+Root cause: the ``jira`` library's ``ResilientSession.raise_on_error``
+raises ``JIRAError(status_code=404)`` *before* returning any response
+object, so the existing ``if getattr(response, "status_code", None) == 404``
+guard is dead code that never executes. The raised ``JIRAError`` falls
+straight into the ``except Exception as exc`` handler which calls
+``self._logger.exception(...)`` — printing a full traceback at ERROR
+level for each of the 55 workflows.
+
+Fix: catch ``JIRAError`` explicitly in the ``except`` block; when
+``exc.status_code == 404`` log at DEBUG and return ``[]``. For all other
+status codes / exception types keep the existing raise behaviour so real
+failures are still visible.
 """
 
 from __future__ import annotations
@@ -22,8 +32,13 @@ import pytest
 
 from src.infrastructure.jira.jira_workflow_service import JiraWorkflowService
 
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
 
-def _make_service(status_code: int = 404, json_body: Any | None = None) -> JiraWorkflowService:
+
+def _make_service_returning(status_code: int = 200, json_body: Any | None = None) -> JiraWorkflowService:
+    """Session returns a normal response object (200 / 404 via response attribute)."""
     fake_response = MagicMock()
     fake_response.status_code = status_code
     fake_response.json.return_value = json_body if json_body is not None else {}
@@ -49,10 +64,89 @@ def _make_service(status_code: int = 404, json_body: Any | None = None) -> JiraW
     return JiraWorkflowService(fake_client)
 
 
+def _make_service_raising_jira_error(status_code: int) -> JiraWorkflowService:
+    """Session raises JIRAError with the given status_code — the real production path."""
+    from jira.exceptions import JIRAError
+
+    fake_session = MagicMock()
+    fake_session.get.side_effect = JIRAError(
+        text="Not Found",
+        status_code=status_code,
+        url="https://jira.example.com/rest/api/2/workflow/Some%20Workflow",
+    )
+
+    fake_jira = MagicMock()
+    fake_jira._session = fake_session
+
+    fake_client = MagicMock()
+    fake_client.jira = fake_jira
+    fake_client.base_url = "https://jira.example.com"
+
+    return JiraWorkflowService(fake_client)
+
+
+# ---------------------------------------------------------------------------
+# Tests: JIRAError raised by ResilientSession (the real production path)
+# ---------------------------------------------------------------------------
+
+
+def test_get_workflow_transitions_no_error_log_when_jira_raises_404(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JIRAError(status_code=404) must be handled quietly — no ERROR log, returns []."""
+    service = _make_service_raising_jira_error(status_code=404)
+    with caplog.at_level(logging.DEBUG):
+        result = service.get_workflow_transitions("Sales + Accounting: Customer Epic")
+    assert result == [], "expected empty list on 404"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records == [], f"Got unexpected ERROR log entries: {error_records}"
+
+
+def test_get_workflow_statuses_no_error_log_when_jira_raises_404(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JIRAError(status_code=404) must be handled quietly — no ERROR log, returns []."""
+    service = _make_service_raising_jira_error(status_code=404)
+    with caplog.at_level(logging.DEBUG):
+        result = service.get_workflow_statuses("DXP: Management tasks workflow")
+    assert result == [], "expected empty list on 404"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records == [], f"Got unexpected ERROR log entries: {error_records}"
+
+
+def test_get_workflow_transitions_raises_on_jira_500(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JIRAError(status_code=500) must still raise JiraApiError so real failures surface."""
+    from src.infrastructure.jira.jira_client import JiraApiError
+
+    service = _make_service_raising_jira_error(status_code=500)
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(JiraApiError):
+            service.get_workflow_transitions("X")
+
+
+def test_get_workflow_statuses_raises_on_jira_500(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JIRAError(status_code=500) must still raise JiraApiError so real failures surface."""
+    from src.infrastructure.jira.jira_client import JiraApiError
+
+    service = _make_service_raising_jira_error(status_code=500)
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(JiraApiError):
+            service.get_workflow_statuses("X")
+
+
+# ---------------------------------------------------------------------------
+# Tests: original response-object path (kept for regression coverage)
+# ---------------------------------------------------------------------------
+
+
 def test_get_workflow_transitions_returns_empty_on_404(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    service = _make_service(status_code=404)
+    service = _make_service_returning(status_code=404)
     with caplog.at_level(logging.DEBUG):
         result = service.get_workflow_transitions("Sales: Customer Epic")
     assert result == []
@@ -63,7 +157,7 @@ def test_get_workflow_transitions_returns_empty_on_404(
 def test_get_workflow_statuses_returns_empty_on_404(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    service = _make_service(status_code=404)
+    service = _make_service_returning(status_code=404)
     with caplog.at_level(logging.DEBUG):
         result = service.get_workflow_statuses("Sales: Customer Epic")
     assert result == []
@@ -75,7 +169,7 @@ def test_get_workflow_transitions_still_raises_on_other_errors() -> None:
     """Non-404 errors should still surface as JiraApiError."""
     from src.infrastructure.jira.jira_client import JiraApiError
 
-    service = _make_service(status_code=500)
+    service = _make_service_returning(status_code=500)
     with pytest.raises(JiraApiError):
         service.get_workflow_transitions("X")
 
@@ -83,5 +177,5 @@ def test_get_workflow_transitions_still_raises_on_other_errors() -> None:
 def test_get_workflow_transitions_returns_data_on_success() -> None:
     """Sanity: a 200 with proper payload returns the transitions list."""
     transitions = [{"id": "1", "name": "To Do → In Progress"}]
-    service = _make_service(status_code=200, json_body={"transitions": transitions})
+    service = _make_service_returning(status_code=200, json_body={"transitions": transitions})
     assert service.get_workflow_transitions("X") == transitions


### PR DESCRIPTION
## Summary

- **Symptom**: Every migration run logs 55+ `ERROR`-level tracebacks for workflows like `Sales + Accounting: Customer Epic` and `DXP: Management tasks workflow` that legitimately don't exist on the server. The migration itself continued normally; the errors were pure noise.

- **Root cause**: `get_workflow_transitions` and `get_workflow_statuses` both had a dead-code `if response.status_code == 404` guard. The `jira` library's `ResilientSession.raise_on_error()` raises `JIRAError(status_code=404)` **before** returning any response object, so the guard never executed. The exception fell into `except Exception as exc` which called `self._logger.exception(...)` — printing a full ERROR-level traceback for each workflow.

- **Fix**: In both methods, added an `isinstance(exc, JIRAError) and exc.status_code == 404` check at the top of the `except Exception` block. Matching 404s are logged at DEBUG and return `[]`. All other errors (500, network errors, etc.) continue to raise `JiraApiError` with a full exception log so real failures remain visible.  The original `response.status_code == 404` guard is retained as a defensive fallback for any caller path that returns a response object rather than raising.

- **Conftest**: Updated `_CTestJIRAError` stub in `tests/conftest.py` to accept `status_code` and `url` kwargs (matching the real `JIRAError` signature), enabling tests to simulate the actual production failure path.

## Test plan

- [ ] `pytest tests/unit/test_jira_workflow_404_silent.py -W error -v` — 8 tests pass, including 4 new tests for the `JIRAError`-raised path (404 → `[]` with no ERROR log, 500 → raises `JiraApiError`) for both `get_workflow_transitions` and `get_workflow_statuses`
- [ ] `pytest tests/unit/ -W error -q` — no new failures introduced (pre-existing failures in `test_enhanced_openproject_client.py` are unrelated to this change)
- [ ] `uv run ruff check .` — 0 errors
- [ ] `uv run mypy src/` — 0 errors