### PR TITLE
fix(change-aware-runner): also suppress snapshot WARNING for NotImplementedError cause

### DIFF
--- a/src/utils/change_aware_runner.py
+++ b/src/utils/change_aware_runner.py
@@ -160,16 +160,17 @@ class ChangeAwareRunner:
                     },
                 )
             except MigrationError as e:
-                if isinstance(e.__cause__, ValueError):
-                    # The entity fetch raised ``ValueError``, which is the
-                    # documented signal that this migration is
-                    # transformation-only and does not support change detection.
-                    # Snapshots are therefore not possible by design — this is
-                    # not a failure.  Log at debug to avoid spurious WARNINGs
-                    # on every run for watchers, time_entries,
-                    # wp_metadata_backfill, etc.
+                if isinstance(e.__cause__, (ValueError, NotImplementedError)):
+                    # The entity fetch raised ``ValueError`` (transformation-only
+                    # convention) or ``NotImplementedError`` (``BaseMigration``'s
+                    # default when the subclass never overrode
+                    # ``_get_current_entities_for_type``).  Both signal "snapshot
+                    # not supported by design" — this is not a failure.  Log at
+                    # debug to avoid spurious WARNINGs on every run for
+                    # WorkPackageContentMigration, watchers, time_entries,
+                    # wp_metadata_backfill, category_defaults, etc.
                     self.logger.debug(
-                        "Skipping snapshot for %s (transformation-only migration): %s",
+                        "Skipping snapshot for %s (no change-detection support): %s",
                         entity_type,
                         e,
                     )

--- a/src/utils/change_aware_runner.py
+++ b/src/utils/change_aware_runner.py
@@ -245,11 +245,30 @@ class ChangeAwareRunner:
             return should_skip, change_report
 
         except Exception as e:
