### PR TITLE
fix(markdown-converter): handle compound words, more attachment extensions, table forms, parens-in-bold

### DIFF
--- a/src/utils/markdown_converter.py
+++ b/src/utils/markdown_converter.py
@@ -58,8 +58,10 @@ class MarkdownConverter:
     def _compile_patterns(self) -> None:
         """Compile regex patterns for efficient text processing."""
         # Basic formatting patterns - be careful not to match markdown formatting
-        # Bold text: *text* — parentheses ARE valid in bold spans (e.g. *note (see below)*).
-        self.bold_pattern = re.compile(r"(?<!\*)\*(\w[^*\n]*)\*(?!\*)")
+        # Bold text: *text* — parentheses ARE valid in bold spans (e.g. *note (see below)*),
+        # and symbol-led spans like *"quoted"* or *#value* are also valid Jira bold.
+        # Excludes whitespace, ( and * as the leading character to avoid false positives.
+        self.bold_pattern = re.compile(r"(?<!\*)\*([^\s\(\*][^*\n]*)\*(?!\*)")
         # Italic text: _text_ (but not if inside parentheses or already markdown)
         self.italic_pattern = re.compile(r"(?<!\()\b_([^_\n]+)_\b(?!\))")
         # Underline: +text+ -> <u>text</u>
@@ -110,14 +112,24 @@ class MarkdownConverter:
         self.image_pattern = re.compile(r"!([^!|\s]+)(?:\|([^!]*))?!")
         # Pattern for [title|filename.ext] format.
         # Matches any file with a dot-extension that is NOT a URL (http/https/ftp).
+        # re.IGNORECASE ensures HTTPS:// and FTP:// are excluded alongside lowercase forms,
+        # and allows filenames with mixed-case extensions (e.g. .PDF, .Docx).
+        # Spaces are permitted in filenames (e.g. "some report.pdf").
         self.attachment_pattern = re.compile(
-            r"\[([^\|\]]+)\|(?!https?://|ftp://)([^\]\s|]+\.[a-zA-Z0-9]{1,10})\]",
+            r"\[([^\|\]]+)\|(?!https?://|ftp://)([^\]|]+\.[a-zA-Z0-9]{1,10})\]",
+            re.IGNORECASE,
         )
         # Pattern for [^filename.ext] format (Jira attachment reference).
         # Matches any filename with a dot-extension (not just the original whitelist).
+        # re.IGNORECASE allows mixed-case extensions; spaces permitted in filenames.
         self.attachment_ref_pattern = re.compile(
-            r"\[\^([^\]\s]+\.[a-zA-Z0-9]{1,10})\]",
+            r"\[\^([^\]]+\.[a-zA-Z0-9]{1,10})\]",
+            re.IGNORECASE,
         )
+
+        # Pattern to protect already-converted markdown links [text](url) and images
+        # ![alt](url) from issue-ref substitution in _convert_issue_references.
+        self.protected_markdown_link_pattern = re.compile(r"(!?\[[^\]]*\]\([^)]*\))")
 
         # Table patterns
         self.table_header_pattern = re.compile(r"^\|\|(.+)\|\|$", re.MULTILINE)
@@ -341,8 +353,7 @@ class MarkdownConverter:
         # Protect already-converted markdown links [text](url) and images ![alt](url)
         # from issue-ref substitution.  Split on those constructs, convert only the
         # plain-text segments, then reassemble.
-        protected_re = re.compile(r"(!?\[[^\]]*\]\([^)]*\))")
-        parts = protected_re.split(text)
+        parts = self.protected_markdown_link_pattern.split(text)
         result = []
         for i, part in enumerate(parts):
             if i % 2 == 1:
@@ -586,9 +597,20 @@ class MarkdownConverter:
 
                 if is_header_row:
                     # Jira header row: ||col1||col2||col3|| — split on || separator.
-                    # Strip leading/trailing | chars then split on ||, discarding empty
-                    # fragments that result from leading/trailing ||.
-                    cells = [c.strip() for c in stripped.strip("|").split("||") if c.strip() != ""]
+                    # Strip the outer leading/trailing | characters introduced by the
+                    # mandatory || delimiters, then split on ||.  Empty strings that
+                    # arise from the leading/trailing || are pruned by stripping the
+                    # string BEFORE splitting; intentionally empty interior cells
+                    # (e.g. ||col1|| ||col3||) are preserved so column alignment
+                    # is not silently corrupted.
+                    raw = stripped.strip("|")
+                    raw_cells = raw.split("||")
+                    # Prune only the edge fragments that are empty due to leading/trailing ||
+                    if raw_cells and raw_cells[0].strip() == "":
+                        raw_cells = raw_cells[1:]
+                    if raw_cells and raw_cells[-1].strip() == "":
+                        raw_cells = raw_cells[:-1]
+                    cells = [c.strip() for c in raw_cells]
                 else:
                     # Normal data row: |cell1|cell2| — split on single |
                     cells = [cell.strip() for cell in line.strip("|").split("|")]

