### PR TITLE
fix(work-package-content): idempotent comment creation via provenance marker (+ cleanup script)

### DIFF
--- a/scripts/cleanup_anonymous_comment_duplicates.py
+++ b/scripts/cleanup_anonymous_comment_duplicates.py
@@ -153,26 +153,26 @@ def _build_fetch_script(project_key: str) -> str:
     return f"""
 require 'json'
 proj = Project.find_by(identifier: '{safe_key.lower()}')
-unless proj
-  next {{error: 'project not found', identifier: '{safe_key.lower()}'}}
-end
-
-wp_ids = WorkPackage.where(project_id: proj.id).pluck(:id)
-journals = Journal
-  .where(journable_type: 'WorkPackage', journable_id: wp_ids)
-  .where.not(notes: [nil, ''])
-  .order(:journable_id, :created_at)
-  .pluck(:id, :journable_id, :user_id, :notes, :created_at)
-  .map {{|id, wp_id, user_id, notes, created_at|
-    {{
-      id: id,
-      wp_id: wp_id,
-      user_id: user_id,
-      notes: notes,
-      created_at: created_at
+if proj
+  wp_ids = WorkPackage.where(project_id: proj.id).pluck(:id)
+  journals = Journal
+    .where(journable_type: 'WorkPackage', journable_id: wp_ids)
+    .where.not(notes: [nil, ''])
+    .order(:journable_id, :created_at)
+    .pluck(:id, :journable_id, :user_id, :notes, :created_at)
+    .map {{|id, wp_id, user_id, notes, created_at|
+      {{
+        id: id,
+        wp_id: wp_id,
+        user_id: user_id,
+        notes: notes,
+        created_at: created_at
+      }}
     }}
-  }}
-{{project_id: proj.id, wp_ids_count: wp_ids.length, journals: journals}}
+  {{project_id: proj.id, wp_ids_count: wp_ids.length, journals: journals}}
+else
+  {{error: 'project not found', identifier: '{safe_key.lower()}'}}
+end
 """
 
 
@@ -241,7 +241,14 @@ def run(
     for wp_id, wp_journals in by_wp.items():
         _kept, to_delete = _plan_deletions(wp_journals)
         if to_delete:
-            duplicate_group_count += len(to_delete)
+            # Count the number of duplicate *groups* for this WP (each unique
+            # normalised note text that has more than one copy is one group).
+            # This is distinct from len(to_delete) which counts journals to remove.
+            groups: dict[str, list[dict[str, Any]]] = {}
+            for j in wp_journals:
+                key = _strip_marker(j["notes"])
+                groups.setdefault(key, []).append(j)
+            duplicate_group_count += sum(1 for g in groups.values() if len(g) > 1)
             for j in to_delete:
                 reason = "Anonymous-author duplicate" if j["user_id"] == ANONYMOUS_USER_ID else "duplicate"
                 logger.info(

--- a/scripts/cleanup_anonymous_comment_duplicates.py
+++ b/scripts/cleanup_anonymous_comment_duplicates.py
@@ -1,0 +1,363 @@
+"""Remove duplicate comment journals produced by non-idempotent migration runs.
+
+Before the fix in PR #XXX (fix/wp-content-comment-idempotency) every
+re-run of ``--components work_packages_content`` blindly INSERTed a fresh
+set of comment journals for every work package, producing 2-3× duplicates.
+
+WP 5040 (Jira NRS-4391) accumulates the canonical example:
+
+    total comment-journals: 12  (Jira has 4)
+    unique notes:            8
+    by user:
+        Anonymous (user_id=2): 8   ← May-7 broken runs (author not resolved)
+        Björn Marten:          3   ← correct run
+        Mikhail Sarnov:        1   ← correct run
+
+This script deduplicates those journals **safely**:
+
+1. For each work package in the project's mapping, query OP for all
+   non-empty journals ordered by ``created_at``.
+2. Group journals by their ``notes`` content (normalised to strip the
+   provenance marker so a marker-carrying journal matches a plain one).
+3. Within each duplicate group keep the journal with a **real** author
+   (user_id != 2, i.e. not the Anonymous fallback) — or, if all
+   duplicates have the same author, keep the newest.
+4. Delete the others.
+5. Log every deletion to stdout AND to
+   ``var/logs/cleanup_anonymous_comment_duplicates_<ts>.log``.
+
+Defaults to ``--dry-run``.  Deletion requires explicit ``--apply``.
+
+Usage::
+
+    .venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS
+    .venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS --dry-run
+    .venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS --apply
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: OpenProject user_id for the ``Anonymous`` / system fallback account.
+ANONYMOUS_USER_ID = 2
+
+#: Regex to strip the j2o provenance marker from notes for dedup matching.
+_MARKER_RE = re.compile(r"\n?<!--\s*j2o:jira-comment-id:[^\s>]+\s*-->")
+
+#: Minimum valid project key: 2+ uppercase letters/digits
+_PROJECT_KEY_RE = re.compile(r"\A[A-Z][A-Z0-9_]+\z")
+
+
+# ---------------------------------------------------------------------------
+# Log helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_logging(log_path: Path) -> logging.Logger:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger("cleanup_anon_comments")
+    logger.setLevel(logging.DEBUG)
+    fmt = logging.Formatter("%(asctime)s  %(levelname)-7s  %(message)s")
+
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setLevel(logging.DEBUG)
+    ch.setFormatter(fmt)
+    logger.addHandler(ch)
+
+    fh = logging.FileHandler(log_path, encoding="utf-8")
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(fmt)
+    logger.addHandler(fh)
+
+    return logger
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def _strip_marker(notes: str) -> str:
+    """Remove provenance marker from notes for equality comparison."""
+    return _MARKER_RE.sub("", notes).strip()
+
+
+def _select_keeper(journals: list[dict[str, Any]]) -> dict[str, Any]:
+    """Choose the journal to KEEP from a group of duplicates.
+
+    Selection priority:
+    1. A journal with a real author (user_id != ANONYMOUS_USER_ID).
+       If multiple real-author journals exist, prefer the one whose raw
+       notes carry the j2o provenance marker (from the correctly-run
+       migration) — if still tied, keep the newest.
+    2. If all journals are Anonymous, keep the newest (to match what the
+       fresh correct run would have written last).
+    """
+    real_author = [j for j in journals if j["user_id"] != ANONYMOUS_USER_ID]
+    pool = real_author if real_author else journals
+
+    # Among the pool, prefer marker-bearing journals (they came from the
+    # correctly-fixed run) then fall back to newest.
+    with_marker = [j for j in pool if "j2o:jira-comment-id:" in j["notes"]]
+    candidates = with_marker if with_marker else pool
+
+    # Newest by created_at (ISO string — lexicographic sort works fine)
+    return max(candidates, key=lambda j: j["created_at"])
+
+
+def _plan_deletions(
+    journals: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return (to_keep, to_delete) for a WP's journals.
+
+    Groups by normalised notes content; for each group with >1 entry
+    selects a keeper and marks the rest for deletion.
+    """
+    # Partition by normalised notes text
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for j in journals:
+        key = _strip_marker(j["notes"])
+        groups.setdefault(key, []).append(j)
+
+    to_keep: list[dict[str, Any]] = []
+    to_delete: list[dict[str, Any]] = []
+
+    for _key, group in groups.items():
+        keeper = _select_keeper(group)
+        to_keep.append(keeper)
+        for j in group:
+            if j["id"] != keeper["id"]:
+                to_delete.append(j)
+
+    return to_keep, to_delete
+
+
+def _build_fetch_script(project_key: str) -> str:
+    """Ruby script to fetch all non-empty journals for WPs in the project."""
+    safe_key = project_key.upper()
+    # Fetches all journals with non-empty notes for WPs in the project,
+    # ordered by wp_id then created_at so duplicates are adjacent.
+    return f"""
+require 'json'
+proj = Project.find_by(identifier: '{safe_key.lower()}')
+unless proj
+  next {{error: 'project not found', identifier: '{safe_key.lower()}'}}
+end
+
+wp_ids = WorkPackage.where(project_id: proj.id).pluck(:id)
+journals = Journal
+  .where(journable_type: 'WorkPackage', journable_id: wp_ids)
+  .where.not(notes: [nil, ''])
+  .order(:journable_id, :created_at)
+  .pluck(:id, :journable_id, :user_id, :notes, :created_at)
+  .map {{|id, wp_id, user_id, notes, created_at|
+    {{
+      id: id,
+      wp_id: wp_id,
+      user_id: user_id,
+      notes: notes,
+      created_at: created_at
+    }}
+  }}
+{{project_id: proj.id, wp_ids_count: wp_ids.length, journals: journals}}
+"""
+
+
+def _build_delete_script(journal_ids: list[int]) -> str:
+    """Ruby script to delete a batch of journal IDs."""
+    ids_json = json.dumps(journal_ids)
+    return f"""
+require 'json'
+ids = {ids_json}
+deleted = Journal.where(id: ids).delete_all
+{{deleted: deleted}}
+"""
+
+
+def run(
+    project_key: str,
+    *,
+    apply: bool,
+    logger: logging.Logger,
+    op_client: Any,
+) -> dict[str, int]:
+    """Analyse and optionally clean up duplicate comment journals.
+
+    Returns:
+        Dict with keys: ``wps_scanned``, ``duplicate_groups``, ``to_delete``,
+        ``deleted`` (0 in dry-run mode), ``kept``.
+
+    """
+    mode = "APPLY" if apply else "DRY-RUN"
+    logger.info("Project: %s  Mode: %s", project_key, mode)
+
+    # Step 1: Fetch all non-empty journals
+    logger.info("Fetching journals from OpenProject via Rails …")
+    fetch_script = _build_fetch_script(project_key)
+    try:
+        result = op_client.execute_query_to_json_file(fetch_script)
+    except Exception as exc:
+        logger.error("Rails query failed: %s", exc)
+        raise
+
+    if isinstance(result, dict) and result.get("error"):
+        logger.error("Rails returned error: %s", result["error"])
+        raise RuntimeError(result["error"])
+
+    if not isinstance(result, dict):
+        logger.error("Unexpected result type: %r", type(result))
+        raise TypeError(f"Expected dict, got {type(result)}")
+
+    journals_raw: list[dict[str, Any]] = result.get("journals", [])
+    wp_ids_count: int = result.get("wp_ids_count", 0)
+    logger.info(
+        "Found %d non-empty journals across %d work packages",
+        len(journals_raw),
+        wp_ids_count,
+    )
+
+    # Step 2: Group journals by WP, then plan deletions
+    by_wp: dict[int, list[dict[str, Any]]] = {}
+    for j in journals_raw:
+        wp_id = j["wp_id"]
+        by_wp.setdefault(wp_id, []).append(j)
+
+    all_to_delete: list[dict[str, Any]] = []
+    duplicate_group_count = 0
+
+    for wp_id, wp_journals in by_wp.items():
+        _kept, to_delete = _plan_deletions(wp_journals)
+        if to_delete:
+            duplicate_group_count += len(to_delete)
+            for j in to_delete:
+                reason = "Anonymous-author duplicate" if j["user_id"] == ANONYMOUS_USER_ID else "duplicate"
+                logger.info(
+                    "  [%s] WP#%d  Journal#%d  user_id=%d  created_at=%s  reason=%s",
+                    "DELETE" if apply else "WOULD DELETE",
+                    wp_id,
+                    j["id"],
+                    j["user_id"],
+                    j["created_at"],
+                    reason,
+                )
+                all_to_delete.append(j)
+
+    total_journals = len(journals_raw)
+    total_to_delete = len(all_to_delete)
+    logger.info(
+        "Summary: %d journals scanned, %d WPs with duplicates, %d journals to delete",
+        total_journals,
+        len([wp for wp in by_wp.values() if any(j in all_to_delete for j in wp)]),
+        total_to_delete,
+    )
+
+    if total_to_delete == 0:
+        logger.info("Nothing to do — no duplicate journals found.")
+        return {
+            "wps_scanned": wp_ids_count,
+            "duplicate_groups": 0,
+            "to_delete": 0,
+            "deleted": 0,
+            "kept": total_journals,
+        }
+
+    # Step 3: Delete if --apply
+    deleted = 0
+    if apply:
+        delete_ids = [j["id"] for j in all_to_delete]
+        # Delete in batches of 100 to avoid overly large SQL IN clauses
+        batch_size = 100
+        for i in range(0, len(delete_ids), batch_size):
+            batch = delete_ids[i : i + batch_size]
+            del_script = _build_delete_script(batch)
+            try:
+                del_result = op_client.execute_query_to_json_file(del_script)
+                n = del_result.get("deleted", 0) if isinstance(del_result, dict) else 0
+                deleted += n
+                logger.info("Deleted batch %d–%d: %d rows", i + 1, i + len(batch), n)
+            except Exception as exc:
+                logger.error("Delete batch %d–%d failed: %s", i + 1, i + len(batch), exc)
+        logger.info("DONE: deleted %d duplicate journals", deleted)
+    else:
+        logger.info("DRY-RUN complete — pass --apply to delete %d journals", total_to_delete)
+
+    return {
+        "wps_scanned": wp_ids_count,
+        "duplicate_groups": duplicate_group_count,
+        "to_delete": total_to_delete,
+        "deleted": deleted,
+        "kept": total_journals - deleted,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("project_key", help="Jira project key (e.g. NRS)")
+    apply_grp = parser.add_mutually_exclusive_group()
+    apply_grp.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Actually delete duplicate journals. Default is dry-run.",
+    )
+    apply_grp.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        dest="dry_run",
+        help="Analyse and report only; do not delete (this is the default).",
+    )
+    args = parser.parse_args(argv)
+
+    project_key = args.project_key.upper()
+    if not _PROJECT_KEY_RE.match(project_key):
+        sys.stderr.write(f"Invalid project key: {args.project_key!r}\n")
+        return 2
+
+    ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    log_path = Path("var/logs") / f"cleanup_anonymous_comment_duplicates_{ts}.log"
+
+    logger = _setup_logging(log_path)
+    logger.info("Log: %s", log_path)
+
+    # Import here to avoid import-time side effects from config loading when
+    # running tests that patch this module.
+    from src.infrastructure.openproject.openproject_client import OpenProjectClient
+
+    op_client = OpenProjectClient()
+
+    try:
+        stats = run(
+            project_key,
+            apply=args.apply,
+            logger=logger,
+            op_client=op_client,
+        )
+    except Exception as exc:
+        logger.error("Fatal: %s", exc)
+        return 1
+
+    print(json.dumps(stats, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/application/components/work_package_content_migration.py
+++ b/src/application/components/work_package_content_migration.py
@@ -549,6 +549,9 @@ class WorkPackageContentMigration(BaseMigration):
             converted_body = self._convert_jira_links(body, jira_key=jira_issue.key)
 
             author_id = self._resolve_comment_author_id(comment, jira_issue.key)
+            # Capture Jira comment id for provenance marker — enables idempotency
+            # on re-runs (the Ruby helper skips activities whose marker already exists).
+            jira_comment_id = getattr(comment, "id", None)
 
             try:
                 # Create activity/journal in OpenProject with resolved author
@@ -557,6 +560,7 @@ class WorkPackageContentMigration(BaseMigration):
                     {
                         "comment": {"raw": converted_body},
                         "user_id": author_id,
+                        "jira_comment_id": jira_comment_id,
                     },
                 )
                 migrated += 1
@@ -697,10 +701,11 @@ class WorkPackageContentMigration(BaseMigration):
                         value = self._convert_jira_links(value, jira_key=jira_issue.key)
                     collected["custom_field_updates"][f"customField{op_cf_id}"] = value
 
-        # Collect comments — preserve author id so _bulk_process_collected_content
-        # can include user_id in every activity dict sent to the Rails script.
-        # Without user_id the Rails script falls back to the default_user
-        # (Anonymous, user_id=2) for every comment (regression confirmed on WP 5040).
+        # Collect comments — preserve author id and Jira comment id so
+        # _bulk_process_collected_content can include both in every activity
+        # dict sent to the Rails script.  user_id prevents fallback to
+        # Anonymous (regression confirmed on WP 5040); jira_comment_id enables
+        # provenance-based idempotency across re-runs.
         try:
             comments = self.jira_client.jira.comments(jira_issue.key)
             for comment in comments:
@@ -708,10 +713,12 @@ class WorkPackageContentMigration(BaseMigration):
                 if body:
                     converted_body = self._convert_jira_links(body, jira_key=jira_issue.key)
                     author_id = self._resolve_comment_author_id(comment, jira_issue.key)
+                    jira_comment_id = getattr(comment, "id", None)
                     collected["comments"].append(
                         {
                             "comment": converted_body,
                             "user_id": author_id,
+                            "jira_comment_id": jira_comment_id,
                         }
                     )
         except Exception:
@@ -789,9 +796,11 @@ class WorkPackageContentMigration(BaseMigration):
                 self.logger.debug("Bulk custom field update failed: %s", e)
 
         # Batch 3: Comments (using bulk_create_work_package_activities)
-        # Each entry in item["comments"] is a dict: {"comment": str, "user_id": int}.
-        # We forward user_id so the Rails script attributes journals to the real
-        # Jira author rather than falling back to the default_user (Anonymous).
+        # Each entry in item["comments"] is a dict with keys:
+        #   "comment": str, "user_id": int, "jira_comment_id": str|None.
+        # We forward all three: user_id preserves authorship; jira_comment_id
+        # enables provenance-based idempotency so re-runs skip already-migrated
+        # comments instead of duplicating them.
         all_comments = []
         for item in collected_items:
             for comment_entry in item["comments"]:
@@ -800,6 +809,7 @@ class WorkPackageContentMigration(BaseMigration):
                         "work_package_id": item["wp_id"],
                         "comment": comment_entry["comment"],
                         "user_id": comment_entry["user_id"],
+                        "jira_comment_id": comment_entry.get("jira_comment_id"),
                     },
                 )
 

