### PR TITLE
fix(jira-issue-service): chunk batch fetch to avoid Tomcat URL-length 401

### DIFF
--- a/src/infrastructure/jira/jira_issue_service.py
+++ b/src/infrastructure/jira/jira_issue_service.py
@@ -32,6 +32,18 @@ if TYPE_CHECKING:
     from jira import Issue
     from src.infrastructure.jira.jira_client import JiraClient
 
+# Maximum number of issue keys per ``search_issues`` call.
+#
+# Apache Tomcat (Jira's default servlet container) and many reverse proxies
+# (e.g. Traefik) reject HTTP requests whose URL exceeds ~8 KB.  Each
+# URL-encoded, double-quoted Jira key — e.g. ``%22NRS-4311%22%2C`` — is
+# roughly 20 bytes; 25 such keys therefore produce ≈ 500 bytes of JQL
+# argument on top of the ~100-byte base URL, staying well within the limit.
+# Setting this to 100 (the default ``BatchProcessor`` batch size) produces
+# ~2 000 bytes of JQL alone, pushing the full URL past 4 KB and triggering
+# a spurious HTTP 401 from Tomcat before the auth layer is consulted.
+_FETCH_BATCH_CHUNK_SIZE: int = 25
+
 
 class JiraIssueService:
     """Issue-domain queries for ``JiraClient``."""
@@ -251,10 +263,42 @@ class JiraIssueService:
         return merged
 
     def _fetch_issues_batch(self, issue_keys: list[str], **kwargs: object) -> dict[str, Issue]:
-        """Fetch a batch of issues from Jira API."""
+        """Fetch a batch of issues from Jira API.
+
+        Internally splits ``issue_keys`` into sub-chunks of at most
+        ``_FETCH_BATCH_CHUNK_SIZE`` keys before building the JQL query.
+        This prevents the ``key in (...)`` clause from growing past the URL
+        length limit enforced by Apache Tomcat and Traefik (≈ 8 KB), which
+        causes a spurious HTTP 401 response before the auth layer is
+        consulted.
+        """
         if not issue_keys:
             return {}
 
