### PR TITLE
fix(workflow): silence Tomcat encoded-slash 400 like 404 (workflow names with /)

### DIFF
--- a/src/infrastructure/jira/jira_workflow_service.py
+++ b/src/infrastructure/jira/jira_workflow_service.py
@@ -27,27 +27,55 @@ from src.infrastructure.jira.jira_client import (
 )
 
 
-def _is_workflow_404(exc: BaseException) -> bool:
-    """Return True if *exc* or any exception in its ``__cause__`` chain is a Jira 404.
+def _is_workflow_unfetchable(exc: BaseException) -> bool:
+    """Return True if *exc* represents a workflow endpoint that cannot be fetched.
 
+    Two cases are treated as "unfetchable" and suppressed at DEBUG level
+    (instead of raising at ERROR) because they indicate a server-side
+    configuration limitation rather than a real programming error:
+
+    1. **HTTP 404** — the ``/rest/api/2/workflow/<name>`` endpoint simply does
+       not exist on this Jira Server/DC version.  This is the original case
+       that PR #240 addressed.
+
+    2. **HTTP 400 with "Invalid URI" / "encoded slash"** — Apache Tomcat
+       rejects percent-encoded slash characters (``%2F``) in URL path segments
+       by default (``ALLOW_ENCODED_SLASH`` is ``false``).  A workflow name that
+       contains a literal ``/`` (e.g. ``"NREDIT: Blog/CS Workflow"``) is
+       URL-encoded as ``%2F`` by ``urllib.parse.quote``; Tomcat then returns
+       HTTP 400 with an HTML body containing "Invalid URI" and a message about
+       the encoded slash.  The URL is structurally unfetchable — no retry
+       strategy can work around a server-side Tomcat configuration default.
+       Treating it like a 404 (silent DEBUG, empty result) is correct.
+
+    Implementation notes
+    --------------------
     In production ``JiraClient._patch_jira_client`` wraps every exception
     (including ``JIRAError``) into ``JiraApiError`` so the outer exception is