--- a/src/infrastructure/openproject/openproject_work_package_content_service.py
+++ b/src/infrastructure/openproject/openproject_work_package_content_service.py
@@ -16,6 +16,15 @@ The service owns:
   ``bulk_create_work_package_activities`` (batched variant driven by
   a JSON heredoc with pre-fetched WP/User maps).
 
+Both activity helpers embed a provenance marker
+``<!-- j2o:jira-comment-id:{id} -->`` at the end of each comment body
+when ``jira_comment_id`` is supplied.  The marker is a CommonMark HTML
+comment, which is stripped from rendered output by every compliant
+Markdown renderer (including OpenProject's).  The bulk helper also
+pre-fetches already-migrated markers for the target WPs and skips any
+activity whose marker is already present, making comment migration
+idempotent across re-runs.
+
 ``OpenProjectClient`` exposes the service via ``self.wp_content`` and
 keeps thin delegators for the same method names so existing call sites
 work unchanged.
@@ -27,6 +36,26 @@ import json
 from typing import Any
 
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
+
+# Provenance marker template embedded at the end of every migrated comment.
+# CommonMark HTML comments (<!-- ... -->) are stripped from rendered output by
+# all compliant Markdown renderers including OpenProject's CommonMark renderer.
+# The marker is NOT visible to end users but IS present in the raw ``notes``
+# column, making it grep-able inside Rails for idempotency checks.
+_COMMENT_PROVENANCE_MARKER = "<!-- j2o:jira-comment-id:{jira_comment_id} -->"
+
+
+def _build_comment_with_marker(comment_text: str, jira_comment_id: str | int | None) -> str:
+    """Append the provenance marker to *comment_text* when *jira_comment_id* is set.
+
+    If *jira_comment_id* is ``None`` or empty the comment is returned unchanged
+    so callers that don't have a Jira comment id (e.g. legacy paths) still work.
+    """
+    if not jira_comment_id:
+        return comment_text
+    marker = _COMMENT_PROVENANCE_MARKER.format(jira_comment_id=jira_comment_id)
+    # Append on a new line so it doesn't run into the last word of the comment.
+    return f"{comment_text}\n{marker}"
 
 
 class OpenProjectWorkPackageContentService:
@@ -216,6 +245,11 @@ J2O_DATA
     ) -> dict[str, Any] | None:
         """Create a journal/activity (comment) on a work package.
 
+        When ``activity_data`` contains a ``jira_comment_id`` key the method
+        embeds a provenance marker ``<!-- j2o:jira-comment-id:{id} -->`` at
+        the end of the comment body and skips creation if that marker is
+        already present in an existing journal for the same WP (idempotency).
+
         Args:
             work_package_id: The work package ID
             activity_data: Dict with 'comment' key containing {'raw': 'comment text'}
@@ -223,6 +257,8 @@ J2O_DATA
                 to a specific OpenProject user.  When ``user_id`` is absent or
                 the user cannot be found the Rails default user is used as a
                 fallback (mirrors ``bulk_create_work_package_activities``).
+                Optional 'jira_comment_id' key (str/int) enables idempotency
+                via the provenance marker.
 
         Returns:
             Created journal data or None on failure
@@ -245,6 +281,9 @@ J2O_DATA
         if not comment_text:
             return None
 
+        jira_comment_id = activity_data.get("jira_comment_id")
+        comment_text = _build_comment_with_marker(comment_text, jira_comment_id)
+
         # Escape single quotes for Ruby
         escaped_comment = escape_ruby_single_quoted(comment_text)
 
@@ -253,6 +292,20 @@ J2O_DATA
         raw_user_id = activity_data.get("user_id")
         ruby_user_id = int(raw_user_id) if raw_user_id is not None else "nil"
 
+        # Build the idempotency check expression for Ruby.
+        # When jira_comment_id is present we grep existing journals for the
+        # provenance marker; if found we skip (idempotent re-run).
+        if jira_comment_id:
+            escaped_marker = escape_ruby_single_quoted(
+                _COMMENT_PROVENANCE_MARKER.format(jira_comment_id=jira_comment_id)
+            )
+            ruby_idempotency_check = (
+                f"existing_journal = wp.journals.where(\"notes LIKE '%{escaped_marker}%'\").first\n"
+                "          return {{ id: existing_journal.id, status: 'skipped' }} if existing_journal"
+            )
+        else:
+            ruby_idempotency_check = ""
+
         # OpenProject 15+ requires using journal_notes/journal_user + save!
         script = f"""
         begin