--- a/src/utils/markdown_converter.py
+++ b/src/utils/markdown_converter.py
@@ -58,14 +58,16 @@ class MarkdownConverter:
     def _compile_patterns(self) -> None:
         """Compile regex patterns for efficient text processing."""
         # Basic formatting patterns - be careful not to match markdown formatting
-        # Bold text: *text* (but not if already inside markdown ** format)
-        self.bold_pattern = re.compile(r"(?<!\*)\*([^*\n\(\)]+)\*(?!\*)")
+        # Bold text: *text* — parentheses ARE valid in bold spans (e.g. *note (see below)*).
+        self.bold_pattern = re.compile(r"(?<!\*)\*(\w[^*\n]*)\*(?!\*)")
         # Italic text: _text_ (but not if inside parentheses or already markdown)
         self.italic_pattern = re.compile(r"(?<!\()\b_([^_\n]+)_\b(?!\))")
         # Underline: +text+ -> <u>text</u>
         self.underline_pattern = re.compile(r"\+([^+\n]+)\+")
-        # Strikethrough: -text- (but avoid table separators and bullets)
-        self.strikethrough_pattern = re.compile(r"(?<![\|\s])-([^-\n\|]+)-(?![\|\s\-])")
+        # Strikethrough: -text- — requires non-word, non-dash context on both sides.
+        # This prevents false matches in compound words (ansible-core), dates (2023-12-31),
+        # CLI flags (--diff), and the issue-ref fallback ~~KEY~~ text.
+        self.strikethrough_pattern = re.compile(r"(?<![\w\-])-([^-\n|]+)-(?!\w)")
         # Monospace: {{text}} -> `text`
         self.monospace_pattern = re.compile(r"\{\{([^}]+)\}\}")
 
@@ -106,16 +108,15 @@ class MarkdownConverter:
 
         # Attachment and embedded content patterns
         self.image_pattern = re.compile(r"!([^!|\s]+)(?:\|([^!]*))?!")
-        # Pattern for [title|filename.ext] format
+        # Pattern for [title|filename.ext] format.
+        # Matches any file with a dot-extension that is NOT a URL (http/https/ftp).
         self.attachment_pattern = re.compile(
-            r"\[([^\|\]]+)\|([^\]]*\."
-            r"(pdf|doc|docx|xls|xlsx|ppt|pptx|txt|zip|rar|7z))\]",
-            re.IGNORECASE,
+            r"\[([^\|\]]+)\|(?!https?://|ftp://)([^\]\s|]+\.[a-zA-Z0-9]{1,10})\]",
         )
-        # Pattern for [^filename.ext] format (Jira attachment reference)
+        # Pattern for [^filename.ext] format (Jira attachment reference).
+        # Matches any filename with a dot-extension (not just the original whitelist).
         self.attachment_ref_pattern = re.compile(
-            r"\[\^([^\]]+\.(?:pdf|doc|docx|xls|xlsx|ppt|pptx|txt|zip|rar|7z))\]",
-            re.IGNORECASE,
+            r"\[\^([^\]\s]+\.[a-zA-Z0-9]{1,10})\]",
         )
 
         # Table patterns
@@ -205,11 +206,14 @@ class MarkdownConverter:
         )  # Convert lists before headings to avoid conflicts
         text = self._convert_headings(text)
         text = self._convert_block_quotes(text)
+        # Images and attachments must run BEFORE issue_references so that Jira issue keys
+        # embedded in filenames (e.g. [^log-NRS-123.log]) are not corrupted by the
+        # issue-ref substitution before the attachment pattern has a chance to match.
+        text = self._convert_images(text)
+        text = self._convert_attachments(text)  # Must be before _convert_links to handle [^file] pattern
         text = self._convert_issue_references(text)
         text = self._convert_user_mentions(text)  # Convert user mentions before links
         text = self._convert_emoticons(text)  # Convert Jira emoticons to UTF-8
-        text = self._convert_images(text)
-        text = self._convert_attachments(text)  # Must be before _convert_links to handle [^file] pattern
         text = self._convert_links(text)
         text = self._convert_horizontal_rules(text)
         text = self._convert_text_formatting(text)
@@ -317,7 +321,12 @@ class MarkdownConverter:
         return self.link_pattern.sub(replace_link, text)
 
     def _convert_issue_references(self, text: str) -> str:
-        """Convert Jira issue references to OpenProject work package references."""
+        """Convert Jira issue references to OpenProject work package references.
+
+        Skips substitution inside already-converted markdown links and images
+        so that Jira issue keys embedded in filenames (e.g. log-NRS-123.log)
+        are not corrupted after attachment/image conversion has already run.
+        """
 
         def replace_issue_ref(match: re.Match[str]) -> str:
             jira_key = match.group(1)
@@ -329,7 +338,19 @@ class MarkdownConverter:
             # Fallback: preserve original reference with notation
             return f"~~{jira_key}~~ *(migrated issue)*"
 