-    never a ``JIRAError`` directly.  The original ``JIRAError(status_code=404)``
-    is stored as ``exc.__cause__``.  Walking the chain makes the check work
-    for both the bare-``JIRAError`` path (unit-test stub, some alternate code
-    paths) and the production-wrapping path.
+    never a ``JIRAError`` directly.  The original ``JIRAError`` is stored as
+    ``exc.__cause__``.  Walking the chain makes the check work for both the
+    bare-``JIRAError`` path (unit-test stub, some alternate code paths) and
+    the production-wrapping path.
 
     The *seen* set guards against pathological cycles where ``__cause__`` is
     set to the exception itself.
     """
     from jira.exceptions import JIRAError as _JIRAError
 
+    _ENCODED_SLASH_MARKERS = ("invalid uri", "encoded slash")
+
     seen: set[int] = set()
     current: BaseException | None = exc
     while current is not None and id(current) not in seen:
         seen.add(id(current))
-        if isinstance(current, _JIRAError) and getattr(current, "status_code", None) == HTTP_NOT_FOUND:
-            return True
+        status = getattr(current, "status_code", None)
+        if isinstance(current, _JIRAError):
+            if status == HTTP_NOT_FOUND:
+                return True
+            if status == 400:
+                text = (getattr(current, "text", "") or "").lower()
+                if any(marker in text for marker in _ENCODED_SLASH_MARKERS):
+                    return True
         current = current.__cause__
     return False
 
@@ -219,11 +247,14 @@ class JiraWorkflowService:
             #
             # In production JiraClient._patch_jira_client wraps every exception
             # into JiraApiError, so exc is never a JIRAError directly — the
-            # original JIRAError(status_code=404) lives in exc.__cause__.
-            # _is_workflow_404 walks the __cause__ chain to handle both paths.
-            if _is_workflow_404(exc):
+            # original JIRAError lives in exc.__cause__.
+            # _is_workflow_unfetchable walks the __cause__ chain and handles:
+            #   • HTTP 404 — endpoint not available on this Server/DC version
+            #   • HTTP 400 "Invalid URI" — Tomcat rejects %2F in URL path
+            #     (workflow name contains "/" and ALLOW_ENCODED_SLASH=false)
+            if _is_workflow_unfetchable(exc):
                 self._logger.debug(
-                    "Workflow '%s' transitions endpoint returned 404 (not available on this server); treating as empty",
+                    "Workflow '%s' transitions endpoint unfetchable (404 not-found or Tomcat encoded-slash 400); treating as empty",
                     workflow_name,
                 )
                 return []
@@ -275,11 +306,14 @@ class JiraWorkflowService:
             #
             # In production JiraClient._patch_jira_client wraps every exception
             # into JiraApiError, so exc is never a JIRAError directly — the
-            # original JIRAError(status_code=404) lives in exc.__cause__.
-            # _is_workflow_404 walks the __cause__ chain to handle both paths.
-            if _is_workflow_404(exc):
+            # original JIRAError lives in exc.__cause__.
+            # _is_workflow_unfetchable walks the __cause__ chain and handles:
+            #   • HTTP 404 — endpoint not available on this Server/DC version
+            #   • HTTP 400 "Invalid URI" — Tomcat rejects %2F in URL path
+            #     (workflow name contains "/" and ALLOW_ENCODED_SLASH=false)
+            if _is_workflow_unfetchable(exc):
                 self._logger.debug(
-                    "Workflow '%s' definition endpoint returned 404 (not available on this server); treating as empty",
+                    "Workflow '%s' definition endpoint unfetchable (404 not-found or Tomcat encoded-slash 400); treating as empty",
                     workflow_name,
                 )
                 return []

--- a/src/infrastructure/jira/jira_workflow_service.py
+++ b/src/infrastructure/jira/jira_workflow_service.py
@@ -62,6 +62,10 @@ def _is_workflow_unfetchable(exc: BaseException) -> bool:
     """
     from jira.exceptions import JIRAError as _JIRAError
 
+    # Tomcat's ``ALLOW_ENCODED_SLASH=false`` rejects ``%2F`` in URI paths with
+    # an HTML page whose body contains both phrases. We require *both* markers
+    # so that a generic "Invalid URI" response from a different cause is not
+    # silently demoted to DEBUG.
     _ENCODED_SLASH_MARKERS = ("invalid uri", "encoded slash")
 
     seen: set[int] = set()
@@ -74,7 +78,7 @@ def _is_workflow_unfetchable(exc: BaseException) -> bool:
                 return True
             if status == 400:
                 text = (getattr(current, "text", "") or "").lower()
-                if any(marker in text for marker in _ENCODED_SLASH_MARKERS):
+                if all(marker in text for marker in _ENCODED_SLASH_MARKERS):
                     return True
         current = current.__cause__
     return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ if "jira" not in sys.modules:
     class _CTestJIRAError(Exception):
         def __init__(self, text=None, status_code=None, url=None, **kwargs):
             super().__init__(text)
+            self.text = text
             self.status_code = status_code
             self.url = url
 

--- a/tests/unit/test_jira_workflow_404_silent.py
+++ b/tests/unit/test_jira_workflow_404_silent.py
@@ -97,20 +97,22 @@ def _make_service_raising_jira_error(status_code: int, text: str = "Not Found") 
     return JiraWorkflowService(fake_client)
 
 
+_TOMCAT_400_TEXT = (
+    "<!doctype html><h1>HTTP Status 400 – Bad Request</h1>"
+    "Message: Invalid URI: [The encoded slash character is not allowed]"
+    "Apache Tomcat/9.0.85"
+)
+
+
 def _make_service_raising_jira_error_400_encoded_slash(
     workflow_name: str = "NREDIT: Blog/CS Workflow",
 ) -> JiraWorkflowService:
     """Session raises JIRAError(400) with Tomcat encoded-slash message — bare path."""
     from jira.exceptions import JIRAError
 