@@ -260,6 +313,7 @@ J2O_DATA
           default_user = User.current || User.find_by(admin: true)
           user_id = {ruby_user_id}
           user = user_id ? (User.find_by(id: user_id) || default_user) : default_user
+          {ruby_idempotency_check}
           wp.journal_notes = '{escaped_comment}'
           wp.journal_user = user
           wp.save!
@@ -278,36 +332,95 @@ J2O_DATA
             self._logger.debug("Failed to create activity for WP#%d: %s", work_package_id, e)
             return None
 
+    def fetch_migrated_comment_ids(
+        self,
+        wp_ids: list[int],
+    ) -> set[tuple[int, str]]:
+        """Return the set of (wp_id, jira_comment_id) pairs already in OP.
+
+        Queries Rails for all journals on the given work packages whose
+        ``notes`` column contains the j2o provenance marker pattern.
+        Returns a set of ``(openproject_wp_id, jira_comment_id)`` tuples so
+        the Python layer can skip already-migrated comments before sending
+        the bulk-create payload.
+
+        Args:
+            wp_ids: OpenProject work package IDs to query.
+
+        Returns:
+            Set of (wp_id, jira_comment_id) tuples already present in OP.
+
+        """
+        if not wp_ids:
+            return set()
+
+        wp_ids_ruby = json.dumps([int(w) for w in wp_ids])
+        # Extract the jira_comment_id from the marker using a Ruby regex.
+        # The marker format is: <!-- j2o:jira-comment-id:{id} -->
+        script = f"""
+          require 'json'
+          wp_ids = {wp_ids_ruby}
+          marker_re = /<!--\\s*j2o:jira-comment-id:(\\S+?)\\s*-->/
+          pairs = Journal
+            .where(journable_type: 'WorkPackage', journable_id: wp_ids)
+            .where("notes LIKE '%j2o:jira-comment-id:%'")
+            .pluck(:journable_id, :notes)
+            .filter_map do |wp_id, notes|
+              m = marker_re.match(notes.to_s)
+              m ? [wp_id, m[1]] : nil
+            end
+          pairs
+        """
+        try:
+            result = self._client.execute_query_to_json_file(script)
+            if isinstance(result, list):
+                return {(int(wp_id), str(jira_id)) for wp_id, jira_id in result}
+            return set()
+        except Exception as e:
+            self._logger.warning("Failed to fetch migrated comment IDs: %s", e)
+            return set()
+
     def bulk_create_work_package_activities(
         self,
         activities: list[dict[str, Any]],
     ) -> dict[str, Any]:
         """Create multiple journal/activity entries (comments) in a single Rails call.
 
+        Each entry may optionally carry a ``jira_comment_id`` key.  When
+        present the provenance marker ``<!-- j2o:jira-comment-id:{id} -->`` is
+        appended to the comment body and the Rails script skips any activity
+        whose marker is already found in an existing journal for that WP
+        (idempotency across re-runs).
+
         Args:
             activities: List of dicts with keys:
                 - work_package_id: int
                 - comment: str (the comment text)
                 - user_id: int (optional, defaults to admin user)
+                - jira_comment_id: str/int (optional, enables idempotency)
 
         Returns:
-            Dict with 'success': bool, 'created': int, 'failed': int
+            Dict with 'success': bool, 'created': int, 'skipped': int, 'failed': int
 
         """
         if not activities:
-            return {"success": True, "created": 0, "failed": 0}
+            return {"success": True, "created": 0, "skipped": 0, "failed": 0}
 
-        # Build JSON data for Ruby - escape properly
+        # Build JSON data for Ruby - embed provenance marker in comment body
         data = []
         for act in activities:
             comment = act.get("comment", "")
             if isinstance(comment, dict):
                 comment = comment.get("raw", "")
+            comment_str = str(comment)
+            jira_comment_id = act.get("jira_comment_id")
+            comment_with_marker = _build_comment_with_marker(comment_str, jira_comment_id)
             data.append(
                 {
                     "work_package_id": int(act["work_package_id"]),
-                    "comment": str(comment),
+                    "comment": comment_with_marker,
                     "user_id": act.get("user_id"),
+                    "jira_comment_id": str(jira_comment_id) if jira_comment_id is not None else None,
                 },
             )
 
@@ -323,7 +436,7 @@ J2O_DATA
 J2O_DATA
 )
 
-          results = {{ created: 0, failed: 0, errors: [] }}
+          results = {{ created: 0, skipped: 0, failed: 0, errors: [] }}
           default_user = User.current || User.find_by(admin: true)
 
           # Pre-fetch all referenced WPs and Users to avoid N+1 queries
@@ -332,12 +445,32 @@ J2O_DATA
           wps = WorkPackage.where(id: wp_ids).index_by(&:id)
           users = User.where(id: user_ids).index_by(&:id)
 
+          # Pre-fetch already-migrated provenance markers for idempotency.
+          # Collect all (wp_id, jira_comment_id) pairs that already exist in
+          # Journal#notes so we can skip them without a per-item DB query.
+          marker_re = /<!--\\s*j2o:jira-comment-id:(\\S+?)\\s*-->/
+          migrated_pairs = Journal
+            .where(journable_type: 'WorkPackage', journable_id: wp_ids)
+            .where("notes LIKE '%j2o:jira-comment-id:%'")
+            .pluck(:journable_id, :notes)
+            .each_with_object(Set.new) do |(wp_id, notes), set|
+              m = marker_re.match(notes.to_s)
+              set.add([wp_id, m[1]]) if m
+            end
+
           data.each do |item|
             begin
               wp = wps[item['work_package_id']]
               unless wp
                 results[:failed] += 1
                 results[:errors] << {{ wp_id: item['work_package_id'], error: 'WorkPackage not found' }}
+                next
+              end
+
+              # Idempotency: skip if this jira_comment_id already migrated for this WP
+              jira_cid = item['jira_comment_id']
+              if jira_cid && migrated_pairs.include?([item['work_package_id'], jira_cid])
+                results[:skipped] += 1
                 next
               end
 
@@ -368,7 +501,7 @@ J2O_DATA
             result = self._client.execute_query_to_json_file(script)
             if isinstance(result, dict):
                 return result
-            return {"success": False, "created": 0, "failed": len(activities), "error": str(result)}
+            return {"success": False, "created": 0, "skipped": 0, "failed": len(activities), "error": str(result)}
         except Exception as e:
             self._logger.warning("Bulk create WP activities failed: %s", e)
-            return {"success": False, "created": 0, "failed": len(activities), "error": str(e)}
+            return {"success": False, "created": 0, "skipped": 0, "failed": len(activities), "error": str(e)}

--- a/src/infrastructure/openproject/openproject_work_package_content_service.py
+++ b/src/infrastructure/openproject/openproject_work_package_content_service.py
@@ -45,15 +45,34 @@ from src.infrastructure.openproject.openproject_client import OpenProjectClient
 _COMMENT_PROVENANCE_MARKER = "<!-- j2o:jira-comment-id:{jira_comment_id} -->"
 
 
+def _normalize_comment_id(jcid: str | int | None) -> str | None:
+    """Normalize a Jira comment id to a non-empty stripped string or ``None``.
+
+    Treats ``None``, ``0`` (int), ``""``, and whitespace-only strings all as
+    absent (returns ``None``).  Any other value is converted to ``str`` and
+    stripped.  This prevents ``int(0)`` (falsy) or ``"  "`` (truthy but
+    meaningless) from producing inconsistent marker/idempotency behaviour.
+    """
+    if jcid is None:
+        return None
+    # Treat numeric zero as absent — Jira comment IDs are positive integers.
+    if isinstance(jcid, int) and jcid == 0:
+        return None
+    s = str(jcid).strip()
+    return s or None
+
+
 def _build_comment_with_marker(comment_text: str, jira_comment_id: str | int | None) -> str:
     """Append the provenance marker to *comment_text* when *jira_comment_id* is set.
 
-    If *jira_comment_id* is ``None`` or empty the comment is returned unchanged
-    so callers that don't have a Jira comment id (e.g. legacy paths) still work.
+    If *jira_comment_id* normalizes to ``None`` (i.e. it is ``None``, ``0``,
+    ``""``, or whitespace-only) the comment is returned unchanged so callers
+    that don't have a Jira comment id (e.g. legacy paths) still work.
     """
-    if not jira_comment_id:
+    normalized = _normalize_comment_id(jira_comment_id)
+    if normalized is None:
         return comment_text
-    marker = _COMMENT_PROVENANCE_MARKER.format(jira_comment_id=jira_comment_id)
+    marker = _COMMENT_PROVENANCE_MARKER.format(jira_comment_id=normalized)
     # Append on a new line so it doesn't run into the last word of the comment.
     return f"{comment_text}\n{marker}"
 
@@ -294,17 +313,25 @@ J2O_DATA
 
         # Build the idempotency check expression for Ruby.
         # When jira_comment_id is present we grep existing journals for the
-        # provenance marker; if found we skip (idempotent re-run).
-        if jira_comment_id:
+        # provenance marker; if found we evaluate to a 'skipped' hash without
+        # using bare `return` (which raises LocalJumpError at the top level of
+        # a Rails console eval).  Instead we use if/else so the script always
+        # evaluates to a hash in both branches.
+        normalized_jira_id = _normalize_comment_id(jira_comment_id)
+        if normalized_jira_id is not None:
             escaped_marker = escape_ruby_single_quoted(
-                _COMMENT_PROVENANCE_MARKER.format(jira_comment_id=jira_comment_id)
+                _COMMENT_PROVENANCE_MARKER.format(jira_comment_id=normalized_jira_id)
             )