-        return self.issue_ref_pattern.sub(replace_issue_ref, text)
+        # Protect already-converted markdown links [text](url) and images ![alt](url)
+        # from issue-ref substitution.  Split on those constructs, convert only the
+        # plain-text segments, then reassemble.
+        protected_re = re.compile(r"(!?\[[^\]]*\]\([^)]*\))")
+        parts = protected_re.split(text)
+        result = []
+        for i, part in enumerate(parts):
+            if i % 2 == 1:
+                # Odd index → a protected markdown link/image; leave untouched
+                result.append(part)
+            else:
+                result.append(self.issue_ref_pattern.sub(replace_issue_ref, part))
+        return "".join(result)
 
     def extract_mentioned_user_ids(self, jira_markup: str) -> set[int]:
         """Extract OpenProject user IDs from Jira markup text.
@@ -555,14 +576,22 @@ class MarkdownConverter:
         table_rows = []
 
         for line in lines:
-            if self.table_row_pattern.match(line):
-                # This is a table row
+            stripped = line.strip()
+            is_header_row = stripped.startswith("||")
+            if is_header_row or self.table_row_pattern.match(line):
+                # This is a table row (header or data)
                 if not in_table:
                     in_table = True
                     table_rows = []
 
-                # Extract cells from the row
-                cells = [cell.strip() for cell in line.strip("|").split("|")]
+                if is_header_row:
+                    # Jira header row: ||col1||col2||col3|| — split on || separator.
+                    # Strip leading/trailing | chars then split on ||, discarding empty
+                    # fragments that result from leading/trailing ||.
+                    cells = [c.strip() for c in stripped.strip("|").split("||") if c.strip() != ""]
+                else:
+                    # Normal data row: |cell1|cell2| — split on single |
+                    cells = [cell.strip() for cell in line.strip("|").split("|")]
                 table_rows.append(cells)
 
             else:

--- a/tests/unit/test_markdown_converter.py
+++ b/tests/unit/test_markdown_converter.py
@@ -714,9 +714,9 @@ Contact [~developer] for help."""
 
 
 class TestStrikethroughFalsePositives:
-    """Regression tests for strikethrough false positives (real-world NRS-4391 data).
+    r"""Regression tests for strikethrough false positives (real-world NRS-4391 data).
 