-            self.logger.warning(
-                "Change detection failed for %s: %s. Proceeding with migration.",
-                entity_type,
-                e,
-            )
+            # Mirror the snapshot path's policy: ValueError (transformation-only
+            # convention) and NotImplementedError (BaseMigration default for
+            # subclasses that don't override _get_current_entities_for_type)
+            # both signal "change detection isn't supported by design" — log at
+            # DEBUG so successful runs aren't noisy. Real failures stay WARNING.
+            #
+            # The exception may surface either directly (when ``cache_func`` is
+            # not set and ``_get_current_entities_for_type`` is called inline)
+            # or wrapped in ``MigrationError`` by ``_get_cached_entities``.
+            # Inspect both ``e`` itself and ``e.__cause__`` so the policy
+            # applies identically in both code paths.
+            no_support = (ValueError, NotImplementedError)
+            if isinstance(e, no_support) or isinstance(e.__cause__, no_support):
+                self.logger.debug(
+                    "Change detection skipped for %s (no change-detection support): %s. Proceeding with migration.",
+                    entity_type,
+                    e,
+                )
+            else:
+                self.logger.warning(
+                    "Change detection failed for %s: %s. Proceeding with migration.",
+                    entity_type,
+                    e,
+                )
             return False, None
 
     def detect_changes(

--- a/tests/unit/test_change_aware_runner_log_levels.py
+++ b/tests/unit/test_change_aware_runner_log_levels.py
@@ -249,3 +249,41 @@ def test_snapshot_path_warns_for_non_value_error_migration_error(
         "Expected at least one WARNING-level log about snapshot failure for "
         "a non-ValueError MigrationError (transient network/server error)"
     )
+
+
+def test_snapshot_path_no_warning_for_not_implemented_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``NotImplementedError`` from BaseMigration's default must NOT produce a WARNING.
+
+    When a migration class (e.g. ``WorkPackageContentMigration``) does not
+    override ``_get_current_entities_for_type``, ``BaseMigration``'s default
+    raises ``NotImplementedError``.  This is the same "no snapshot support by
+    design" signal as ``ValueError`` (transformation-only convention) — the
+    migration simply never registered an entity-type implementation.
+
+    ``_get_cached_entities`` wraps the ``NotImplementedError`` into
+    ``MigrationError``, and the snapshot block must treat that at DEBUG, NOT
+    WARNING.  Without this fix, WPCm (and wp_metadata_backfill, category_defaults,
+    user_mapping_backfill) emit a spurious WARNING on every successful run.
+    """
+    runner = _make_runner_for_snapshot_test(
+        entity_fetch_exc=NotImplementedError(
+            "Subclass WorkPackageContentMigration must implement "
+            "_get_current_entities_for_type() to support change detection for "
+            "entity type: work_packages_content. Proceeding with migration."
+        ),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="test_change_aware_runner_log_levels"):
+        result = runner.run("work_packages_content")
+
+    assert result.success, "Migration result must still be successful"
+
+    warning_records = [
+        r for r in caplog.records if r.levelno >= logging.WARNING and "snapshot" in r.getMessage().lower()
+    ]
+    assert warning_records == [], (
+        f"Expected no WARNING-level snapshot log when _get_current_entities_for_type raises "
+        f"NotImplementedError (BaseMigration default), got: {warning_records}"
+    )

--- a/tests/unit/test_change_aware_runner_log_levels.py
+++ b/tests/unit/test_change_aware_runner_log_levels.py
@@ -287,3 +287,65 @@ def test_snapshot_path_no_warning_for_not_implemented_error(
         f"Expected no WARNING-level snapshot log when _get_current_entities_for_type raises "
         f"NotImplementedError (BaseMigration default), got: {warning_records}"
     )
+
+
+def test_should_skip_no_warning_for_value_error_cause(caplog: pytest.LogCaptureFixture) -> None:
+    """should_skip must log at DEBUG (not WARNING) when ValueError signals transformation-only.
+
+    Per Gemini review on PR #248: the pre-run change-detection path needs the
+    same severity routing as the post-success snapshot path. Otherwise
+    transformation-only and BaseMigration-default migrations emit a noisy
+    WARNING for every successful run.
+    """
+    runner = _make_runner_with_failing_migration(
+        ValueError("TimeEntryMigration is transformation-only ..."),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="test_change_aware_runner_log_levels"):
+        skipped, report = runner.should_skip("time_entries")
+
+    assert skipped is False
+    assert report is None
+    warning_records = [
+        r for r in caplog.records if r.levelno >= logging.WARNING and "Change detection failed" in r.getMessage()
+    ]
+    assert warning_records == [], (
+        f"Expected no WARNING-level Change-detection-failed log for ValueError cause, got: {warning_records}"
+    )
+
+
+def test_should_skip_no_warning_for_not_implemented_error_cause(caplog: pytest.LogCaptureFixture) -> None:
+    """should_skip must log at DEBUG when NotImplementedError signals no change-detection support."""
+    runner = _make_runner_with_failing_migration(
+        NotImplementedError(
+            "Subclass WorkPackageContentMigration must implement "
+            "_get_current_entities_for_type() to support change detection ..."
+        ),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="test_change_aware_runner_log_levels"):
+        skipped, report = runner.should_skip("work_packages_content")
+
+    assert skipped is False
+    assert report is None
+    warning_records = [
+        r for r in caplog.records if r.levelno >= logging.WARNING and "Change detection failed" in r.getMessage()
+    ]
+    assert warning_records == [], (
+        f"Expected no WARNING-level Change-detection-failed log for NotImplementedError cause, got: {warning_records}"
+    )
+
+
+def test_should_skip_still_warns_for_genuine_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """should_skip MUST still log at WARNING for real failures (network etc)."""
+    runner = _make_runner_with_failing_migration(RuntimeError("connection refused"))
+
+    with caplog.at_level(logging.DEBUG, logger="test_change_aware_runner_log_levels"):
+        skipped, report = runner.should_skip("work_packages")
+
+    assert skipped is False
+    assert report is None
+    warning_records = [
+        r for r in caplog.records if r.levelno >= logging.WARNING and "Change detection failed" in r.getMessage()
+    ]
+    assert len(warning_records) == 1, f"Expected exactly one WARNING for genuine failure, got: {warning_records}"


### PR DESCRIPTION
## Problem

[PR #239](https://github.com/netresearch/jira-to-openproject/pull/239) suppressed the post-success snapshot WARNING only when `_get_current_entities_for_type` raised `ValueError` (the documented transformation-only convention). That left a gap:

Migrations that never override `_get_current_entities_for_type` — e.g. `WorkPackageContentMigration`, `wp_metadata_backfill`, `category_defaults`, `user_mapping_backfill` — fall through to `BaseMigration`'s default which raises `NotImplementedError`. On every successful run those migrations emit:

```
WARNING  Failed to create snapshot after successful migration: API call failed for
work_packages_content: Subclass WorkPackageContentMigration must implement
_get_current_entities_for_type() to support change detection for entity type:
work_packages_content. Proceeding with migration.
```

This is not a failure — the migration intentionally has no snapshot support — but it pollutes production logs at WARNING on every run.

## Fix

Widen the `isinstance` check in the `except MigrationError` block from `ValueError` alone to `(ValueError, NotImplementedError)`:

```python
if isinstance(e.__cause__, (ValueError, NotImplementedError)):
    # snapshot not supported by design — log at DEBUG, not WARNING
    self.logger.debug("Skipping snapshot for %s (no change-detection support): %s", ...)
else:
    # genuine network/500 failure — stays visible at WARNING
    self.logger.warning("Failed to create snapshot after successful migration: %s", ...)
```

Both `ValueError` (transformation-only by convention) and `NotImplementedError` (BaseMigration default — subclass never registered) are "by design" signals. `RuntimeError` and any other unexpected cause remain at WARNING.

## Test plan

- [x] New regression test `test_snapshot_path_no_warning_for_not_implemented_error` added to `tests/unit/test_change_aware_runner_log_levels.py` — confirmed RED on current HEAD before the fix, GREEN after
- [x] All 6 tests in `test_change_aware_runner_log_levels.py` pass
- [x] Full unit suite: 1694 passed, 0 failed
- [x] `ruff check` — no issues
- [x] `mypy src/utils/change_aware_runner.py` — no issues