-    tomcat_body = (
-        "<!doctype html><h1>HTTP Status 400 – Bad Request</h1>"
-        "Message: Invalid URI: [The encoded slash character is not allowed]"
-        "Apache Tomcat/9.0.85"
-    )
     fake_session = MagicMock()
     fake_session.get.side_effect = JIRAError(
-        text=tomcat_body,
+        text=_TOMCAT_400_TEXT,
         status_code=400,
         url=f"https://jira.example.com/rest/api/2/workflow/{workflow_name}/transitions",
     )
@@ -158,13 +160,6 @@ def _make_service_raising_wrapped_jira_error(status_code: int, text: str = "Not 
     fake_client.base_url = "https://jira.example.com"
 
     return JiraWorkflowService(fake_client)
-
-
-_TOMCAT_400_TEXT = (
-    "<!doctype html><h1>HTTP Status 400 – Bad Request</h1>"
-    "Message: Invalid URI: [The encoded slash character is not allowed]"
-    "Apache Tomcat/9.0.85"
-)
 
 
 def _make_service_raising_wrapped_jira_error_400_encoded_slash() -> JiraWorkflowService:

--- a/tests/unit/test_jira_workflow_404_silent.py
+++ b/tests/unit/test_jira_workflow_404_silent.py
@@ -1,4 +1,4 @@
-"""Workflow-detail endpoints (transitions / statuses) must treat 404 quietly.
+"""Workflow-detail endpoints (transitions / statuses) must treat unfetchable cases quietly.
 
 The Jira Server REST endpoints
 ``/rest/api/2/workflow/<name>/transitions`` and
@@ -8,7 +8,7 @@ in ``workflow_migration.py`` already swallows the exception and uses an
 empty list, so logging at ERROR with a stack trace per workflow (55 such
 records on the live NRS run) is pure noise.
 
-Root cause: the ``jira`` library's ``ResilientSession.raise_on_error``
+Root cause (404 case): the ``jira`` library's ``ResilientSession.raise_on_error``
 raises ``JIRAError(status_code=404)`` *before* returning any response
 object, so the existing ``if getattr(response, "status_code", None) == 404``
 guard is dead code that never executes. The raised ``JIRAError`` falls
@@ -16,18 +16,22 @@ straight into the ``except Exception as exc`` handler which calls
 ``self._logger.exception(...)`` — printing a full traceback at ERROR
 level for each of the 55 workflows.
 
-Fix (initial): catch ``JIRAError`` explicitly in the ``except`` block; when
-``exc.status_code == 404`` log at DEBUG and return ``[]``. For all other
-status codes / exception types keep the existing raise behaviour so real
-failures are still visible.
-
-Fix (production-complete): In production ``JiraClient._patch_jira_client``
+Fix (production-complete for 404): In production ``JiraClient._patch_jira_client``
 wraps the ``jira`` SDK session so that *all* exceptions (including
 ``JIRAError``) are re-raised as ``JiraApiError`` with the original
 ``JIRAError`` stored as ``exc.__cause__``. Therefore the ``isinstance(exc,
 JIRAError)`` check is always ``False`` in production. The fix must walk the
 ``__cause__`` chain so that a ``JiraApiError`` whose cause is a
 ``JIRAError(status_code=404)`` is also treated silently.
+
+Additional case (Tomcat encoded-slash 400): workflow names that contain a
+literal ``/`` character (e.g. ``"NREDIT: Blog/CS Workflow"``) are
+percent-encoded as ``%2F`` by ``urllib.parse.quote``.  Apache Tomcat rejects
+such encoded slashes in URL path segments by default (``ALLOW_ENCODED_SLASH``
+is ``false`` unless explicitly changed) and returns HTTP 400 with an HTML
+body containing "Invalid URI: [The encoded slash character is not allowed]".
+This is structurally unfetchable — no retry can work around it.  It is
+treated identically to a 404: log at DEBUG, return ``[]``.
 """
 
 from __future__ import annotations
@@ -72,13 +76,13 @@ def _make_service_returning(status_code: int = 200, json_body: Any | None = None
     return JiraWorkflowService(fake_client)
 
 
-def _make_service_raising_jira_error(status_code: int) -> JiraWorkflowService:
+def _make_service_raising_jira_error(status_code: int, text: str = "Not Found") -> JiraWorkflowService:
     """Session raises JIRAError directly — bare path (no production wrapping)."""
     from jira.exceptions import JIRAError
 
     fake_session = MagicMock()
     fake_session.get.side_effect = JIRAError(
-        text="Not Found",
+        text=text,
         status_code=status_code,
         url="https://jira.example.com/rest/api/2/workflow/Some%20Workflow",
     )
@@ -93,23 +97,50 @@ def _make_service_raising_jira_error(status_code: int) -> JiraWorkflowService:
     return JiraWorkflowService(fake_client)
 
 
-def _make_service_raising_wrapped_jira_error(status_code: int) -> JiraWorkflowService:
+def _make_service_raising_jira_error_400_encoded_slash(
+    workflow_name: str = "NREDIT: Blog/CS Workflow",
+) -> JiraWorkflowService:
+    """Session raises JIRAError(400) with Tomcat encoded-slash message — bare path."""
+    from jira.exceptions import JIRAError
+
+    tomcat_body = (
+        "<!doctype html><h1>HTTP Status 400 – Bad Request</h1>"
+        "Message: Invalid URI: [The encoded slash character is not allowed]"
+        "Apache Tomcat/9.0.85"
+    )
+    fake_session = MagicMock()
+    fake_session.get.side_effect = JIRAError(
+        text=tomcat_body,
+        status_code=400,
+        url=f"https://jira.example.com/rest/api/2/workflow/{workflow_name}/transitions",
+    )
+
+    fake_jira = MagicMock()
+    fake_jira._session = fake_session
+
+    fake_client = MagicMock()
+    fake_client.jira = fake_jira
+    fake_client.base_url = "https://jira.example.com"
+
+    return JiraWorkflowService(fake_client)
+
+
+def _make_service_raising_wrapped_jira_error(status_code: int, text: str = "Not Found") -> JiraWorkflowService:
     """Session raises JiraApiError whose __cause__ is a JIRAError.
 
     This simulates the PRODUCTION path: ``JiraClient._patch_jira_client``
     installs a ``patched_request`` shim that catches *all* exceptions and
     re-raises them as ``JiraApiError(msg) from original_exc``.  So the
-    ``JIRAError(status_code=404)`` raised by the ``jira`` SDK's
-    ``ResilientSession`` never reaches the service directly — instead the
-    service sees a ``JiraApiError`` with the original ``JIRAError`` stored
-    as ``__cause__``.
+    ``JIRAError`` raised by the ``jira`` SDK's ``ResilientSession`` never
+    reaches the service directly — instead the service sees a ``JiraApiError``
+    with the original ``JIRAError`` stored as ``__cause__``.
     """
     from jira.exceptions import JIRAError
 
     from src.infrastructure.jira.jira_client import JiraApiError
 
     cause = JIRAError(
-        text="Not Found",
+        text=text,
         status_code=status_code,
         url="https://jira.example.com/rest/api/2/workflow/Some%20Workflow",
     )
@@ -127,6 +158,18 @@ def _make_service_raising_wrapped_jira_error(status_code: int) -> JiraWorkflowSe
     fake_client.base_url = "https://jira.example.com"
 
     return JiraWorkflowService(fake_client)
+
+
+_TOMCAT_400_TEXT = (
+    "<!doctype html><h1>HTTP Status 400 – Bad Request</h1>"
+    "Message: Invalid URI: [The encoded slash character is not allowed]"
+    "Apache Tomcat/9.0.85"
+)
+
+
+def _make_service_raising_wrapped_jira_error_400_encoded_slash() -> JiraWorkflowService:
+    """Production-path version: JiraApiError wrapping JIRAError(400) with Tomcat body."""
+    return _make_service_raising_wrapped_jira_error(status_code=400, text=_TOMCAT_400_TEXT)
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +282,108 @@ def test_get_workflow_statuses_raises_on_wrapped_500(
     with caplog.at_level(logging.DEBUG):
         with pytest.raises(JiraApiError):
             service.get_workflow_statuses("X")
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tomcat encoded-slash 400 — bare JIRAError path
+# ---------------------------------------------------------------------------
+
+
+def test_get_workflow_transitions_no_error_log_when_jira_raises_400_encoded_slash(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JIRAError(400) with Tomcat encoded-slash body must be silenced at DEBUG, returns []."""
+    service = _make_service_raising_jira_error_400_encoded_slash("NREDIT: Blog/CS Workflow")
+    with caplog.at_level(logging.DEBUG):
+        result = service.get_workflow_transitions("NREDIT: Blog/CS Workflow")
+    assert result == [], "expected empty list on Tomcat 400 encoded-slash"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records == [], f"Got unexpected ERROR log entries: {error_records}"
+
+
+def test_get_workflow_statuses_no_error_log_when_jira_raises_400_encoded_slash(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JIRAError(400) with Tomcat encoded-slash body must be silenced at DEBUG, returns []."""
+    service = _make_service_raising_jira_error_400_encoded_slash("NREDIT: Blog/CS Workflow")
+    with caplog.at_level(logging.DEBUG):
+        result = service.get_workflow_statuses("NREDIT: Blog/CS Workflow")
+    assert result == [], "expected empty list on Tomcat 400 encoded-slash"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records == [], f"Got unexpected ERROR log entries: {error_records}"
+
+
+def test_get_workflow_transitions_400_encoded_slash_logs_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The encoded-slash 400 suppression must emit a DEBUG message (not silence entirely)."""
+    service = _make_service_raising_jira_error_400_encoded_slash("NREDIT: Blog/CS Workflow")
+    with caplog.at_level(logging.DEBUG):
+        service.get_workflow_transitions("NREDIT: Blog/CS Workflow")
+    debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    assert any(
+        "unfetchable" in r.message.lower() or "encoded" in r.message.lower() or "400" in r.message
+        for r in debug_records
+    ), f"Expected a DEBUG log mentioning unfetchable/encoded/400, got: {[r.message for r in debug_records]}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tomcat encoded-slash 400 — production-wrapped path
+# ---------------------------------------------------------------------------
+
+
+def test_get_workflow_transitions_no_error_log_when_wrapped_400_encoded_slash(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JiraApiError wrapping JIRAError(400)+encoded-slash must be silenced at DEBUG, returns []."""
+    service = _make_service_raising_wrapped_jira_error_400_encoded_slash()
+    with caplog.at_level(logging.DEBUG):
+        result = service.get_workflow_transitions("NREDIT: Blog/CS Workflow")
+    assert result == [], "expected empty list on production-wrapped 400 encoded-slash"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records == [], f"Got unexpected ERROR log entries: {error_records}"
+
+
+def test_get_workflow_statuses_no_error_log_when_wrapped_400_encoded_slash(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JiraApiError wrapping JIRAError(400)+encoded-slash must be silenced at DEBUG, returns []."""
+    service = _make_service_raising_wrapped_jira_error_400_encoded_slash()
+    with caplog.at_level(logging.DEBUG):
+        result = service.get_workflow_statuses("NREDIT: Blog/CS Workflow")
+    assert result == [], "expected empty list on production-wrapped 400 encoded-slash"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records == [], f"Got unexpected ERROR log entries: {error_records}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: 400 without encoded-slash body must NOT be silenced (negative regression)
+# ---------------------------------------------------------------------------
+
+
+def test_get_workflow_transitions_raises_on_jira_400_other_reason(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JIRAError(400) with a generic body (not encoded-slash) must still raise at ERROR."""
+    from src.infrastructure.jira.jira_client import JiraApiError
+
+    # Generic 400 — bad request for some other reason
+    service = _make_service_raising_jira_error(status_code=400, text="Bad Request: malformed query")
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(JiraApiError):
+            service.get_workflow_transitions("SomeWorkflow")
+
+
+def test_get_workflow_statuses_raises_on_jira_400_other_reason(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JIRAError(400) with a generic body (not encoded-slash) must still raise at ERROR."""
+    from src.infrastructure.jira.jira_client import JiraApiError
+
+    service = _make_service_raising_jira_error(status_code=400, text="Bad Request: malformed query")
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(JiraApiError):
+            service.get_workflow_statuses("SomeWorkflow")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A fresh production-like migration run revealed this error (PR #240's 404 silencing did NOT cover this variant):

```
[18:04:36.401622] ERROR    Failed to fetch transitions for workflow 'NREDIT: Blog/CS Workflow': Error during API request to https://jira.netresearch.de/rest/api/2/workflow/NREDIT%3A%20Blog%2FCS%20Workflow/transitions: JiraError HTTP 400 url: ...
text: <!doctype html><h1>HTTP Status 400 – Bad Request</h1>
Message: Invalid URI: [The encoded slash character is not allowed]
Apache Tomcat/9.0.85
```

Workflow names that contain a literal `/` character (e.g. `"NREDIT: Blog/CS Workflow"`) are percent-encoded as `%2F` by `urllib.parse.quote`. Apache Tomcat rejects percent-encoded slashes in URL path segments by default (`ALLOW_ENCODED_SLASH=false`) and returns HTTP 400 with an HTML body containing `"Invalid URI: [The encoded slash character is not allowed]"`.

This is **structurally unfetchable** — no retry strategy can work around a Tomcat configuration default. The correct treatment is identical to a 404: log at DEBUG, return `[]`, continue the migration.

## Changes

**`src/infrastructure/jira/jira_workflow_service.py`**
- Rename `_is_workflow_404` → `_is_workflow_unfetchable` with an expanded docstring
- Add a second match arm: `JIRAError(status_code=400)` whose `.text` contains `"invalid uri"` or `"encoded slash"` (case-insensitive)
- Update both call sites (`get_workflow_transitions`, `get_workflow_statuses`) with the new helper name and revised log message
- A generic HTTP 400 (body not matching those markers) still raises at ERROR level — real failures stay visible

**`tests/conftest.py`**
- Add `self.text = text` to `_CTestJIRAError` stub so the stub correctly models the real `JIRAError` interface (was missing the `.text` attribute)

**`tests/unit/test_jira_workflow_404_silent.py`**
- 11 new test cases covering:
  - Bare `JIRAError(400)` + Tomcat body → silenced, returns `[]` (transitions + statuses)
  - DEBUG log is emitted (not complete silence)
  - Production-wrapped `JiraApiError` whose `__cause__` is `JIRAError(400)` + Tomcat body → silenced
  - Bare `JIRAError(400)` with a **generic** body → still raises (negative regression guard)
- All 8 pre-existing 404 tests kept green

## Test plan

- [x] `pytest tests/unit/test_jira_workflow_404_silent.py -W error` — 19/19 pass
- [x] `ruff check . && ruff format --check .` — clean
- [x] `mypy src/` — 0 errors
- [x] Full suite — pre-existing failures in `test_enhanced_openproject_client.py` are unrelated to this change (verified by running the same tests on unmodified `main`)

Predecessor: [PR #240](https://github.com/netresearch/jira-to-openproject/pull/240) (404 silencing)