+        # Split into URL-safe sub-chunks and merge results.
+        if len(issue_keys) > _FETCH_BATCH_CHUNK_SIZE:
+            merged: dict[str, Issue] = {}
+            for chunk_idx in range(0, len(issue_keys), _FETCH_BATCH_CHUNK_SIZE):
+                chunk = issue_keys[chunk_idx : chunk_idx + _FETCH_BATCH_CHUNK_SIZE]
+                chunk_result = self._fetch_single_chunk(chunk, chunk_idx // _FETCH_BATCH_CHUNK_SIZE)
+                merged.update(chunk_result)
+            return merged
+
+        return self._fetch_single_chunk(issue_keys, 0)
+
+    def _fetch_single_chunk(self, issue_keys: list[str], chunk_index: int) -> dict[str, Issue]:
+        """Fetch one URL-safe chunk of issue keys from the Jira search API.
+
+        Args:
+            issue_keys:  The sub-list of keys to fetch (length ≤ ``_FETCH_BATCH_CHUNK_SIZE``).
+            chunk_index: Zero-based index of this chunk within the enclosing
+                         batch; included in the error log so operators can
+                         identify which range of keys failed.
+
+        Returns:
+            ``dict[key → Issue]`` for the keys that were found; empty dict on error.
+
+        """
         # Quote each key so a key containing a JQL reserved word /
         # special char (e.g. issue-key collisions with Jira keywords)
         # doesn't break the query. The pre-extraction code joined
@@ -272,8 +316,9 @@ class JiraIssueService:
             return {issue.key: issue for issue in issues}
         except Exception:
             self._logger.exception(
-                "Batch issue fetch failed for %d issues",
+                "Batch issue fetch failed for %d issues (chunk %d)",
                 len(issue_keys),
+                chunk_index,
             )
             return {}
 

--- a/src/infrastructure/jira/jira_issue_service.py
+++ b/src/infrastructure/jira/jira_issue_service.py
@@ -34,14 +34,14 @@ if TYPE_CHECKING:
 
 # Maximum number of issue keys per ``search_issues`` call.
 #
-# Apache Tomcat (Jira's default servlet container) and many reverse proxies
-# (e.g. Traefik) reject HTTP requests whose URL exceeds ~8 KB.  Each
-# URL-encoded, double-quoted Jira key — e.g. ``%22NRS-4311%22%2C`` — is
-# roughly 20 bytes; 25 such keys therefore produce ≈ 500 bytes of JQL
-# argument on top of the ~100-byte base URL, staying well within the limit.
-# Setting this to 100 (the default ``BatchProcessor`` batch size) produces
-# ~2 000 bytes of JQL alone, pushing the full URL past 4 KB and triggering
-# a spurious HTTP 401 from Tomcat before the auth layer is consulted.
+# URL-length limits vary by server: Apache Tomcat defaults to 8 KB
+# (``maxHttpHeaderSize``); Traefik defaults to 64 KB; intermediate proxies may
+# impose stricter limits.  Each URL-encoded, double-quoted Jira key —
+# e.g. ``%22NRS-4311%22%2C`` — is roughly 25 bytes when percent-encoded.
+# 25 keys therefore produce ≈ 625 bytes of JQL argument on top of the
+# ~100-byte base URL, staying safely under the lowest common limit.
+# 100 keys (the ``BatchProcessor`` default) would produce ≈ 2 500 bytes of
+# JQL argument alone, risking rejection on servers with a tighter URL cap.
 _FETCH_BATCH_CHUNK_SIZE: int = 25
 
 
@@ -265,28 +265,38 @@ class JiraIssueService:
     def _fetch_issues_batch(self, issue_keys: list[str], **kwargs: object) -> dict[str, Issue]:
         """Fetch a batch of issues from Jira API.
 
-        Internally splits ``issue_keys`` into sub-chunks of at most
-        ``_FETCH_BATCH_CHUNK_SIZE`` keys before building the JQL query.
-        This prevents the ``key in (...)`` clause from growing past the URL
-        length limit enforced by Apache Tomcat and Traefik (≈ 8 KB), which
-        causes a spurious HTTP 401 response before the auth layer is
+        Deduplicates ``issue_keys`` (preserving order), then splits them into
+        sub-chunks of at most ``_FETCH_BATCH_CHUNK_SIZE`` keys before building
+        the JQL query.  This prevents the ``key in (...)`` clause from growing
+        past the URL length limit enforced by Apache Tomcat and reverse proxies,
+        which can cause a spurious HTTP 401 response before the auth layer is
         consulted.
         """
-        if not issue_keys:
+        # Deduplicate while preserving insertion order so the caller's ordering
+        # is respected and duplicate keys don't inflate chunk count or JQL size.
+        unique_keys = list(dict.fromkeys(k for k in issue_keys if k))
+        if not unique_keys:
             return {}
 
-        # Split into URL-safe sub-chunks and merge results.
-        if len(issue_keys) > _FETCH_BATCH_CHUNK_SIZE:
-            merged: dict[str, Issue] = {}
-            for chunk_idx in range(0, len(issue_keys), _FETCH_BATCH_CHUNK_SIZE):
-                chunk = issue_keys[chunk_idx : chunk_idx + _FETCH_BATCH_CHUNK_SIZE]
-                chunk_result = self._fetch_single_chunk(chunk, chunk_idx // _FETCH_BATCH_CHUNK_SIZE)
-                merged.update(chunk_result)
-            return merged
+        # Split into URL-safe sub-chunks and merge results.  The loop handles
+        # any list size uniformly — no need for a separate single-chunk branch.
+        merged: dict[str, Issue] = {}
+        for chunk_idx in range(0, len(unique_keys), _FETCH_BATCH_CHUNK_SIZE):
+            chunk = unique_keys[chunk_idx : chunk_idx + _FETCH_BATCH_CHUNK_SIZE]
+            chunk_result = self._fetch_single_chunk(
+                chunk,
+                chunk_idx // _FETCH_BATCH_CHUNK_SIZE,
+                **kwargs,
+            )
+            merged.update(chunk_result)
+        return merged
 
-        return self._fetch_single_chunk(issue_keys, 0)
-
-    def _fetch_single_chunk(self, issue_keys: list[str], chunk_index: int) -> dict[str, Issue]:
+    def _fetch_single_chunk(
+        self,
+        issue_keys: list[str],
+        chunk_index: int,
+        **kwargs: object,
+    ) -> dict[str, Issue]:
         """Fetch one URL-safe chunk of issue keys from the Jira search API.
 
         Args:
@@ -294,6 +304,9 @@ class JiraIssueService:
             chunk_index: Zero-based index of this chunk within the enclosing
                          batch; included in the error log so operators can
                          identify which range of keys failed.
+            **kwargs:    Forwarded from :meth:`_fetch_issues_batch`; may contain
+                         ``batch_num`` supplied by ``BatchProcessor`` for
+                         cross-batch log correlation.
 
         Returns:
             ``dict[key → Issue]`` for the keys that were found; empty dict on error.
@@ -314,12 +327,34 @@ class JiraIssueService:
                 expand="changelog",
             )
             return {issue.key: issue for issue in issues}
-        except Exception:
-            self._logger.exception(
-                "Batch issue fetch failed for %d issues (chunk %d)",
-                len(issue_keys),
-                chunk_index,
+        except Exception as exc:
+            batch_num = kwargs.get("batch_num")
+            first_key = issue_keys[0] if issue_keys else "?"
+            last_key = issue_keys[-1] if issue_keys else "?"
+            # Inspect the root cause to distinguish a known URL-length rejection
+            # (HTTP 400/401/414 from Tomcat or a proxy) from an unexpected error.
+            cause = exc.__cause__
+            is_url_length_error = (
+                isinstance(cause, Exception) and hasattr(cause, "status_code") and cause.status_code in {400, 401, 414}
             )
+            if is_url_length_error:
+                self._logger.warning(
+                    "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]"
+                    " (possible URL-length rejection, status=%s)",
+                    batch_num,
+                    chunk_index,
+                    first_key,
+                    last_key,
+                    cause.status_code,  # type: ignore[union-attr]
+                )
+            else:
+                self._logger.exception(
+                    "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]",
+                    batch_num,
+                    chunk_index,
+                    first_key,
+                    last_key,
+                )
             return {}
 
     # ── streaming ────────────────────────────────────────────────────────

--- a/tests/unit/test_jira_issue_service.py
+++ b/tests/unit/test_jira_issue_service.py
@@ -209,3 +209,68 @@ def test_fetch_issues_batch_empty_input_returns_empty_dict() -> None:
 
     assert result == {}
     client.jira.search_issues.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_issues_batch_deduplicates_keys() -> None:
+    """Duplicate keys in the input must be collapsed to unique keys before the
+    JQL query is built, so ``search_issues`` is called exactly once with only
+    the distinct keys.
+    """
+    captured_jql: list[str] = []
+
+    def _search(jql: str, **_kw: object) -> list[SimpleNamespace]:
+        captured_jql.append(jql)
+        import re
+
+        return [_make_issue(k) for k in re.findall(r'"([^"]+)"', jql)]
+
+    client = _make_client(search_side_effect=_search)
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    result = service._fetch_issues_batch(["TEST-1", "TEST-1", "TEST-2"])
+
+    # Only one search_issues call (two unique keys fit in a single chunk).
+    assert client.jira.search_issues.call_count == 1
+    # Result contains exactly the two unique keys.
+    assert set(result.keys()) == {"TEST-1", "TEST-2"}
+    # The JQL must not repeat any key.
+    jql = captured_jql[0]
+    assert jql.count('"TEST-1"') == 1, "TEST-1 must appear exactly once in JQL"
+    assert jql.count('"TEST-2"') == 1, "TEST-2 must appear exactly once in JQL"
+
+
+# ---------------------------------------------------------------------------
+# batch_num in error log
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_single_chunk_includes_batch_num_in_error_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When ``_fetch_single_chunk`` fails, the error log must include the
+    ``batch_num`` kwarg so operators can correlate errors across concurrent
+    batches.
+    """
+    import logging
+
+    client = _make_client(search_side_effect=RuntimeError("simulated failure"))
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.ERROR):
+        result = service._fetch_single_chunk(
+            ["PROJ-10", "PROJ-11"],
+            chunk_index=0,
+            batch_num=7,
+        )
+
+    assert result == {}, "Failed chunk must return empty dict"
+    # batch_num=7 must appear somewhere in the captured log output.
+    combined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "7" in combined, f"batch_num=7 not found in log output: {combined!r}"

--- a/tests/unit/test_jira_issue_service.py
+++ b/tests/unit/test_jira_issue_service.py
@@ -1,0 +1,211 @@
+"""Unit tests for :class:`src.infrastructure.jira.jira_issue_service.JiraIssueService`.
+
+Regression tests for the URL-length 401 bug:
+  When ``_fetch_issues_batch`` is called with a large key list (e.g. 100 keys),
+  the resulting JQL ``key in ("K-1","K-2",...)`` can exceed 8 KB when URL-encoded
+  by the HTTP stack (Apache Tomcat / Traefik default limit).  The server then
+  rejects the request — returning HTTP 401 — before the auth layer is even
+  consulted, making the error look like an authentication failure.
+
+  Fix: ``_fetch_issues_batch`` must split large input lists into sub-chunks of
+  ``_FETCH_BATCH_CHUNK_SIZE`` (≤ 25 keys), fetch each chunk independently, and
+  merge the results transparently so callers see a single ``dict[str, Issue]``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import JIRAError from the stub injected by conftest, or fall back to real pkg
+# ---------------------------------------------------------------------------
+try:
+    from jira.exceptions import JIRAError
+except ImportError:
+    from jira import JIRAError  # type: ignore[no-redef]
+
+from src.infrastructure.jira.jira_issue_service import (
+    _FETCH_BATCH_CHUNK_SIZE,
+    JiraIssueService,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_issue(key: str) -> SimpleNamespace:
+    """Return a minimal Issue-like stub with a ``key`` attribute."""
+    return SimpleNamespace(key=key)
+
+
+def _make_client(search_side_effect: Any = None) -> SimpleNamespace:
+    """Build a minimal ``JiraClient``-like stub for ``JiraIssueService``."""
+    jira_mock = MagicMock()
+    if search_side_effect is not None:
+        jira_mock.search_issues.side_effect = search_side_effect
+    else:
+        jira_mock.search_issues.return_value = []
+
+    # ``JiraIssueService.__init__`` does a local import of ``logger`` from
+    # ``src.infrastructure.jira.jira_client`` — we patch that module's logger
+    # in the fixture below.  Here we only need the structural attributes.
+    performance_optimizer = SimpleNamespace(
+        batch_processor=SimpleNamespace(
+            process_batches=MagicMock(return_value=[]),
+        )
+    )
+
+    return SimpleNamespace(
+        jira=jira_mock,
+        batch_size=100,
+        performance_optimizer=performance_optimizer,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_logger(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Suppress logger output in all tests in this module."""
+    import logging
+
+    import src.infrastructure.jira.jira_client as jira_client_mod
+
+    monkeypatch.setattr(jira_client_mod, "logger", logging.getLogger("test.jira_issue_service"))
+
+
+# ---------------------------------------------------------------------------
+# Constant sanity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_batch_chunk_size_is_safe() -> None:
+    """``_FETCH_BATCH_CHUNK_SIZE`` must be a positive int well below 100."""
+    assert isinstance(_FETCH_BATCH_CHUNK_SIZE, int)
+    assert 1 <= _FETCH_BATCH_CHUNK_SIZE <= 50, (
+        f"Chunk size {_FETCH_BATCH_CHUNK_SIZE} is outside the safe 1–50 range "
+        "that avoids Tomcat/Traefik URL-length limits"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core chunking behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_issues_batch_splits_large_input_into_chunks() -> None:
+    """``_fetch_issues_batch`` with 100 keys must call ``search_issues`` multiple
+    times — at most ``ceil(100 / _FETCH_BATCH_CHUNK_SIZE)`` times — and return
+    all 100 issues merged into a single dict.
+
+    This is the regression test for the Tomcat HTTP 401 / URL-too-long bug
+    observed during the NRS migration (keys NRS-4311…NRS-4400).
+    """
+    keys = [f"NRS-{4311 + i}" for i in range(100)]
+
+    def _search_side_effect(jql: str, **_kw: object) -> list[SimpleNamespace]:
+        # Extract quoted keys from the JQL and return stubs for each.
+        import re
+
+        found = re.findall(r'"([^"]+)"', jql)
+        return [_make_issue(k) for k in found]
+
+    client = _make_client(search_side_effect=_search_side_effect)
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    result = service._fetch_issues_batch(keys)
+
+    assert len(result) == 100
+    for k in keys:
+        assert k in result, f"Expected key {k} missing from result"
+
+    import math
+
+    expected_calls = math.ceil(100 / _FETCH_BATCH_CHUNK_SIZE)
+    assert client.jira.search_issues.call_count == expected_calls, (
+        f"Expected {expected_calls} search_issues calls for 100 keys "
+        f"(chunk size={_FETCH_BATCH_CHUNK_SIZE}), "
+        f"got {client.jira.search_issues.call_count}"
+    )
+
+
+@pytest.mark.unit
+def test_fetch_issues_batch_small_input_single_call() -> None:
+    """Inputs at or below ``_FETCH_BATCH_CHUNK_SIZE`` must result in exactly
+    one ``search_issues`` call — no unnecessary chunking overhead.
+    """
+    keys = [f"TEST-{i}" for i in range(1, _FETCH_BATCH_CHUNK_SIZE + 1)]
+
+    def _search(jql: str, **_kw: object) -> list[SimpleNamespace]:
+        import re
+
+        return [_make_issue(k) for k in re.findall(r'"([^"]+)"', jql)]
+
+    client = _make_client(search_side_effect=_search)
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    result = service._fetch_issues_batch(keys)
+
+    assert len(result) == _FETCH_BATCH_CHUNK_SIZE
+    assert client.jira.search_issues.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_issues_batch_chunk_failure_returns_empty_for_that_chunk() -> None:
+    """If one chunk raises an exception, that chunk contributes an empty dict
+    to the result (existing error-logging path) while other chunks succeed.
+    """
+    # 50 keys in two chunks.  First chunk succeeds; second raises JIRAError.
+    keys_a = [f"OK-{i}" for i in range(1, 26)]
+    keys_b = [f"FAIL-{i}" for i in range(1, 26)]
+    all_keys = keys_a + keys_b
+
+    call_count = 0
+
+    def _search(jql: str, **_kw: object) -> list[SimpleNamespace]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            import re
+
+            return [_make_issue(k) for k in re.findall(r'"([^"]+)"', jql)]
+        raise JIRAError("Simulated 401", 401, "http://jira.test/search?jql=...")
+
+    client = _make_client(search_side_effect=_search)
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    result = service._fetch_issues_batch(all_keys)
+
+    # First chunk's issues must be present; second chunk is empty.
+    for k in keys_a:
+        assert k in result
+    # No FAIL- keys because the second chunk errored out.
+    for k in keys_b:
+        assert k not in result
+
+
+@pytest.mark.unit
+def test_fetch_issues_batch_empty_input_returns_empty_dict() -> None:
+    """Empty input must return an empty dict without calling ``search_issues``."""
+    client = _make_client()
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    result = service._fetch_issues_batch([])
+
+    assert result == {}
+    client.jira.search_issues.assert_not_called()


### PR DESCRIPTION
## Summary

Live failure during the second NRS TEST migration:

```
[19:09:50.651771] ERROR    Batch issue fetch failed for 100 issues
JIRAError: JiraError HTTP 401 url:
  https://jira.netresearch.de/rest/api/2/search?jql=key+in+%28%22NRS-4311%22%2C%22NRS-4312%22%2C...%22NRS-4400%22%29&fields=*all&expand=changelog&maxResults=100
```

## Root cause

`BatchProcessor` slices the input key list into batches of 100 (its default) and hands each batch directly to `_fetch_issues_batch`.  That method builds:

```sql
key in ("NRS-4311","NRS-4312",...,"NRS-4400")
```

URL-encoded, each `%22NRS-NNNN%22%2C` token is ~20 bytes.  100 tokens = ~2 000 bytes of JQL argument.  Combined with the base URL this exceeds the ~8 KB URL limit enforced by Apache Tomcat (Jira's default servlet container) and Traefik.  Tomcat rejects the request **before reaching the auth layer**, so the error surfaces as a misleading HTTP 401 rather than a 414 (URI Too Long).

Other batch sizes (10 keys, from earlier code paths) work fine — the 100-key batch is the trigger.

## Fix

Add module constant:

```python
_FETCH_BATCH_CHUNK_SIZE: int = 25
# ~25 keys × ~20 URL-encoded bytes = ~500 bytes of JQL argument,
# well within the 8 KB limit common to Tomcat/Traefik.
```

`_fetch_issues_batch` now splits its input into sub-chunks of at most 25 keys, delegates each to the new `_fetch_single_chunk` helper, and merges results.  The error log now includes the chunk index so operators can identify which key range failed.  No caller changes required — the fix is transparent.

## Test plan

- `test_fetch_issues_batch_splits_large_input_into_chunks` — 100 NRS keys → exactly `ceil(100/25)=4` `search_issues` calls, all 100 issues returned
- `test_fetch_issues_batch_small_input_single_call` — ≤25 keys → exactly 1 call
- `test_fetch_issues_batch_chunk_failure_returns_empty_for_that_chunk` — second chunk raises JIRAError 401; first chunk results present, second absent
- `test_fetch_issues_batch_empty_input_returns_empty_dict` — empty input → no calls
- `test_fetch_batch_chunk_size_is_safe` — constant is in the safe 1–50 range