-            ruby_idempotency_check = (
+            ruby_idempotency_open = (
                 f"existing_journal = wp.journals.where(\"notes LIKE '%{escaped_marker}%'\").first\n"
-                "          return {{ id: existing_journal.id, status: 'skipped' }} if existing_journal"
+                "          if existing_journal\n"
+                "            {{ id: existing_journal.id, status: 'skipped' }}\n"
+                "          else"
             )
+            ruby_idempotency_close = "          end"
         else:
-            ruby_idempotency_check = ""
+            ruby_idempotency_open = ""
+            ruby_idempotency_close = ""
 
         # OpenProject 15+ requires using journal_notes/journal_user + save!
         script = f"""
@@ -313,11 +340,12 @@ J2O_DATA
           default_user = User.current || User.find_by(admin: true)
           user_id = {ruby_user_id}
           user = user_id ? (User.find_by(id: user_id) || default_user) : default_user
-          {ruby_idempotency_check}
+          {ruby_idempotency_open}
           wp.journal_notes = '{escaped_comment}'
           wp.journal_user = user
           wp.save!
           {{ id: wp.journals.last.id, status: 'created' }}
+          {ruby_idempotency_close}
         rescue => e
           {{ error: e.message }}
         end
@@ -413,14 +441,14 @@ J2O_DATA
             if isinstance(comment, dict):
                 comment = comment.get("raw", "")
             comment_str = str(comment)
-            jira_comment_id = act.get("jira_comment_id")
+            jira_comment_id = _normalize_comment_id(act.get("jira_comment_id"))
             comment_with_marker = _build_comment_with_marker(comment_str, jira_comment_id)
             data.append(
                 {
                     "work_package_id": int(act["work_package_id"]),
                     "comment": comment_with_marker,
                     "user_id": act.get("user_id"),
-                    "jira_comment_id": str(jira_comment_id) if jira_comment_id is not None else None,
+                    "jira_comment_id": jira_comment_id,
                 },
             )
 

--- a/tests/unit/test_cleanup_anonymous_comment_duplicates.py
+++ b/tests/unit/test_cleanup_anonymous_comment_duplicates.py
@@ -356,3 +356,114 @@ class TestRunFunction:
         total_calls = mock_op.execute_query_to_json_file.call_count
         assert total_calls == 3, f"Expected 3 calls (1 fetch + 2 batches), got {total_calls}"
         assert stats["to_delete"] == 149
+
+
+# ---------------------------------------------------------------------------
+# Ruby `next` at top level — would cause LocalJumpError
+# ---------------------------------------------------------------------------
+
+
+class TestFetchScriptNoTopLevelNext:
+    """_build_fetch_script must not use bare `next` at the top level of the
+    Ruby string.  `next` outside a block raises LocalJumpError in Ruby when
+    the script is eval'd via the Rails console.
+    """
+
+    def test_no_bare_next_in_fetch_script(self) -> None:
+        import re
+
+        from scripts.cleanup_anonymous_comment_duplicates import _build_fetch_script
+
+        script = _build_fetch_script("NRS")
+        # Find all occurrences of `next` not inside a `do…end` or `{…}` block.
+        # The simplest reliable check: assert no bare `next` keyword appears at
+        # all; the if/else replacement uses no `next`.
+        bare_next = re.findall(r"\bnext\b", script)
+        assert bare_next == [], (
+            f"Ruby fetch script contains {len(bare_next)} bare `next` keyword(s) "
+            f"which would raise LocalJumpError when eval'd at top level:\n{script}"
+        )
+
+    def test_fetch_script_uses_if_else_for_missing_project(self) -> None:
+        """The missing-project branch must use if/else so the script always
+        evaluates to a hash.
+        """
+        from scripts.cleanup_anonymous_comment_duplicates import _build_fetch_script
+
+        script = _build_fetch_script("NRS")
+        # Must contain an if/else or unless/else structure for the error case
+        assert "if proj" in script or "unless proj" in script, (
+            "Expected if/else guard for missing project in fetch script"
+        )
+        assert "else" in script, "Expected `else` branch for the missing-project guard"
+
+    def test_fetch_script_evaluates_to_hash_in_both_branches(self) -> None:
+        """The script must end with a hash literal evaluating to the result in
+        both the project-found and project-not-found branches.
+        """
+        from scripts.cleanup_anonymous_comment_duplicates import _build_fetch_script
+
+        script = _build_fetch_script("NRS")
+        # Both branches must produce a hash; check that error hash is present
+        assert "error:" in script or "error: " in script, "Script must include an error hash for the not-found branch"
+        assert "project_id:" in script, "Script must include a project_id key for the found branch"
+
+
+# ---------------------------------------------------------------------------
+# Metric correctness: duplicate_groups vs journals_to_delete
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateGroupMetric:
+    """run() must report `duplicate_groups` as the number of *groups* that
+    had duplicates (one per unique note text per WP that needed cleanup),
+    not the total number of journals to delete.
+
+    Fixture: 3 WPs each contributing 1 duplicate group with varying journals
+    to delete → groups == 3, to_delete == 5.
+    """
+
+    def _make_logger(self) -> MagicMock:
+        logger = MagicMock()
+        logger.info = MagicMock()
+        logger.error = MagicMock()
+        logger.warning = MagicMock()
+        return logger
+
+    def test_duplicate_groups_counts_groups_not_journals(self) -> None:
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        ANON = 2
+        mock_op = MagicMock()
+
+        # WP 1: 1 real keeper + 1 anon to delete  → 1 group, 1 deletion
+        # WP 2: 1 real keeper + 2 anon to delete  → 1 group, 2 deletions
+        # WP 3: 1 real keeper + 2 anon to delete  → 1 group, 2 deletions
+        # Total: 3 groups, 5 deletions
+        journals = [
+            # WP 1
+            _journal(1, 1001, ANON, "Note A", "2026-05-07T00:00:00Z"),
+            _journal(2, 1001, 100, "Note A\n<!-- j2o:jira-comment-id:10 -->", "2026-05-09T00:00:00Z"),
+            # WP 2
+            _journal(3, 1002, ANON, "Note B", "2026-05-07T00:00:00Z"),
+            _journal(4, 1002, ANON, "Note B", "2026-05-08T00:00:00Z"),
+            _journal(5, 1002, 100, "Note B\n<!-- j2o:jira-comment-id:11 -->", "2026-05-09T00:00:00Z"),
+            # WP 3
+            _journal(6, 1003, ANON, "Note C", "2026-05-07T00:00:00Z"),
+            _journal(7, 1003, ANON, "Note C", "2026-05-08T00:00:00Z"),
+            _journal(8, 1003, 100, "Note C\n<!-- j2o:jira-comment-id:12 -->", "2026-05-09T00:00:00Z"),
+        ]
+
+        mock_op.execute_query_to_json_file.return_value = {
+            "project_id": 1,
+            "wp_ids_count": 3,
+            "journals": journals,
+        }
+
+        stats = run("NRS", apply=False, logger=self._make_logger(), op_client=mock_op)
+
+        assert stats["to_delete"] == 5, f"Expected 5 journals to delete, got {stats['to_delete']}"
+        assert stats["duplicate_groups"] == 3, (
+            f"Expected 3 duplicate groups (one per WP), got {stats['duplicate_groups']}. "
+            f"duplicate_groups must count groups, not individual journals to delete."
+        )

--- a/tests/unit/test_cleanup_anonymous_comment_duplicates.py
+++ b/tests/unit/test_cleanup_anonymous_comment_duplicates.py
@@ -1,0 +1,358 @@
+"""Unit tests for scripts/cleanup_anonymous_comment_duplicates.py.
+
+Tests the pure-Python deduplication logic without hitting Rails.
+Specifically:
+- _strip_marker: removes provenance marker from notes for equality matching.
+- _select_keeper: picks the right journal to preserve from a duplicate group.
+- _plan_deletions: produces correct (kept, deleted) split for a WP's journals.
+- run(): mocks the Rails query and asserts the right journal IDs are selected
+  for deletion.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the helpers from the script
+# ---------------------------------------------------------------------------
+
+
+def _import_helpers():
+    from scripts.cleanup_anonymous_comment_duplicates import (
+        ANONYMOUS_USER_ID,
+        _plan_deletions,
+        _select_keeper,
+        _strip_marker,
+    )
+
+    return ANONYMOUS_USER_ID, _strip_marker, _select_keeper, _plan_deletions
+
+
+# ---------------------------------------------------------------------------
+# Helper factories
+# ---------------------------------------------------------------------------
+
+
+def _journal(
+    journal_id: int,
+    wp_id: int,
+    user_id: int,
+    notes: str,
+    created_at: str = "2026-05-07T10:00:00Z",
+) -> dict[str, Any]:
+    return {
+        "id": journal_id,
+        "wp_id": wp_id,
+        "user_id": user_id,
+        "notes": notes,
+        "created_at": created_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _strip_marker
+# ---------------------------------------------------------------------------
+
+
+class TestStripMarker:
+    def test_strips_provenance_marker(self) -> None:
+        _, _strip_marker, _, __ = _import_helpers()
+        text = "Comment body\n<!-- j2o:jira-comment-id:597766 -->"
+        assert _strip_marker(text) == "Comment body"
+
+    def test_strips_marker_with_spaces(self) -> None:
+        _, _strip_marker, _, __ = _import_helpers()
+        text = "Comment body\n<!--  j2o:jira-comment-id:597766  -->"
+        assert _strip_marker(text) == "Comment body"
+
+    def test_noop_on_text_without_marker(self) -> None:
+        _, _strip_marker, _, __ = _import_helpers()
+        text = "Plain comment with no marker"
+        assert _strip_marker(text) == text
+
+    def test_strips_leading_newline_before_marker(self) -> None:
+        _, _strip_marker, _, __ = _import_helpers()
+        text = "Body\n<!-- j2o:jira-comment-id:42 -->"
+        result = _strip_marker(text)
+        assert "j2o:jira-comment-id" not in result
+        assert "Body" in result
+
+
+# ---------------------------------------------------------------------------
+# _select_keeper
+# ---------------------------------------------------------------------------
+
+
+class TestSelectKeeper:
+    def test_real_author_preferred_over_anonymous(self) -> None:
+        ANON, _, _select_keeper, __ = _import_helpers()
+        anon = _journal(1, 5040, ANON, "Same note", "2026-05-07T09:00:00Z")
+        real = _journal(2, 5040, 100, "Same note\n<!-- j2o:jira-comment-id:1 -->", "2026-05-09T10:00:00Z")
+        result = _select_keeper([anon, real])
+        assert result["id"] == real["id"]
+
+    def test_marker_bearing_journal_preferred_among_real_authors(self) -> None:
+        """When both are real-author journals, prefer the one with a provenance marker."""
+        _, _, _select_keeper, __ = _import_helpers()
+        no_marker = _journal(1, 5040, 100, "Same note", "2026-05-07T09:00:00Z")
+        with_marker = _journal(2, 5040, 100, "Same note\n<!-- j2o:jira-comment-id:1 -->", "2026-05-07T09:00:00Z")
+        result = _select_keeper([no_marker, with_marker])
+        assert result["id"] == with_marker["id"]
+
+    def test_newest_anonymous_kept_when_all_anonymous(self) -> None:
+        ANON, _, _select_keeper, __ = _import_helpers()
+        older = _journal(1, 5040, ANON, "Note", "2026-05-07T09:00:00Z")
+        newer = _journal(2, 5040, ANON, "Note", "2026-05-09T10:00:00Z")
+        result = _select_keeper([older, newer])
+        assert result["id"] == newer["id"]
+
+    def test_single_journal_returned_unchanged(self) -> None:
+        _, _, _select_keeper, __ = _import_helpers()
+        j = _journal(1, 5040, 100, "Only journal")
+        assert _select_keeper([j])["id"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _plan_deletions
+# ---------------------------------------------------------------------------
+
+
+class TestPlanDeletions:
+    def test_no_duplicates_nothing_deleted(self) -> None:
+        _, _, _, _plan_deletions = _import_helpers()
+        journals = [
+            _journal(1, 5040, 100, "First comment"),
+            _journal(2, 5040, 200, "Second comment"),
+        ]
+        kept, to_delete = _plan_deletions(journals)
+        assert len(kept) == 2
+        assert len(to_delete) == 0
+
+    def test_anonymous_duplicate_of_real_author_deleted(self) -> None:
+        """An anonymous copy of a real-author comment must be deleted."""
+        ANON, _, _, _plan_deletions = _import_helpers()
+        real = _journal(10, 5040, 100, "Comment body\n<!-- j2o:jira-comment-id:1 -->", "2026-05-09T10:00:00Z")
+        anon = _journal(5, 5040, ANON, "Comment body", "2026-05-07T09:00:00Z")
+        kept, to_delete = _plan_deletions([real, anon])
+
+        assert len(kept) == 1
+        assert len(to_delete) == 1
+        assert kept[0]["id"] == real["id"]
+        assert to_delete[0]["id"] == anon["id"]
+
+    def test_three_duplicates_two_deleted(self) -> None:
+        ANON, _, _, _plan_deletions = _import_helpers()
+        j1 = _journal(1, 5040, ANON, "Note", "2026-05-06T00:00:00Z")
+        j2 = _journal(2, 5040, ANON, "Note", "2026-05-07T00:00:00Z")
+        j3 = _journal(3, 5040, 100, "Note\n<!-- j2o:jira-comment-id:9 -->", "2026-05-09T00:00:00Z")
+
+        kept, to_delete = _plan_deletions([j1, j2, j3])
+        assert len(kept) == 1
+        assert len(to_delete) == 2
+        assert kept[0]["id"] == j3["id"]
+        delete_ids = {j["id"] for j in to_delete}
+        assert delete_ids == {1, 2}
+
+    def test_different_notes_all_kept(self) -> None:
+        ANON, _, _, _plan_deletions = _import_helpers()
+        journals = [
+            _journal(1, 5040, ANON, "First comment"),
+            _journal(2, 5040, ANON, "Second comment"),
+            _journal(3, 5040, 100, "Third comment"),
+        ]
+        kept, to_delete = _plan_deletions(journals)
+        assert len(kept) == 3
+        assert len(to_delete) == 0
+
+    def test_marker_stripped_for_equality(self) -> None:
+        """A comment body WITH and WITHOUT marker should be treated as duplicates."""
+        ANON, _, _, _plan_deletions = _import_helpers()
+        plain = _journal(1, 5040, ANON, "Comment text", "2026-05-07T00:00:00Z")
+        marked = _journal(2, 5040, 100, "Comment text\n<!-- j2o:jira-comment-id:5 -->", "2026-05-09T00:00:00Z")
+        kept, to_delete = _plan_deletions([plain, marked])
+        assert len(kept) == 1
+        assert kept[0]["id"] == marked["id"]
+        assert to_delete[0]["id"] == plain["id"]
+
+    def test_wp_5040_live_scenario(self) -> None:
+        """Reproduce the WP 5040 scenario: 8 anonymous + 4 real → keep 4 real, delete 8 anon."""
+        ANON, _, _, _plan_deletions = _import_helpers()
+        # 4 unique comments × 3 duplicates each (2 anon + 1 real)
+        journals = []
+        jid = 1
+        # 8 anonymous copies from broken May-7 runs (two copies of each of 4 comments)
+        anon_ids = []
+        for comment_idx in range(4):
+            for run_n in range(2):
+                j = _journal(jid, 5040, ANON, f"Comment {comment_idx}", f"2026-05-0{7 + run_n}T10:00:00Z")
+                journals.append(j)
+                anon_ids.append(jid)
+                jid += 1
+        # 4 real journals from correct May-9 run
+        real_ids = []
+        for comment_idx in range(4):
+            author_id = 300 + comment_idx
+            j = _journal(
+                jid,
+                5040,
+                author_id,
+                f"Comment {comment_idx}\n<!-- j2o:jira-comment-id:{1000 + comment_idx} -->",
+                "2026-05-09T10:00:00Z",
+            )
+            journals.append(j)
+            real_ids.append(jid)
+            jid += 1
+
+        kept, to_delete = _plan_deletions(journals)
+        assert len(kept) == 4
+        assert len(to_delete) == 8
+        assert {j["id"] for j in kept} == set(real_ids)
+        assert {j["id"] for j in to_delete} == set(anon_ids)
+
+
+# ---------------------------------------------------------------------------
+# run() — integration with mocked Rails
+# ---------------------------------------------------------------------------
+
+
+class TestRunFunction:
+    def _make_logger(self) -> MagicMock:
+        logger = MagicMock()
+        logger.info = MagicMock()
+        logger.error = MagicMock()
+        logger.warning = MagicMock()
+        return logger
+
+    def test_dry_run_does_not_call_delete(self) -> None:
+        """In dry-run mode, execute_query_to_json_file is called exactly once (fetch only)."""
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        ANON = 2
+        mock_op = MagicMock()
+        mock_op.execute_query_to_json_file.return_value = {
+            "project_id": 1,
+            "wp_ids_count": 1,
+            "journals": [
+                _journal(1, 5040, ANON, "Body", "2026-05-07T00:00:00Z"),
+                _journal(2, 5040, 100, "Body\n<!-- j2o:jira-comment-id:9 -->", "2026-05-09T00:00:00Z"),
+            ],
+        }
+
+        stats = run("NRS", apply=False, logger=self._make_logger(), op_client=mock_op)
+
+        # Only the fetch call — no delete
+        mock_op.execute_query_to_json_file.assert_called_once()
+        assert stats["to_delete"] == 1
+        assert stats["deleted"] == 0
+
+    def test_apply_calls_delete_with_correct_ids(self) -> None:
+        """In apply mode, the delete script must receive exactly the IDs selected for deletion."""
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        ANON = 2
+        mock_op = MagicMock()
+
+        # First call: fetch
+        # Second call: delete
+        fetch_result = {
+            "project_id": 1,
+            "wp_ids_count": 1,
+            "journals": [
+                _journal(1, 5040, ANON, "Body", "2026-05-07T00:00:00Z"),
+                _journal(2, 5040, 100, "Body\n<!-- j2o:jira-comment-id:9 -->", "2026-05-09T00:00:00Z"),
+            ],
+        }
+        delete_result = {"deleted": 1}
+        mock_op.execute_query_to_json_file.side_effect = [fetch_result, delete_result]
+
+        stats = run("NRS", apply=True, logger=self._make_logger(), op_client=mock_op)
+
+        # Fetch + delete calls
+        assert mock_op.execute_query_to_json_file.call_count == 2
+        delete_call_script: str = mock_op.execute_query_to_json_file.call_args_list[1][0][0]
+        # Journal id=1 (anonymous duplicate) must be in the delete payload
+        assert "1" in delete_call_script
+        # Journal id=2 (real author, keeper) must NOT be in the delete payload
+        # (it should only appear if id=2 is explicitly in the ids list — use full parse)
+        import json as _json
+
+        start = delete_call_script.find("[")
+        end = delete_call_script.find("]", start) + 1
+        ids_to_delete = _json.loads(delete_call_script[start:end])
+        assert 1 in ids_to_delete
+        assert 2 not in ids_to_delete
+
+        assert stats["deleted"] == 1
+        assert stats["to_delete"] == 1
+
+    def test_no_duplicates_returns_zero_counts(self) -> None:
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        mock_op = MagicMock()
+        mock_op.execute_query_to_json_file.return_value = {
+            "project_id": 1,
+            "wp_ids_count": 2,
+            "journals": [
+                _journal(1, 5040, 100, "First comment"),
+                _journal(2, 5041, 100, "Second comment"),
+            ],
+        }
+
+        stats = run("NRS", apply=False, logger=self._make_logger(), op_client=mock_op)
+
+        assert stats["to_delete"] == 0
+        assert stats["deleted"] == 0
+        assert stats["duplicate_groups"] == 0
+        # Only the fetch call — no delete even if apply=False
+        mock_op.execute_query_to_json_file.assert_called_once()
+
+    def test_rails_error_propagated(self) -> None:
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        mock_op = MagicMock()
+        mock_op.execute_query_to_json_file.return_value = {
+            "error": "project not found",
+            "identifier": "nrs",
+        }
+
+        with pytest.raises(RuntimeError, match="project not found"):
+            run("NRS", apply=False, logger=self._make_logger(), op_client=mock_op)
+
+    def test_apply_batches_large_deletion_lists(self) -> None:
+        """Large delete lists must be batched (>100 IDs)."""
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        ANON = 2
+        mock_op = MagicMock()
+
+        # 150 anonymous journals for the same comment — 1 real keeper + 149 anon to delete
+        journals = []
+        for i in range(149):
+            journals.append(_journal(i + 1, 5040, ANON, "Same comment", f"2026-05-0{(i % 9) + 1}T00:00:00Z"))
+        real = _journal(200, 5040, 100, "Same comment\n<!-- j2o:jira-comment-id:1 -->", "2026-05-10T00:00:00Z")
+        journals.append(real)
+
+        fetch_result = {
+            "project_id": 1,
+            "wp_ids_count": 1,
+            "journals": journals,
+        }
+
+        # Mock all subsequent calls (delete batches) to return success
+        def side_effect(script: str):
+            if "delete_all" in script:
+                return {"deleted": 100}
+            return fetch_result
+
+        mock_op.execute_query_to_json_file.side_effect = side_effect
+
+        stats = run("NRS", apply=True, logger=self._make_logger(), op_client=mock_op)
+
+        # 149 to delete → 2 batches (100 + 49)
+        total_calls = mock_op.execute_query_to_json_file.call_count
+        assert total_calls == 3, f"Expected 3 calls (1 fetch + 2 batches), got {total_calls}"
+        assert stats["to_delete"] == 149

--- a/tests/unit/test_work_package_content_comment_idempotency.py
+++ b/tests/unit/test_work_package_content_comment_idempotency.py
@@ -617,3 +617,229 @@ class TestFetchMigratedCommentIds:
         assert "j2o:jira-comment-id:" in source
         assert "notes" in source
         assert "pluck" in source
+
+
+# ---------------------------------------------------------------------------
+# 9. Ruby `return` at top level — would cause LocalJumpError
+# ---------------------------------------------------------------------------
+
+
+class TestSingleActivityNoTopLevelReturn:
+    """create_work_package_activity must not use bare `return` at the top level
+    of the Ruby script string.  A bare `return` outside a method/block raises
+    LocalJumpError in Ruby when the script is eval'd via the Rails console.
+    """
+
+    def _capture_script(self) -> str:
+        from unittest.mock import MagicMock
+
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        captured: list[str] = []
+        mock_client.execute_query_to_json_file.side_effect = lambda s: (
+            captured.append(s) or {"id": 1, "status": "created"}
+        )
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        svc.create_work_package_activity(
+            work_package_id=1,
+            activity_data={"comment": "test", "user_id": 1, "jira_comment_id": "42"},
+        )
+        assert captured
+        return captured[0]
+
+    def test_no_bare_return_at_top_level(self) -> None:
+        """The Ruby script must not contain a bare `return` statement outside
+        a method or block — that would raise LocalJumpError.
+
+        The idempotency skip must use an `if/else` structure instead.
+        """
+        script = self._capture_script()
+        # A bare `return` followed by whitespace/brace is the problem pattern.
+        # `return` inside a rescue block or as part of a hash key is fine
+        # but the provenance-marker early-return pattern is NOT inside a method.
+        import re
+
+        bare_returns = re.findall(r"\breturn\b", script)
+        assert bare_returns == [], (
+            f"Ruby script contains {len(bare_returns)} bare `return` keyword(s) "
+            f"which would raise LocalJumpError when eval'd at top level:\n{script}"
+        )
+
+    def test_idempotency_uses_if_else_structure(self) -> None:
+        """When jira_comment_id is given the script must use if/else for
+        the skip branch, not a trailing `return ... if existing_journal`.
+        """
+        script = self._capture_script()
+        # Must still contain the idempotency check
+        assert "existing_journal" in script, "Idempotency check is missing entirely"
+        # Must contain an else or end for the conditional structure
+        assert "else" in script or script.count("end") >= 2, (
+            "Expected if/else structure for idempotency but found neither 'else' nor sufficient 'end' keywords"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 10. _normalize_comment_id — edge-value behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeCommentId:
+    """_normalize_comment_id must treat None, 0, '', '  ' as absent and
+    return None; non-empty strings and non-zero ints must be returned as
+    stripped strings.
+    """
+
+    def _normalize(self, value):
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            _normalize_comment_id,
+        )
+
+        return _normalize_comment_id(value)
+
+    def test_none_returns_none(self) -> None:
+        assert self._normalize(None) is None
+
+    def test_zero_int_returns_none(self) -> None:
+        assert self._normalize(0) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert self._normalize("") is None
+
+    def test_whitespace_only_string_returns_none(self) -> None:
+        assert self._normalize("  ") is None
+
+    def test_string_id_returned_as_stripped_string(self) -> None:
+        assert self._normalize("123") == "123"
+
+    def test_int_id_returned_as_string(self) -> None:
+        assert self._normalize(123) == "123"
+
+    def test_padded_string_stripped(self) -> None:
+        assert self._normalize("  42  ") == "42"
+
+
+class TestBuildCommentWithMarkerNormalization:
+    """_build_comment_with_marker must behave consistently for all edge values
+    of jira_comment_id after normalization is applied.
+    """
+
+    def _build(self, cid):
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            _build_comment_with_marker,
+        )
+
+        return _build_comment_with_marker("text", cid)
+
+    def test_none_no_marker(self) -> None:
+        assert self._build(None) == "text"
+
+    def test_zero_int_no_marker(self) -> None:
+        # int(0) is falsy — must NOT add marker
+        assert self._build(0) == "text"
+
+    def test_empty_string_no_marker(self) -> None:
+        assert self._build("") == "text"
+
+    def test_whitespace_string_no_marker(self) -> None:
+        assert self._build("  ") == "text"
+
+    def test_valid_string_id_adds_marker(self) -> None:
+        result = self._build("123")
+        assert "j2o:jira-comment-id:123" in result
+
+    def test_valid_int_id_adds_marker(self) -> None:
+        result = self._build(123)
+        assert "j2o:jira-comment-id:123" in result
+
+
+class TestCreateWorkPackageActivityNormalization:
+    """create_work_package_activity must apply consistent normalization —
+    int(0) and whitespace-only strings must not inject an idempotency check.
+    """
+
+    def _capture_script(self, jira_comment_id) -> str:
+        from unittest.mock import MagicMock
+
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        captured: list[str] = []
+        mock_client.execute_query_to_json_file.side_effect = lambda s: (
+            captured.append(s) or {"id": 1, "status": "created"}
+        )
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        svc.create_work_package_activity(
+            work_package_id=1,
+            activity_data={"comment": "hi", "user_id": 1, "jira_comment_id": jira_comment_id},
+        )
+        return captured[0] if captured else ""
+
+    def test_zero_id_no_idempotency_guard(self) -> None:
+        script = self._capture_script(0)
+        assert "existing_journal" not in script, "int(0) jira_comment_id must NOT inject idempotency guard"
+
+    def test_whitespace_id_no_idempotency_guard(self) -> None:
+        script = self._capture_script("  ")
+        assert "existing_journal" not in script, "whitespace jira_comment_id must NOT inject idempotency guard"
+
+    def test_valid_int_id_adds_idempotency_guard(self) -> None:
+        script = self._capture_script(42)
+        assert "existing_journal" in script, "valid int jira_comment_id must inject idempotency guard"
+
+
+class TestBulkPayloadNormalization:
+    """bulk_create_work_package_activities must normalize jira_comment_id in the
+    JSON payload: empty strings must become null, not '""'.
+    """
+
+    def _payload(self, jira_comment_id) -> dict:
+        import json
+        from unittest.mock import MagicMock
+
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        captured: list[str] = []
+        mock_client.execute_query_to_json_file.side_effect = lambda s: (
+            captured.append(s) or {"created": 1, "skipped": 0, "failed": 0, "success": True}
+        )
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        svc.bulk_create_work_package_activities(
+            [{"work_package_id": 1, "comment": "hi", "user_id": 1, "jira_comment_id": jira_comment_id}]
+        )
+        script = captured[0]
+        start = script.find("\n", script.find("J2O_DATA")) + 1
+        end = script.find("J2O_DATA", start)
+        return json.loads(script[start:end].strip())[0]
+
+    def test_empty_string_becomes_null_in_payload(self) -> None:
+        item = self._payload("")
+        assert item["jira_comment_id"] is None, (
+            "empty string jira_comment_id must be serialised as null in the Ruby payload"
+        )
+
+    def test_whitespace_string_becomes_null_in_payload(self) -> None:
+        item = self._payload("  ")
+        assert item["jira_comment_id"] is None
+
+    def test_zero_int_becomes_null_in_payload(self) -> None:
+        item = self._payload(0)
+        assert item["jira_comment_id"] is None
+
+    def test_valid_string_preserved_in_payload(self) -> None:
+        item = self._payload("597766")
+        assert item["jira_comment_id"] == "597766"
+
+    def test_valid_int_becomes_string_in_payload(self) -> None:
+        item = self._payload(597766)
+        assert item["jira_comment_id"] == "597766"

--- a/tests/unit/test_work_package_content_comment_idempotency.py
+++ b/tests/unit/test_work_package_content_comment_idempotency.py
@@ -1,0 +1,619 @@
+"""Tests for idempotent comment creation via provenance marker.
+
+Root cause: every re-run of work_packages_content added a fresh set of
+comments to OpenProject work packages.  WP 5040 accumulated 12 journals
+(8 Anonymous from broken May-7 runs + 4 correct ones) because
+bulk_create_work_package_activities blindly INSERT-ed without checking
+for prior existence.
+
+Fix: embed ``<!-- j2o:jira-comment-id:{id} -->`` at the end of each
+migrated comment body.  The Rails script pre-fetches existing markers and
+skips any activity whose marker is already present.
+
+Coverage:
+1. _build_comment_with_marker — marker appended when id present, no-op otherwise.
+2. bulk_create_work_package_activities — jira_comment_id forwarded in JSON payload.
+3. bulk_create_work_package_activities — Ruby script contains Set-based marker
+   dedup logic (static inspection).
+4. _collect_content_for_issue — jira_comment_id captured from Jira comment.
+5. _bulk_process_collected_content — jira_comment_id forwarded to bulk helper.
+6. Single-issue _populate_comments — jira_comment_id forwarded to single helper.
+7. create_work_package_activity — jira_comment_id forwarded to Ruby script.
+8. fetch_migrated_comment_ids — returns set of (wp_id, jira_comment_id) pairs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+
+def _build_mig(tmp_path: Path):
+    from src.application.components.work_package_content_migration import (
+        WorkPackageContentMigration,
+    )
+
+    jira = MagicMock()
+    op = MagicMock()
+    mig = WorkPackageContentMigration(jira_client=jira, op_client=op)
+    mig.data_dir = tmp_path
+    mig.work_package_mapping_file = tmp_path / mig.WORK_PACKAGE_MAPPING_FILE
+    mig.attachment_mapping_file = tmp_path / mig.ATTACHMENT_MAPPING_FILE
+    return mig
+
+
+@pytest.fixture
+def _mock_mappings(monkeypatch: pytest.MonkeyPatch):
+    import src.config as cfg
+
+    class DummyMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "project": {"PROJ": {"openproject_id": 11}},
+                "user": {"alice": {"openproject_id": 201}},
+                "custom_field": {},
+            }
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, value):
+            self._m[name] = value
+
+    monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+
+
+def _make_comment(author_name: str, body: str, comment_id: str = "cid-1"):
+    c = MagicMock()
+    c.body = body
+    c.id = comment_id
+    c.author = SimpleNamespace(
+        name=author_name,
+        displayName=author_name.capitalize(),
+        emailAddress=f"{author_name}@example.com",
+        accountId=None,
+        key=None,
+    )
+    return c
+
+
+# ---------------------------------------------------------------------------
+# 1. _build_comment_with_marker unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommentWithMarker:
+    def test_marker_appended_when_id_present(self) -> None:
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            _build_comment_with_marker,
+        )
+
+        result = _build_comment_with_marker("Hello world", "597766")
+        assert "<!-- j2o:jira-comment-id:597766 -->" in result
+        assert result.startswith("Hello world")
+
+    def test_no_marker_when_id_is_none(self) -> None:
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            _build_comment_with_marker,
+        )
+
+        result = _build_comment_with_marker("Hello world", None)
+        assert result == "Hello world"
+        assert "j2o:" not in result
+
+    def test_no_marker_when_id_is_empty_string(self) -> None:
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            _build_comment_with_marker,
+        )
+
+        result = _build_comment_with_marker("Hello world", "")
+        assert result == "Hello world"
+
+    def test_marker_on_new_line(self) -> None:
+        """Marker must be on its own line, not inline with last word."""
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            _build_comment_with_marker,
+        )
+
+        result = _build_comment_with_marker("Line one\nLine two", "42")
+        lines = result.split("\n")
+        assert any("<!-- j2o:jira-comment-id:42 -->" in line for line in lines)
+        # Marker must not be on the same line as text content
+        assert lines[-1].strip() == "<!-- j2o:jira-comment-id:42 -->"
+
+
+# ---------------------------------------------------------------------------
+# 2. bulk_create_work_package_activities — jira_comment_id in JSON payload
+# ---------------------------------------------------------------------------
+
+
+class TestBulkCreateActivitiesPayload:
+    def test_jira_comment_id_forwarded_in_json_payload(self) -> None:
+        """The JSON data sent to Rails must include jira_comment_id for each activity."""
+        from unittest.mock import MagicMock
+
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        captured_scripts: list[str] = []
+
+        def capture_script(script: str):
+            captured_scripts.append(script)
+            return {"created": 1, "skipped": 0, "failed": 0, "success": True}
+
+        mock_client.execute_query_to_json_file.side_effect = capture_script
+
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        svc.bulk_create_work_package_activities(
+            [
+                {
+                    "work_package_id": 5040,
+                    "comment": "First comment",
+                    "user_id": 100,
+                    "jira_comment_id": "597766",
+                }
+            ]
+        )
+
+        assert captured_scripts, "No Rails script was generated"
+        script = captured_scripts[0]
+
+        # The JSON payload embedded in the script must contain the jira_comment_id
+        # Extract JSON from script (between J2O_DATA markers)
+        start = script.find("\n", script.find("J2O_DATA")) + 1
+        end = script.find("J2O_DATA", start)
+        payload_json = script[start:end].strip()
+        payload = json.loads(payload_json)
+
+        assert len(payload) == 1
+        assert payload[0]["jira_comment_id"] == "597766"
+
+    def test_null_jira_comment_id_when_not_provided(self) -> None:
+        """When no jira_comment_id is supplied, null is sent (legacy path still works)."""
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        captured_scripts: list[str] = []
+
+        def capture_script(script: str):
+            captured_scripts.append(script)
+            return {"created": 1, "skipped": 0, "failed": 0, "success": True}
+
+        mock_client.execute_query_to_json_file.side_effect = capture_script
+
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        svc.bulk_create_work_package_activities([{"work_package_id": 1, "comment": "Legacy comment", "user_id": 5}])
+
+        script = captured_scripts[0]
+        start = script.find("\n", script.find("J2O_DATA")) + 1
+        end = script.find("J2O_DATA", start)
+        payload = json.loads(script[start:end].strip())
+        assert payload[0]["jira_comment_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Ruby script contains Set-based idempotency dedup logic
+# ---------------------------------------------------------------------------
+
+
+class TestBulkCreateRubyScriptIdempotency:
+    def test_ruby_script_fetches_migrated_pairs(self) -> None:
+        """The Ruby script must query existing Journal notes for the provenance marker."""
+        import inspect
+
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        source = inspect.getsource(OpenProjectWorkPackageContentService.bulk_create_work_package_activities)
+        # Must contain the pre-fetch query for existing markers
+        assert "j2o:jira-comment-id" in source, "Ruby script does not search for existing provenance markers"
+        # Must contain the idempotency skip check
+        assert "migrated_pairs" in source, "Ruby script missing migrated_pairs set for idempotency check"
+        assert "skipped" in source, "Ruby script must increment skipped counter for already-migrated comments"
+
+    def test_ruby_script_uses_set_for_dedup(self) -> None:
+        """The Ruby script must use a Set (not Array#include?) for O(1) lookups."""
+        import inspect
+
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        source = inspect.getsource(OpenProjectWorkPackageContentService.bulk_create_work_package_activities)
+        # Set.new must be used for the migrated_pairs collection
+        assert "Set.new" in source, "Ruby script must use Set.new for O(1) idempotency lookups"
+
+    def test_result_dict_includes_skipped_key(self) -> None:
+        """bulk_create_work_package_activities must return a 'skipped' count."""
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        mock_client.execute_query_to_json_file.return_value = {
+            "created": 1,
+            "skipped": 1,
+            "failed": 0,
+            "success": True,
+        }
+
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        result = svc.bulk_create_work_package_activities(
+            [
+                {"work_package_id": 1, "comment": "a", "user_id": 1, "jira_comment_id": "111"},
+                {"work_package_id": 1, "comment": "a", "user_id": 1, "jira_comment_id": "111"},
+            ]
+        )
+        assert "skipped" in result, f"Expected 'skipped' key in result: {result}"
+        assert result["skipped"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. _collect_content_for_issue — jira_comment_id captured
+# ---------------------------------------------------------------------------
+
+
+class TestCollectContentCapturesCommentId:
+    def test_jira_comment_id_present_in_collected_comments(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        """Each collected comment must carry jira_comment_id from the Jira comment."""
+        mig = _build_mig(tmp_path)
+
+        issue = MagicMock()
+        issue.key = "PROJ-1"
+        issue.fields.description = None
+        issue.raw = {"fields": {}}
+        mig.jira_client.jira.comments.return_value = [
+            _make_comment("alice", "First comment", comment_id="597766"),
+            _make_comment("alice", "Second comment", comment_id="597767"),
+        ]
+        mig.jira_client.get_issue_watchers.return_value = []
+
+        collected = mig._collect_content_for_issue(issue, wp_id=5040)
+        comments = collected["comments"]
+
+        assert len(comments) == 2
+        assert comments[0]["jira_comment_id"] == "597766"
+        assert comments[1]["jira_comment_id"] == "597767"
+
+    def test_none_comment_id_when_jira_comment_has_no_id(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        """When comment has no .id attribute, jira_comment_id should be None."""
+        mig = _build_mig(tmp_path)
+
+        issue = MagicMock()
+        issue.key = "PROJ-1"
+        issue.fields.description = None
+        issue.raw = {"fields": {}}
+
+        # Comment without an id attribute
+        comment = MagicMock(spec=["body", "author"])
+        comment.body = "No id comment"
+        comment.author = SimpleNamespace(
+            name="alice",
+            displayName="Alice",
+            emailAddress="alice@example.com",
+            accountId=None,
+            key=None,
+        )
+        mig.jira_client.jira.comments.return_value = [comment]
+        mig.jira_client.get_issue_watchers.return_value = []
+
+        collected = mig._collect_content_for_issue(issue, wp_id=1)
+        assert collected["comments"][0]["jira_comment_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# 5. _bulk_process_collected_content — jira_comment_id forwarded to bulk helper
+# ---------------------------------------------------------------------------
+
+
+class TestBulkProcessForwardsCommentId:
+    def test_jira_comment_id_in_activity_payload_sent_to_op(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        """_bulk_process_collected_content must forward jira_comment_id to the op_client call."""
+        mig = _build_mig(tmp_path)
+
+        collected_items = [
+            {
+                "wp_id": 5040,
+                "jira_key": "PROJ-1",
+                "description_update": None,
+                "custom_field_updates": {},
+                "comments": [
+                    {"comment": "First", "user_id": 201, "jira_comment_id": "597766"},
+                    {"comment": "Second", "user_id": 201, "jira_comment_id": "597767"},
+                ],
+                "watchers": [],
+            }
+        ]
+
+        mig.op_client.bulk_create_work_package_activities.return_value = {
+            "created": 2,
+            "skipped": 0,
+            "failed": 0,
+        }
+
+        mig._bulk_process_collected_content(collected_items)
+
+        call_args = mig.op_client.bulk_create_work_package_activities.call_args
+        assert call_args is not None
+        activities = call_args[0][0]
+        assert len(activities) == 2
+
+        # Both entries must carry jira_comment_id
+        assert activities[0]["jira_comment_id"] == "597766"
+        assert activities[1]["jira_comment_id"] == "597767"
+
+    def test_none_jira_comment_id_forwarded_when_absent(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        """When jira_comment_id is absent from collected entry, None is forwarded."""
+        mig = _build_mig(tmp_path)
+
+        collected_items = [
+            {
+                "wp_id": 1,
+                "jira_key": "PROJ-1",
+                "description_update": None,
+                "custom_field_updates": {},
+                "comments": [
+                    # Legacy entry without jira_comment_id key
+                    {"comment": "Legacy comment", "user_id": 201},
+                ],
+                "watchers": [],
+            }
+        ]
+
+        mig.op_client.bulk_create_work_package_activities.return_value = {
+            "created": 1,
+            "skipped": 0,
+            "failed": 0,
+        }
+
+        mig._bulk_process_collected_content(collected_items)
+
+        activities = mig.op_client.bulk_create_work_package_activities.call_args[0][0]
+        assert activities[0]["jira_comment_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Single-issue _populate_comments — jira_comment_id forwarded
+# ---------------------------------------------------------------------------
+
+
+class TestPopulateCommentsForwardsCommentId:
+    def test_jira_comment_id_in_single_activity_payload(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        """_populate_comments must include jira_comment_id in every create_work_package_activity call."""
+        mig = _build_mig(tmp_path)
+
+        issue = MagicMock()
+        issue.key = "PROJ-1"
+        mig.jira_client.jira.comments.return_value = [
+            _make_comment("alice", "alice's note", comment_id="597766"),
+        ]
+
+        mig._populate_comments(issue, wp_id=5040)
+
+        calls = mig.op_client.create_work_package_activity.call_args_list
+        assert len(calls) == 1
+        payload = calls[0][0][1]
+        assert "jira_comment_id" in payload, f"jira_comment_id missing from payload: {payload}"
+        assert payload["jira_comment_id"] == "597766"
+
+    def test_multiple_comments_each_have_their_own_id(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        """Each comment gets its own distinct jira_comment_id."""
+        mig = _build_mig(tmp_path)
+
+        issue = MagicMock()
+        issue.key = "PROJ-1"
+        mig.jira_client.jira.comments.return_value = [
+            _make_comment("alice", "comment one", comment_id="100"),
+            _make_comment("alice", "comment two", comment_id="101"),
+            _make_comment("alice", "comment three", comment_id="102"),
+        ]
+
+        mig._populate_comments(issue, wp_id=99)
+
+        calls = mig.op_client.create_work_package_activity.call_args_list
+        assert len(calls) == 3
+        sent_ids = [c[0][1]["jira_comment_id"] for c in calls]
+        assert sent_ids == ["100", "101", "102"]
+
+
+# ---------------------------------------------------------------------------
+# 7. create_work_package_activity — jira_comment_id forwarded to Ruby script
+# ---------------------------------------------------------------------------
+
+
+class TestSingleActivityRubyIdempotency:
+    def test_marker_embedded_in_single_activity_ruby_script(self) -> None:
+        """create_work_package_activity must embed the provenance marker in the Ruby script."""
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        captured_scripts: list[str] = []
+
+        def capture_script(script: str):
+            captured_scripts.append(script)
+            return {"id": 1, "status": "created"}
+
+        mock_client.execute_query_to_json_file.side_effect = capture_script
+
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        svc.create_work_package_activity(
+            work_package_id=5040,
+            activity_data={
+                "comment": {"raw": "Hello, comment body"},
+                "user_id": 100,
+                "jira_comment_id": "597766",
+            },
+        )
+
+        assert captured_scripts
+        script = captured_scripts[0]
+        # The provenance marker must appear in the Ruby script
+        assert "j2o:jira-comment-id:597766" in script, f"Provenance marker not found in Ruby script:\n{script}"
+
+    def test_idempotency_check_in_single_activity_ruby_script(self) -> None:
+        """create_work_package_activity must include a skip-if-exists check in Ruby."""
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        captured_scripts: list[str] = []
+
+        def capture_script(script: str):
+            captured_scripts.append(script)
+            return {"id": 1, "status": "created"}
+
+        mock_client.execute_query_to_json_file.side_effect = capture_script
+
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        svc.create_work_package_activity(
+            work_package_id=42,
+            activity_data={
+                "comment": {"raw": "idempotency test"},
+                "user_id": 5,
+                "jira_comment_id": "999",
+            },
+        )
+
+        script = captured_scripts[0]
+        # The script must contain a skip-if-exists guard
+        assert "skipped" in script or "existing_journal" in script, (
+            f"No idempotency guard found in single-activity Ruby script:\n{script}"
+        )
+
+    def test_no_idempotency_check_without_jira_comment_id(self) -> None:
+        """When jira_comment_id is absent no idempotency guard should be injected."""
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        captured_scripts: list[str] = []
+
+        def capture_script(script: str):
+            captured_scripts.append(script)
+            return {"id": 1, "status": "created"}
+
+        mock_client.execute_query_to_json_file.side_effect = capture_script
+
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        svc.create_work_package_activity(
+            work_package_id=42,
+            activity_data={"comment": {"raw": "no id comment"}, "user_id": 5},
+        )
+
+        script = captured_scripts[0]
+        assert "existing_journal" not in script, (
+            "Idempotency guard should NOT be present when jira_comment_id is absent"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. fetch_migrated_comment_ids — returns set of (wp_id, jira_comment_id) pairs
+# ---------------------------------------------------------------------------
+
+
+class TestFetchMigratedCommentIds:
+    def test_returns_empty_set_for_no_wp_ids(self) -> None:
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        svc = OpenProjectWorkPackageContentService(mock_client)
+
+        result = svc.fetch_migrated_comment_ids([])
+        assert result == set()
+        mock_client.execute_query_to_json_file.assert_not_called()
+
+    def test_returns_pairs_from_rails_result(self) -> None:
+        """fetch_migrated_comment_ids converts Rails [[wp_id, jira_id], ...] to set of tuples."""
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        mock_client.execute_query_to_json_file.return_value = [
+            [5040, "597766"],
+            [5040, "597767"],
+            [5041, "597770"],
+        ]
+
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        result = svc.fetch_migrated_comment_ids([5040, 5041])
+
+        assert result == {(5040, "597766"), (5040, "597767"), (5041, "597770")}
+
+    def test_returns_empty_set_on_rails_error(self) -> None:
+        """On Rails failure, returns empty set (non-fatal; callers treat as 'none migrated yet')."""
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        mock_client.execute_query_to_json_file.side_effect = RuntimeError("Rails down")
+
+        svc = OpenProjectWorkPackageContentService(mock_client)
+        result = svc.fetch_migrated_comment_ids([1, 2, 3])
+        assert result == set()
+
+    def test_ruby_script_queries_notes_column(self) -> None:
+        """The Rails query must target the notes column with the j2o marker pattern."""
+        import inspect
+
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        source = inspect.getsource(OpenProjectWorkPackageContentService.fetch_migrated_comment_ids)
+        assert "j2o:jira-comment-id:" in source
+        assert "notes" in source
+        assert "pluck" in source


### PR DESCRIPTION
## Live evidence (WP 5040, Jira NRS-4391) — trigger for this PR

After the May-9 re-run of `--components work_packages_content` on NRS:

```
total comment-journals: 12  (Jira side has 4)
unique notes:            8
by user:
    Anonymous (user_id=2): 8   ← May-7 broken runs (still present)
    Björn Marten:          3   ← May-9 correct run
    Mikhail Sarnov:        1   ← May-9 correct run
```

Every re-run was blindly INSERTing a fresh copy of all comments.

---

## Root cause

`bulk_create_work_package_activities` (and `create_work_package_activity`) had no existence check before INSERTing. Each migration run called `wp.journal_notes = …; wp.save!` unconditionally for every Jira comment, producing cumulative duplicates.

---

## Idempotency audit — all 4 WPCm outputs

| Output | Method | Idempotent? | Notes |
|--------|--------|-------------|-------|
| Descriptions | `batch_update_work_packages` | ✅ Yes | UPDATE semantics, same value on re-run |
| Custom fields | same | ✅ Yes | UPDATE semantics |
| Comments / journals | `bulk_create_work_package_activities` | ❌ **Was INSERT-only** | **Fixed in this PR** |
| Watchers | `bulk_add_watchers` | ✅ Yes | Pre-existing Set-based dedup in Ruby script |

Only comments required a fix.

---

## Fix: provenance marker + Rails-side dedup

Each migrated comment body gets `<!-- j2o:jira-comment-id:{id} -->` appended as a trailing line. This is a CommonMark HTML comment — stripped from rendered output by every compliant Markdown renderer including OpenProject's. The marker is **not visible to end users** but is present in the raw `notes` column where Rails can grep for it.

### Marker visibility decision

`<!-- … -->` HTML comments were chosen because:
- OpenProject uses CommonMark (spec §4.6): HTML comments are valid block-level HTML and are **not rendered** in output.
- The codebase already uses this pattern for project descriptions (`<!-- J2O_ORIGIN_START -->` in `openproject_project_attribute_service.py`).
- No schema changes required.
- Grep-able inside Rails for both idempotency checks and auditing.

### Changes

**`openproject_work_package_content_service.py`**
- `_build_comment_with_marker(text, jira_comment_id)` — module-level helper that appends the marker when `jira_comment_id` is set (no-op otherwise for legacy callers)
- `bulk_create_work_package_activities` — embeds marker in JSON payload; Ruby script pre-fetches all `(wp_id, jira_comment_id)` pairs already present in `Journal#notes` using a single query into a `Set`, then `next`s on any item whose pair is already in the set. Returns `skipped` count alongside `created`/`failed`.
- `create_work_package_activity` — same marker embedding + per-comment `LIKE`-based skip guard in Ruby
- `fetch_migrated_comment_ids(wp_ids)` — utility method that queries Rails and returns `Set{(wp_id, jira_comment_id)}` for upstream callers

**`work_package_content_migration.py`**
- `_collect_content_for_issue` — captures `comment.id` from each Jira comment, stores as `jira_comment_id` in collected dict
- `_populate_comments` (single-issue path) — same, forwards to `create_work_package_activity`
- `_bulk_process_collected_content` — forwards `jira_comment_id` from collected entry to the bulk call

---

## Cleanup script: `scripts/cleanup_anonymous_comment_duplicates.py`

One-shot tool for the **already-accumulated duplicates in production**. Not run as part of the migration — the operator runs it manually.

```
# Dry-run (default): analyse and report
.venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS

# Apply deletions
.venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS --apply
```

Algorithm:
1. Fetches all non-empty journals for the project's WPs via Rails
2. Groups by normalised notes (marker stripped for equality)
3. Within each duplicate group: keeps the journal with a real author (user_id ≠ 2); among real-author journals prefers the marker-bearing one; ties broken by newest `created_at`
4. Deletes the rest in batches of 100
5. Logs every deletion to stdout + `var/logs/cleanup_anonymous_comment_duplicates_<ts>.log`

Defaults to `--dry-run`. `--apply` required for actual deletion.

---

## Tests

41 new unit tests added across two files:

- `tests/unit/test_work_package_content_comment_idempotency.py` (22 tests)
  - `_build_comment_with_marker` — marker appended/omitted correctly
  - `bulk_create_work_package_activities` — `jira_comment_id` in JSON payload; Ruby script contains `Set.new` + `migrated_pairs` dedup; result dict includes `skipped`
  - `_collect_content_for_issue` — `jira_comment_id` captured from Jira comment
  - `_bulk_process_collected_content` — `jira_comment_id` forwarded
  - `_populate_comments` — `jira_comment_id` forwarded per comment
  - `create_work_package_activity` — marker in Ruby script; idempotency guard present; no guard when id absent
  - `fetch_migrated_comment_ids` — empty input, Rails result conversion, error fallback, Ruby query targets `notes` column

- `tests/unit/test_cleanup_anonymous_comment_duplicates.py` (19 tests)
  - `_strip_marker` — normalises notes for equality matching
  - `_select_keeper` — real-author preference, marker preference, newest fallback
  - `_plan_deletions` — WP 5040 live scenario (8 anon + 4 real → delete 8)
  - `run()` — dry-run makes 1 Rails call; apply sends correct IDs to delete; batches >100 IDs

All 41 tests confirmed **red on pre-fix HEAD**, **green after fix**.

## Test plan

- [ ] `pytest tests/unit/test_work_package_content_comment_idempotency.py tests/unit/test_work_package_content_migration_comment_author.py tests/unit/test_cleanup_anonymous_comment_duplicates.py -W error -q` — all pass
- [ ] `pytest tests/unit/ -W error -q --no-cov` — no regressions beyond pre-existing failures in `test_enhanced_openproject_client.py`
- [ ] `ruff check . && ruff format --check .` — clean
- [ ] `mypy src/ scripts/cleanup_anonymous_comment_duplicates.py` — 0 errors
- [ ] On NRS: run migration re-run and confirm no new duplicate journals created
- [ ] On NRS: run `scripts/cleanup_anonymous_comment_duplicates.py NRS --dry-run` and verify the 8 anonymous duplicates on WP 5040 are identified; then run with `--apply`