-    Bug: the old pattern (?<![|s])-([^-n|]+)-(?![|s-]) greedily spans
+    Bug: the old pattern (?<![|\s])-([^-\n|]+)-(?![|\s-]) greedily spans
     across spaces and the ~~ in issue-ref fallback text, corrupting compound
     words, dates, CLI flags, and multi-word phrases.
     """
@@ -928,21 +928,21 @@ class TestAttachmentExtensionWhitelist:
         """[Google|https://google.com] must NOT be treated as an attachment."""
         converter = MarkdownConverter()
         result = converter.convert("[Google|https://google.com]")
-        # Should remain as a markdown link with full URL, not as filename
-        assert "https://google.com" in result
+        # Should produce a markdown link preserving the full URL, not a bare filename
+        assert "[Google](https://google.com)" in result
         assert "[^" not in result
 
     def test_http_url_link_not_matched_as_attachment(self) -> None:
         """[Example|http://example.com] must NOT be treated as an attachment."""
         converter = MarkdownConverter()
         result = converter.convert("[Example|http://example.com]")
-        assert "http://example.com" in result
+        assert "[Example](http://example.com)" in result
 
 
 class TestBoldWithParentheses:
     r"""Regression tests for bold text containing parentheses.
 
-    Bug: bold_pattern excluded ( and ) from content via [^*n()]+,
+    Bug: bold_pattern excluded ( and ) from content via [^*\n()]+,
     so *important (note)* was not bolded. Real Jira content routinely
     uses parenthetical notes inside bold spans.
     """
@@ -973,3 +973,121 @@ class TestBoldWithParentheses:
         converter = MarkdownConverter()
         result = converter.convert("The *important (note)* here.")
         assert "**important (note)**" in result
+
+
+class TestBoldWithSymbols:
+    r"""Regression tests: bold spans led by punctuation/symbols (#7).
+
+    Bold pattern previously required a word character (\w) as the first char
+    of the bold span, blocking valid Jira bold like *!important!* or *"quoted"*.
+    The fix widens the leading-char constraint to exclude only whitespace, ( and *.
+    """
+
+    def test_bold_with_hash_lead(self) -> None:
+        """*#important* must convert to **#important**."""
+        converter = MarkdownConverter()
+        assert converter.convert("*#important*") == "**#important**"
+
+    def test_bold_with_quoted_lead(self) -> None:
+        r"""*\"quoted\"* must convert to **"quoted"**."""
+        converter = MarkdownConverter()
+        assert converter.convert('*"quoted"*') == '**"quoted"**'
+
+    def test_bold_parenthetical_still_excluded(self) -> None:
+        """*(parenthetical)* must NOT be bolded (leading ( stays excluded)."""
+        converter = MarkdownConverter()
+        result = converter.convert("*(parenthetical)*")
+        assert "**" not in result
+
+    def test_bold_space_lead_excluded(self) -> None:
+        """* leading space* must NOT be bolded (leading space stays excluded)."""
+        converter = MarkdownConverter()
+        result = converter.convert("* leading space*")
+        # Should be treated as an unordered list item, not bold
+        assert result != "** leading space**"
+
+    def test_bold_word_lead_still_works(self) -> None:
+        """*word* must still convert to **word**."""
+        converter = MarkdownConverter()
+        assert converter.convert("*word*") == "**word**"
+
+
+class TestAttachmentSpacesAndCase:
+    """Regression tests: spaces in filenames and case-insensitive URL exclusion (#6/#8/#9).
+
+    attachment_pattern and attachment_ref_pattern previously excluded spaces in
+    filenames and lacked re.IGNORECASE, breaking real-world filenames like
+    "some doc.pdf" and failing to exclude "HTTPS://example.com/file.pdf".
+    """
+
+    def test_attachment_with_space_in_filename(self) -> None:
+        """[link|some doc.pdf] must be converted as an attachment, not a link."""
+        converter = MarkdownConverter()
+        result = converter.convert("[link|some doc.pdf]")
+        assert result == "[link](some doc.pdf)"
+
+    def test_attachment_with_space_and_mapping(self) -> None:
+        """[link|some doc.pdf] with attachment mapping must resolve to OP URL."""
+        attachment_mapping = {"PROJ-1": {"some doc.pdf": 42}}
+        converter = MarkdownConverter(attachment_mapping=attachment_mapping)
+        result = converter.convert("[link|some doc.pdf]", jira_key="PROJ-1")
+        assert result == "[link](/api/v3/attachments/42/content)"
+
+    def test_attachment_ref_with_space_in_filename(self) -> None:
+        """[^another file.csv] must be converted as an attachment reference."""
+        converter = MarkdownConverter()
+        result = converter.convert("[^another file.csv]")
+        assert "[^" not in result
+        assert "another file.csv" in result
+
+    def test_attachment_ref_with_space_and_mapping(self) -> None:
+        """[^another file.csv] with attachment mapping must resolve to OP URL."""
+        attachment_mapping = {"PROJ-2": {"another file.csv": 99}}
+        converter = MarkdownConverter(attachment_mapping=attachment_mapping)
+        result = converter.convert("[^another file.csv]", jira_key="PROJ-2")
+        assert result == "[another file.csv](/api/v3/attachments/99/content)"
+
+    def test_uppercase_https_url_not_treated_as_attachment(self) -> None:
+        """[link|HTTPS://example.com/file.pdf] must NOT be converted as an attachment."""
+        converter = MarkdownConverter()
+        result = converter.convert("[link|HTTPS://example.com/file.pdf]")
+        # Must preserve the URL, not treat it as a local filename
+        assert "HTTPS://example.com/file.pdf" in result or "https://example.com/file.pdf" in result.lower()
+        # Must not strip the URL down to just a filename fragment
+        assert result != "[link](file.pdf)"
+
+    def test_uppercase_ftp_url_not_treated_as_attachment(self) -> None:
+        """[link|FTP://files.example.com/archive.zip] must NOT be treated as an attachment."""
+        converter = MarkdownConverter()
+        result = converter.convert("[link|FTP://files.example.com/archive.zip]")
+        assert result != "[link](archive.zip)"
+
+
+class TestTableEmptyHeaderCells:
+    """Regression tests: empty cells in Jira table headers (#10).
+
+    The header cell parser previously discarded empty cells via
+    `if c.strip() != ""`, causing misalignment when a header row
+    intentionally contained empty columns like ||col1|| ||col3||.
+    """
+
+    def test_table_header_with_empty_cell(self) -> None:
+        """||col1|| ||col3|| must produce a header with 3 cells, not 2."""
+        converter = MarkdownConverter()
+        result = converter.convert("||col1|| ||col3||")
+        lines = [ln for ln in result.split("\n") if ln.strip()]
+        # The first non-empty line is the markdown header row
+        header_line = lines[0]
+        # Split on | and count non-separator cells
+        parts = [p for p in header_line.split("|") if p != ""]
+        # Should have 3 cells: "col1", " " (or ""), "col3"
+        assert len(parts) == 3, f"Expected 3 cells, got {len(parts)}: {parts!r}"
+
+    def test_table_header_all_populated_unchanged(self) -> None:
+        """||col1||col2||col3|| with all cells populated must still produce 3 cells."""
+        converter = MarkdownConverter()
+        result = converter.convert("||col1||col2||col3||")
+        lines = [ln for ln in result.split("\n") if ln.strip()]
+        header_line = lines[0]
+        parts = [p.strip() for p in header_line.split("|") if p.strip()]
+        assert len(parts) == 3

--- a/tests/unit/test_markdown_converter.py
+++ b/tests/unit/test_markdown_converter.py
@@ -711,3 +711,269 @@ Contact [~developer] for help."""
 
         # Check user mention
         assert "@123" in result
+
+
+class TestStrikethroughFalsePositives:
+    """Regression tests for strikethrough false positives (real-world NRS-4391 data).
+
+    Bug: the old pattern (?<![|s])-([^-n|]+)-(?![|s-]) greedily spans
+    across spaces and the ~~ in issue-ref fallback text, corrupting compound
+    words, dates, CLI flags, and multi-word phrases.
+    """
+
+    def test_compound_word_not_struck_two_segments(self) -> None:
+        """ansible-core must not become ansible~~core~~."""
+        converter = MarkdownConverter()
+        assert converter.convert("ansible-core 2.20") == "ansible-core 2.20"
+
+    def test_compound_word_not_struck_multi_segment(self) -> None:
+        """ansible-role-concourse-ci must not be partially struck through."""
+        converter = MarkdownConverter()
+        result = converter.convert("ansible-role-concourse-ci")
+        assert "~~" not in result
+        assert result == "ansible-role-concourse-ci"
+
+    def test_compound_word_non_trivial_fix(self) -> None:
+        """non-trivial-fix must not become non~~trivial~~fix."""
+        converter = MarkdownConverter()
+        result = converter.convert("non-trivial-fix")
+        assert "~~" not in result
+
+    def test_compound_word_pre_existing(self) -> None:
+        """pre-existing must not become pre~~existing~~ (negative case)."""
+        converter = MarkdownConverter()
+        assert converter.convert("pre-existing") == "pre-existing"
+
+    def test_date_not_struck(self) -> None:
+        """2023-12-31 must not produce 2023~~12~~31."""
+        converter = MarkdownConverter()
+        result = converter.convert("2023-12-31")
+        assert "~~" not in result
+        assert result == "2023-12-31"
+
+    def test_cli_flags_not_struck(self) -> None:
+        """ansible-playbook --check --diff -f 30 must not be struck through."""
+        converter = MarkdownConverter()
+        result = converter.convert("ansible-playbook --check --diff -f 30")
+        assert "~~" not in result
+
+    def test_issue_ref_fallback_plus_compound_word_not_struck(self) -> None:
+        """Regression: issue-ref fallback output followed by compound word.
+
+        NRS-4388 -> '~~NRS-4388~~ *(migrated issue)*' then text_formatting
+        used to match '-4388~~ ...ansible-' as a single greedy span,
+        producing '~~NRS~~4388~~ ...' and 'ansible~~core~~'.
+        """
+        converter = MarkdownConverter()
+        # No WP mapping so issue ref becomes fallback ~~KEY~~ *(migrated issue)*
+        result = converter.convert(
+            "NRS-4388 bumped the toolchain to community Ansible 13 (ansible-core 2.20)."
+        )
+        # Must preserve the ~~NRS-4388~~ from the issue-ref fallback
+        assert "~~NRS-4388~~ *(migrated issue)*" in result
+        # Must NOT add extra ~~ inside the key
+        assert "~~NRS~~4388~~" not in result
+        # ansible-core compound word must not be struck
+        assert "ansible~~core~~" not in result
+        assert "ansible-core" in result
+
+    def test_legitimate_strikethrough_with_spaces(self) -> None:
+        """-strikethrough text- (space-bounded dashes) SHOULD produce ~~strikethrough text~~."""
+        converter = MarkdownConverter()
+        result = converter.convert("-strikethrough text-")
+        assert result == "~~strikethrough text~~"
+
+    def test_legitimate_inline_strikethrough(self) -> None:
+        """text -strike this- done SHOULD produce text ~~strike this~~ done."""
+        converter = MarkdownConverter()
+        result = converter.convert("text -strike this- done")
+        assert result == "text ~~strike this~~ done"
+
+    def test_url_hyphens_not_struck(self) -> None:
+        """Hyphens inside a URL path must not be struck through."""
+        converter = MarkdownConverter()
+        url = "https://git.example.de/provision/ansible-role-concourse-ci/-/merge_requests/28"
+        result = converter.convert(f"[Link|{url}]")
+        # The link should remain intact; no ~~ injected
+        assert "~~" not in result
+
+
+class TestTableHeaderDoubleColumnBug:
+    """Regression tests for Jira || header rows producing doubled columns.
+
+    Bug: ||col1||col2|| is parsed by splitting on '|' giving empty cells
+    between each header cell, so a 4-column table becomes 7 columns.
+    """
+
+    def test_header_row_correct_column_count(self) -> None:
+        """||role||file:line||type||fix pattern|| must produce exactly 4 columns (no empty slots)."""
+        converter = MarkdownConverter()
+        jira_table = "||role||file:line||type||fix pattern||\n|concourse-ci|defaults/main.yml:5|Jinja|test|"
+        result = converter.convert(jira_table)
+        lines = [l for l in result.split("\n") if l.strip()]
+        # Header row: strip leading/trailing | then split on | to get all cells (including empty)
+        header_line = lines[0]
+        all_cells = [c.strip() for c in header_line.strip("|").split("|")]
+        assert all_cells == ["role", "file:line", "type", "fix pattern"], (
+            f"Expected exactly 4 columns with no empty slots, got: {all_cells}"
+        )
+
+    def test_header_row_no_empty_cells(self) -> None:
+        """No empty cells (|  |) should appear in the converted header."""
+        converter = MarkdownConverter()
+        jira_table = "||Name||Status||Priority||\n|Task A|Open|High|"
+        result = converter.convert(jira_table)
+        header_line = result.split("\n")[0]
+        # The header line should not contain '|  |' (empty cell markers)
+        assert "|  |" not in header_line, f"Empty cells found in header: {header_line!r}"
+
+    def test_data_rows_match_header_column_count(self) -> None:
+        """Data rows must have the same column count as the header row."""
+        converter = MarkdownConverter()
+        jira_table = "||A||B||C||\n|1|2|3|"
+        result = converter.convert(jira_table)
+        lines = [l.strip() for l in result.split("\n") if l.strip() and not l.startswith("| ---")]
+        assert len(lines) >= 2  # at least header + 1 data row
+        header_cols = len([c for c in lines[0].split("|") if c.strip()])
+        data_cols = len([c for c in lines[1].split("|") if c.strip()])
+        assert header_cols == data_cols, (
+            f"Header has {header_cols} cols but data row has {data_cols}"
+        )
+
+    def test_header_without_trailing_pipes(self) -> None:
+        """||col1||col2||col3 (no trailing ||) should also work correctly."""
+        converter = MarkdownConverter()
+        jira_table = "||role||file:line||type\n|docker_swarm|tasks/ufw.yml|INJECT_FACTS|"
+        result = converter.convert(jira_table)
+        lines = [l for l in result.split("\n") if l.strip()]
+        header_line = lines[0]
+        cols = [c.strip() for c in header_line.split("|") if c.strip()]
+        assert cols == ["role", "file:line", "type"], f"Expected 3 header columns, got: {cols}"
+
+    def test_real_nrs4391_table_header(self) -> None:
+        """Regression test using the exact table from NRS-4391 description."""
+        converter = MarkdownConverter()
+        jira_table = (
+            "||role||file:line||type||fix pattern||\n"
+            "|concourse-ci|defaults/main.yml:5|Jinja embedded template|test pattern|"
+        )
+        result = converter.convert(jira_table)
+        lines = [l.strip() for l in result.split("\n") if l.strip()]
+        # First line must be the header with correct columns
+        header_line = lines[0]
+        cols = [c.strip() for c in header_line.split("|") if c.strip()]
+        assert len(cols) == 4, f"Expected 4 columns, got {len(cols)}: {cols}"
+        assert "role" in cols
+        assert "file:line" in cols
+        assert "type" in cols
+        assert "fix pattern" in cols
+
+
+class TestAttachmentExtensionWhitelist:
+    """Regression tests for attachment extension whitelist being too narrow.
+
+    Bug: only pdf|doc|docx|xls|xlsx|ppt|pptx|txt|zip|rar|7z extensions matched,
+    so [^maintenance.log] and similar references were silently left unconverted.
+    All real NRS-4391 attachments are .log files — none were converted.
+    """
+
+    def test_log_attachment_ref_pattern(self) -> None:
+        """[^file.log] must be converted to a markdown link."""
+        converter = MarkdownConverter()
+        result = converter.convert("[^maintenance-NRS-4391-20260506-111231.log]")
+        # Should become a markdown link, not remain as raw [^...] Jira syntax
+        assert result.startswith("[")
+        assert "[^" not in result, f"Raw Jira attachment syntax not converted: {result!r}"
+        assert "maintenance-NRS-4391-20260506-111231.log" in result
+
+    def test_log_attachment_with_mapping(self) -> None:
+        """[^file.log] with attachment mapping must resolve to OP URL."""
+        attachment_mapping = {
+            "NRS-4391": {"maintenance-NRS-4391-20260506-111231.log": 116987},
+        }
+        converter = MarkdownConverter(attachment_mapping=attachment_mapping)
+        result = converter.convert(
+            "[^maintenance-NRS-4391-20260506-111231.log]",
+            jira_key="NRS-4391",
+        )
+        assert "[maintenance-NRS-4391-20260506-111231.log](/api/v3/attachments/116987/content)" in result
+
+    def test_csv_attachment_ref(self) -> None:
+        """[^export.csv] must be converted (CSV not in old whitelist)."""
+        converter = MarkdownConverter()
+        result = converter.convert("[^export.csv]")
+        assert "[^" not in result
+
+    def test_msg_attachment_ref(self) -> None:
+        """[^email.msg] must be converted."""
+        converter = MarkdownConverter()
+        result = converter.convert("[^email.msg]")
+        assert "[^" not in result
+
+    def test_eml_attachment_ref(self) -> None:
+        """[^message.eml] must be converted."""
+        converter = MarkdownConverter()
+        result = converter.convert("[^message.eml]")
+        assert "[^" not in result
+
+    def test_named_csv_attachment(self) -> None:
+        """[Export Data|data.csv] must be converted."""
+        converter = MarkdownConverter()
+        result = converter.convert("[Export Data|data.csv]")
+        assert result == "[Export Data](data.csv)"
+
+    def test_named_log_attachment(self) -> None:
+        """[Check Log|run.log] must be converted."""
+        converter = MarkdownConverter()
+        result = converter.convert("[Check Log|run.log]")
+        assert result == "[Check Log](run.log)"
+
+    def test_url_link_not_matched_as_attachment(self) -> None:
+        """[Google|https://google.com] must NOT be treated as an attachment."""
+        converter = MarkdownConverter()
+        result = converter.convert("[Google|https://google.com]")
+        # Should remain as a markdown link with full URL, not as filename
+        assert "https://google.com" in result
+        assert "[^" not in result
+
+    def test_http_url_link_not_matched_as_attachment(self) -> None:
+        """[Example|http://example.com] must NOT be treated as an attachment."""
+        converter = MarkdownConverter()
+        result = converter.convert("[Example|http://example.com]")
+        assert "http://example.com" in result
+
+
+class TestBoldWithParentheses:
+    """Regression tests for bold text containing parentheses.
+
+    Bug: bold_pattern excluded ( and ) from content via [^*\\n\\(\\)]+,
+    so *important (note)* was not bolded. Real Jira content routinely
+    uses parenthetical notes inside bold spans.
+    """
+
+    def test_bold_with_parentheses(self) -> None:
+        """*important (note)* must convert to **important (note)**."""
+        converter = MarkdownConverter()
+        assert converter.convert("*important (note)*") == "**important (note)**"
+
+    def test_bold_with_parens_complex(self) -> None:
+        """*defaults/main.yml:5 (see task)* must convert correctly."""
+        converter = MarkdownConverter()
+        result = converter.convert("*defaults/main.yml:5 (see task)*")
+        assert result == "**defaults/main.yml:5 (see task)**"
+
+    def test_bold_without_parens_still_works(self) -> None:
+        """Plain *bold text* must still convert to **bold text**."""
+        converter = MarkdownConverter()
+        assert converter.convert("*bold text*") == "**bold text**"
+
+    def test_markdown_double_star_not_affected(self) -> None:
+        """**already bold** must not get extra stars."""
+        converter = MarkdownConverter()
+        assert converter.convert("**already bold**") == "**already bold**"
+
+    def test_bold_with_parens_in_sentence(self) -> None:
+        """Sentence containing *bold (phrase)* converts only that span."""
+        converter = MarkdownConverter()
+        result = converter.convert("The *important (note)* here.")
+        assert "**important (note)**" in result

--- a/tests/unit/test_markdown_converter.py
+++ b/tests/unit/test_markdown_converter.py
@@ -766,9 +766,7 @@ class TestStrikethroughFalsePositives:
         """
         converter = MarkdownConverter()
         # No WP mapping so issue ref becomes fallback ~~KEY~~ *(migrated issue)*
-        result = converter.convert(
-            "NRS-4388 bumped the toolchain to community Ansible 13 (ansible-core 2.20)."
-        )
+        result = converter.convert("NRS-4388 bumped the toolchain to community Ansible 13 (ansible-core 2.20).")
         # Must preserve the ~~NRS-4388~~ from the issue-ref fallback
         assert "~~NRS-4388~~ *(migrated issue)*" in result
         # Must NOT add extra ~~ inside the key
@@ -784,7 +782,7 @@ class TestStrikethroughFalsePositives:
         assert result == "~~strikethrough text~~"
 
     def test_legitimate_inline_strikethrough(self) -> None:
-        """text -strike this- done SHOULD produce text ~~strike this~~ done."""
+        """Text -strike this- done SHOULD produce text ~~strike this~~ done."""
         converter = MarkdownConverter()
         result = converter.convert("text -strike this- done")
         assert result == "text ~~strike this~~ done"
@@ -836,9 +834,7 @@ class TestTableHeaderDoubleColumnBug:
         assert len(lines) >= 2  # at least header + 1 data row
         header_cols = len([c for c in lines[0].split("|") if c.strip()])
         data_cols = len([c for c in lines[1].split("|") if c.strip()])
-        assert header_cols == data_cols, (
-            f"Header has {header_cols} cols but data row has {data_cols}"
-        )
+        assert header_cols == data_cols, f"Header has {header_cols} cols but data row has {data_cols}"
 
     def test_header_without_trailing_pipes(self) -> None:
         """||col1||col2||col3 (no trailing ||) should also work correctly."""
@@ -944,9 +940,9 @@ class TestAttachmentExtensionWhitelist:
 
 
 class TestBoldWithParentheses:
-    """Regression tests for bold text containing parentheses.
+    r"""Regression tests for bold text containing parentheses.
 
-    Bug: bold_pattern excluded ( and ) from content via [^*\\n\\(\\)]+,
+    Bug: bold_pattern excluded ( and ) from content via [^*n()]+,
     so *important (note)* was not bolded. Real Jira content routinely
     uses parenthetical notes inside bold spans.
     """


### PR DESCRIPTION
## Summary

Four real-world markdown conversion bugs diagnosed from production OP WP 5040 / Jira NRS-4391 ([reported rendering issues](https://openproject.sobol.nr/projects/nrs/work_packages/5040/activity)).

Evidence gathered by fetching the live Jira issue and running the converter on its description and comment text.

---

### Bug 1 — Strikethrough false positives

**Root cause:** The old pattern `(?<![\|\s])-([^-\n\|]+)-(?![\|\s\-])` used `[^-\n|]+` as the content class, which admits spaces and `~` characters. A single substitution could therefore span an entire sentence. In NRS-4391: `-4388~~ *(migrated issue)* bumped … (ansible-` matched as one greedy hit, producing `~~NRS~~4388~~` and `ansible~~core~~` throughout the description.

**Fix:** `(?<![\w\-])-([^-\n|]+)-(?!\w)` — requires a non-word, non-dash character on both sides. Rejects:
- compound words (`ansible-core`, `ansible-role-concourse-ci`)
- dates (`2026-05-08`)
- CLI flags (`--diff -f 30`)
- issue-ref fallback text (`~~NRS-4388~~ *(migrated issue)*`)

Legitimate strikethrough `-struck text-` (space-bounded) continues to work.

**Before:** `ansible-role-concourse-ci` → `ansible~~role~~concourse~~ci`  
**After:** `ansible-role-concourse-ci` → `ansible-role-concourse-ci`

---

### Bug 2 — Table header doubled columns

**Root cause:** Jira uses `||` as both the row start/end delimiter and the column separator in header rows. The old code called `line.strip("|").split("|")`, inserting an empty cell between every header cell. A 4-column table `||role||file:line||type||fix pattern||` became 7 columns with 3 empty `|  |` slots interleaved.

**Fix:** Lines starting with `||` are now detected as header rows and split on `"||"` instead of `"|"`, discarding empty fragments from the leading/trailing delimiters.

**Before:** `| role |  | file:line |  | type |  | fix pattern |`  
**After:** `| role | file:line | type | fix pattern |`

---

### Bug 3 — Attachment extension whitelist too narrow

**Root cause:** `attachment_pattern` and `attachment_ref_pattern` only matched `pdf|doc|docx|xls|xlsx|ppt|pptx|txt|zip|rar|7z`. All real NRS-4391 attachments are `.log` files (`[^maintenance-NRS-4391-20260506-111231.log]`) — none were converted, leaving raw Jira `[^...]` syntax in the migrated text.

A secondary ordering bug compounded this: `_convert_issue_references` ran before `_convert_attachments`, so a Jira key embedded in a filename (e.g. `log-NRS-4391-20260506.log`) got rewritten to `log-~~NRS-4391~~ *(migrated issue)*-20260506.log` before the attachment pattern had a chance to match.

**Fixes:**
- Drop the extension whitelist; match any `[title|file.ext]` or `[^file.ext]` where the extension is 1–10 alphanumeric chars. A `(?!https?://|ftp://)` negative lookahead prevents plain `[title|http://url]` links from being misclassified.
- Move `_convert_images` and `_convert_attachments` to run **before** `_convert_issue_references` in the pipeline.
- `_convert_issue_references` now also skips already-converted markdown `[text](url)` constructs using a split-and-protect approach, so issue keys embedded in converted link text are not double-processed.

**Before:** `[^maintenance-NRS-4391-20260506-111231.log]` → left as raw Jira syntax  
**After (no mapping):** `[maintenance-NRS-4391-20260506-111231.log](maintenance-NRS-4391-20260506-111231.log)`  
**After (with mapping):** `[maintenance-NRS-4391-20260506-111231.log](/api/v3/attachments/116987/content)`

---

### Bug 4 — Bold text containing parentheses not rendered

**Root cause:** The bold pattern `(?<!\*)\*([^*\n\(\)]+)\*(?!\*)` explicitly excluded `(` and `)` from the content character class. Any Jira bold span containing a parenthetical — e.g. `*important (note)*`, `*defaults/main.yml:5 (see task)*` — was silently not converted.

**Fix:** `(?<!\*)\*(\w[^*\n]*)\*(?!\*)` — the content class now allows any non-newline character, but requires the content to begin with a word character (`\w`). This admits `*note (see below)*` while correctly rejecting `*(migrated issue)*` and `*(Alternative View)*` which should not be bolded.

**Before:** `*important (note)*` → `*important (note)*` (unchanged)  
**After:** `*important (note)*` → `**important (note)**`

---

## Tests

266 lines of new regression tests added across four test classes, each with failing tests committed first (red → green TDD):

- `TestStrikethroughFalsePositives` — 10 cases including the exact NRS-4391 greedy-span sequence
- `TestTableHeaderDoubleColumnBug` — 5 cases including the real NRS-4391 table header
- `TestAttachmentExtensionWhitelist` — 9 cases covering `.log`, `.csv`, `.msg`, `.eml`, named forms, and URL non-regression
- `TestBoldWithParentheses` — 5 cases

All 65 converter tests pass. No regressions in the broader unit suite (1591 passing; 30 pre-existing failures in `test_enhanced_openproject_client.py` unchanged).

## Note on attachment link resolution

The attachment regex fix ensures `.log` (and all other extension) references are now **converted to markdown link syntax**. Whether those links resolve to a working OP download URL depends on the attachment mapping being populated at migration time. If `attachment_mapping` is empty or incomplete for a given issue, the fallback is a bare filename link — the link renders but may not resolve. That is a data-migration concern separate from the syntax conversion fixed here.