### PR TITLE
tools(cleanup): add orphan-anonymous deletion + provenance-marker backfill

### DIFF
--- a/scripts/backfill_comment_provenance_markers.py
+++ b/scripts/backfill_comment_provenance_markers.py
@@ -76,7 +76,13 @@ _DEFAULT_DATA_DIR = Path("var/data")
 def _setup_logging(log_path: Path) -> logging.Logger:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     logger = logging.getLogger("backfill_comment_provenance")
+    # Guard against duplicate handlers on re-invocation (e.g. repeated calls
+    # from tests or reloads).  If handlers are already attached, skip adding
+    # new ones to avoid log-line duplication.
+    if logger.handlers:
+        return logger
     logger.setLevel(logging.DEBUG)
+    logger.propagate = False
     fmt = logging.Formatter("%(asctime)s  %(levelname)-7s  %(message)s")
 
     ch = logging.StreamHandler(sys.stdout)
@@ -104,8 +110,10 @@ def _pair_journals_with_comments(
 ) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], str | None]:
     """Pair OP journals with Jira comments by chronological order.
 
-    Pre-filters already-marked journals from ``op_journals`` before pairing
-    so the function is idempotent on WPs that are partially backfilled.
+    All-or-nothing semantics: if any OP journal already carries a provenance
+    marker the whole WP is considered partially backfilled and skipped.
+    Partial backfill cannot be safely completed by positional pairing because
+    the already-marked journal's position shifts all subsequent pairings.
 
     Args:
         op_journals: OP journal dicts with keys ``id``, ``wp_id``,
@@ -121,12 +129,22 @@ def _pair_journals_with_comments(
         on success or a descriptive string when the WP must be skipped.
         When ``skip_reason`` is set ``pairs`` is always ``[]``.
     """
-    # Exclude already-marked journals — they need no update.
+    marked = [j for j in op_journals if _MARKER_RE.search(j["notes"])]
     unmarked = [j for j in op_journals if not _MARKER_RE.search(j["notes"])]
 
     # If all journals are already marked: nothing to do, not an error.
     if not unmarked:
         return [], None
+
+    # Partial backfill: some marked, some not.  Cannot safely pair by position
+    # because the marked journal occupies a slot in the ordinal sequence.
+    # Skip with a clear diagnostic rather than a misleading "count mismatch".
+    if marked:
+        return [], (
+            f"partially backfilled: {len(marked)} journal(s) already marked, "
+            f"{len(unmarked)} unmarked — skipping (all-or-nothing policy); "
+            f"re-run after manually removing or verifying existing markers"
+        )
 
     # Count check: we need a 1:1 match.
     if len(unmarked) != len(jira_comments):
@@ -217,30 +235,48 @@ end
 # ---------------------------------------------------------------------------
 
 
-def _default_fetch_jira_comments(jira_issue_key: str) -> list[dict[str, Any]]:
-    """Fetch Jira comments for an issue key using the configured JiraClient.
+def _make_jira_fetcher(jira_client: Any) -> Any:
+    """Return a ``fetch_jira_comments`` callable bound to the given JiraClient.
 
-    Returns a list of dicts with keys ``id``, ``author_account_id``, ``body``.
+    The returned callable has the signature
+    ``(jira_issue_key: str) -> list[dict]`` expected by :func:`run`.
+    Constructing the client once and binding it here avoids per-call
+    reconnection overhead.
+    """
+
+    def _fetch(jira_issue_key: str) -> list[dict[str, Any]]:
+        raw_comments = jira_client.jira.comments(jira_issue_key)
+        result = []
+        for c in raw_comments:
+            author = getattr(c, "author", None)
+            account_id = ""
+            if author is not None:
+                account_id = getattr(author, "accountId", "") or ""
+            result.append(
+                {
+                    "id": getattr(c, "id", ""),
+                    "author_account_id": account_id,
+                    "body": getattr(c, "body", ""),
+                }
+            )
+        return result
+
+    return _fetch
+
+
+def _default_fetch_jira_comments(jira_issue_key: str) -> list[dict[str, Any]]:
+    """Fetch Jira comments for an issue key, constructing a JiraClient each call.
+
+    .. deprecated::
+        Prefer :func:`_make_jira_fetcher` with a shared client instance.
+        This function exists for backward compatibility; ``main()`` uses
+        :func:`_make_jira_fetcher` to avoid per-call reconnection overhead.
     """
     # Lazy import to avoid side effects during tests.
     from src.infrastructure.jira.jira_client import JiraClient  # noqa: PLC0415
 
     client = JiraClient()
-    raw_comments = client.jira.comments(jira_issue_key)
-    result = []
-    for c in raw_comments:
-        author = getattr(c, "author", None)
-        account_id = ""
-        if author is not None:
-            account_id = getattr(author, "accountId", "") or ""
-        result.append(
-            {
-                "id": getattr(c, "id", ""),
-                "author_account_id": account_id,
-                "body": getattr(c, "body", ""),
-            }
-        )
-    return result
+    return _make_jira_fetcher(client)(jira_issue_key)
 
 
 # ---------------------------------------------------------------------------
@@ -273,19 +309,22 @@ def run(
 
     Returns:
         Dict with keys: ``wps_processed``, ``wps_skipped``,
-        ``would_update`` (dry-run), ``updated`` (apply),
-        ``skipped``, ``errors``.
+        ``would_update`` (dry-run), ``updated`` (apply), ``errors``.
     """
     mode = "DRY-RUN" if dry_run else "APPLY"
     logger.info("Backfill provenance markers  Mode: %s  WPs: %d", mode, len(wp_mapping))
 
     stats: dict[str, int] = {
         "wps_processed": 0,
-        "skipped": 0,
+        "wps_skipped": 0,
         "would_update": 0,
         "updated": 0,
         "errors": 0,
     }
+
+    # Accumulate all (journal_id, new_notes) pairs across WPs for a single
+    # batched Rails write at the end (issue #4 — reduce Rails round-trips).
+    all_updates: list[tuple[int, str]] = []
 
     for entry in wp_mapping:
         jira_key: str = entry["jira_key"]
@@ -328,7 +367,7 @@ def run(
                 jira_key,
                 skip_reason,
             )
-            stats["skipped"] += 1
+            stats["wps_skipped"] += 1
             continue
 
         if not pairs:
@@ -357,21 +396,35 @@ def run(
             stats["would_update"] += len(updates)
             continue
 
-        # --- Apply updates ---
-        update_script = _build_update_markers_script(updates)
-        try:
-            update_result = op_client.execute_query_to_json_file(update_script)
-            n = update_result.get("updated", 0) if isinstance(update_result, dict) else 0
-            stats["updated"] += n
-            logger.info("WP#%d (%s): updated %d journal(s)", op_wp_id, jira_key, n)
-        except Exception as exc:
-            logger.error("WP#%d (%s): update failed: %s", op_wp_id, jira_key, exc)
-            stats["errors"] += 1
+        # Accumulate updates for a batched Rails write (see below).
+        all_updates.extend(updates)
+
+    # --- Apply accumulated updates in one batched Rails call ---
+    # Batching reduces the number of Rails console round-trips from O(WPs) to
+    # O(ceil(total_journals / batch_size)).
+    if not dry_run and all_updates:
+        _batch_size = 200
+        for i in range(0, len(all_updates), _batch_size):
+            batch = all_updates[i : i + _batch_size]
+            update_script = _build_update_markers_script(batch)
+            try:
+                update_result = op_client.execute_query_to_json_file(update_script)
+                n = update_result.get("updated", 0) if isinstance(update_result, dict) else 0
+                stats["updated"] += n
+                logger.info(
+                    "Batch update %d–%d: updated %d journal(s)",
+                    i + 1,
+                    i + len(batch),
+                    n,
+                )
+            except Exception as exc:
+                logger.error("Batch update %d–%d failed: %s", i + 1, i + len(batch), exc)
+                stats["errors"] += 1
 
     logger.info(
         "Done.  processed=%d  skipped=%d  would_update=%d  updated=%d  errors=%d",
         stats["wps_processed"],
-        stats["skipped"],
+        stats["wps_skipped"],
         stats["would_update"],
         stats["updated"],
         stats["errors"],
@@ -422,7 +475,24 @@ def _load_wp_mapping(data_dir: Path, project_key: str) -> list[dict[str, Any]]:
 
 
 def _load_user_mapping(data_dir: Path) -> dict[str, int]:
-    """Load user_mapping.json and return ``{jira_account_id: op_user_id}``."""
+    """Load user_mapping.json and return a multi-keyed ``{identifier: op_user_id}`` dict.
+
+    ``user_mapping.json`` is keyed by display name (outer key), but Jira
+    comment authors are identified by Jira Server *key* (e.g. ``JIRAUSER12345``
+    or ``ID12021``), login name, email address, or display name.
+
+    This function builds a lookup indexed by every probe field present on each
+    entry, following the canonical probe order from
+    ``IssueTransformer._JOURNAL_AUTHOR_PROBE_KEYS``:
+    ``jira_key`` → ``jira_name`` → ``jira_display_name`` → ``jira_email``.
+
+    The outer key (display name or jira_key) is also indexed so that mappings
+    whose outer key happens to be the jira_key (e.g. ``"JIRAUSER13400"``) are
+    still resolvable.
+
+    Later insertions do not overwrite earlier ones so the higher-priority probe
+    fields win in the rare case two entries share a secondary field value.
+    """
     mapping_path = data_dir / "user_mapping.json"
     if not mapping_path.exists():
         return {}
@@ -430,12 +500,36 @@ def _load_user_mapping(data_dir: Path) -> dict[str, int]:
     with mapping_path.open("r", encoding="utf-8") as fh:
         raw: dict[str, Any] = json.load(fh)
 
+    # Probe fields in priority order (mirrors IssueTransformer._JOURNAL_AUTHOR_PROBE_KEYS
+    # mapped to the user_mapping.json entry field names).
+    _PROBE_ENTRY_FIELDS: tuple[str, ...] = (
+        "jira_key",  # Server/DC key (e.g. JIRAUSER12345, ID12021)
+        "jira_name",  # Server login name (e.g. anne.geissler)
+        "jira_display_name",  # Display name
+        "jira_email",  # Email address
+    )
+
     result: dict[str, int] = {}
-    for jira_id, entry in raw.items():
-        if isinstance(entry, dict):
-            op_id = entry.get("openproject_id")
-            if op_id:
-                result[str(jira_id)] = int(op_id)
+
+    for outer_key, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        op_id = entry.get("openproject_id")
+        if not op_id:
+            continue
+        op_user_id = int(op_id)
+
+        # Index by each probe field in priority order; skip already-set keys
+        # so higher-priority fields win over lower-priority ones.
+        for field in _PROBE_ENTRY_FIELDS:
+            value = entry.get(field)
+            if value and str(value) not in result:
+                result[str(value)] = op_user_id
+
+        # Also index by the outer key (may be display name or jira_key).
+        if outer_key and outer_key not in result:
+            result[outer_key] = op_user_id
+
     return result
 
 
@@ -492,15 +586,19 @@ def main(argv: list[str] | None = None) -> int:
     user_mapping = _load_user_mapping(data_dir)
     logger.info("Loaded %d user mapping entries", len(user_mapping))
 
+    from src.infrastructure.jira.jira_client import JiraClient  # noqa: PLC0415
     from src.infrastructure.openproject.openproject_client import OpenProjectClient  # noqa: PLC0415
 
+    # Construct clients once; binding the Jira client to a fetcher closure
+    # avoids per-WP reconnection overhead.
+    jira_client = JiraClient()
     op_client = OpenProjectClient()
 
     try:
         stats = run(
             wp_mapping=wp_mapping,
             user_mapping=user_mapping,
-            fetch_jira_comments=_default_fetch_jira_comments,
+            fetch_jira_comments=_make_jira_fetcher(jira_client),
             op_client=op_client,
             dry_run=not args.apply,
             logger=logger,

--- a/scripts/backfill_comment_provenance_markers.py
+++ b/scripts/backfill_comment_provenance_markers.py
@@ -1,0 +1,517 @@
+"""Backfill provenance markers onto OP journal notes that lack them.
+
+After a correctly-authored migration run the OP journals have the right
+author and content but no ``<!-- j2o:jira-comment-id:{id} -->`` marker.
+Without that marker every subsequent re-run of
+``--components work_packages_content`` treats the comments as "not yet
+migrated" and creates a fresh duplicate set.
+
+This script patches the raw ``notes`` column of each un-marked journal with
+the correct provenance marker so future re-runs are idempotent.
+
+Algorithm per work package
+--------------------------
+1. Fetch OP journals (notes != '', no existing marker) ordered by
+   ``created_at`` — the order mirrors the order in which the migration
+   created them.
+2. Fetch Jira comments for the corresponding Jira issue (Jira returns them
+   in chronological order).
+3. If counts differ → SKIP + WARNING (unsafe to pair; operator must
+   investigate).
+4. Zip the two lists by position.  For each pair validate that the Jira
+   comment author (resolved via ``user_mapping``) matches the OP journal's
+   ``user_id``.  If any pair mismatches → SKIP + WARNING.
+5. For safe WPs: append the provenance marker to each journal's notes using
+   ``Journal.update_columns(notes: ...)`` — this bypasses ActiveRecord
+   callbacks so no new journal version is created.
+
+Safety guarantees
+-----------------
+- Default mode is ``--dry-run``; ``--apply`` is required to mutate.
+- Refuses to mutate on count mismatch OR author mismatch.
+- Idempotent: already-marked journals are excluded from the fetch so a
+  second run is a safe no-op.
+
+Usage::
+
+    .venv/bin/python -m scripts.backfill_comment_provenance_markers NRS
+    .venv/bin/python -m scripts.backfill_comment_provenance_markers NRS --dry-run
+    .venv/bin/python -m scripts.backfill_comment_provenance_markers NRS --apply
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Marker template (same as openproject_work_package_content_service.py).
+_COMMENT_PROVENANCE_MARKER = "<!-- j2o:jira-comment-id:{jira_comment_id} -->"
+
+#: Regex to detect an already-present provenance marker in notes.
+_MARKER_RE = re.compile(r"<!--\s*j2o:jira-comment-id:[^\s>]+\s*-->")
+
+#: Minimum valid project key: 2+ uppercase letters/digits.
+_PROJECT_KEY_RE = re.compile(r"\A[A-Z][A-Z0-9_]+\z")
+
+#: Default data directory (relative to project root).
+_DEFAULT_DATA_DIR = Path("var/data")
+
+
+# ---------------------------------------------------------------------------
+# Log helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_logging(log_path: Path) -> logging.Logger:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger("backfill_comment_provenance")
+    logger.setLevel(logging.DEBUG)
+    fmt = logging.Formatter("%(asctime)s  %(levelname)-7s  %(message)s")
+
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setLevel(logging.DEBUG)
+    ch.setFormatter(fmt)
+    logger.addHandler(ch)
+
+    fh = logging.FileHandler(log_path, encoding="utf-8")
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(fmt)
+    logger.addHandler(fh)
+
+    return logger
+
+
+# ---------------------------------------------------------------------------
+# Pure pairing logic
+# ---------------------------------------------------------------------------
+
+
+def _pair_journals_with_comments(
+    op_journals: list[dict[str, Any]],
+    jira_comments: list[dict[str, Any]],
+    user_mapping: dict[str, int],
+) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], str | None]:
+    """Pair OP journals with Jira comments by chronological order.
+
+    Pre-filters already-marked journals from ``op_journals`` before pairing
+    so the function is idempotent on WPs that are partially backfilled.
+
+    Args:
+        op_journals: OP journal dicts with keys ``id``, ``wp_id``,
+            ``user_id``, ``notes``, ``created_at``.
+        jira_comments: Jira comment dicts with keys ``id``,
+            ``author_account_id``, ``body``.  Must be in chronological order
+            (Jira REST API default).
+        user_mapping: ``{jira_account_id: op_user_id}`` dict.
+
+    Returns:
+        ``(pairs, skip_reason)`` where ``pairs`` is a list of
+        ``(op_journal, jira_comment)`` tuples and ``skip_reason`` is ``None``
+        on success or a descriptive string when the WP must be skipped.
+        When ``skip_reason`` is set ``pairs`` is always ``[]``.
+    """
+    # Exclude already-marked journals — they need no update.
+    unmarked = [j for j in op_journals if not _MARKER_RE.search(j["notes"])]
+
+    # If all journals are already marked: nothing to do, not an error.
+    if not unmarked:
+        return [], None
+
+    # Count check: we need a 1:1 match.
+    if len(unmarked) != len(jira_comments):
+        return [], (f"count mismatch: {len(unmarked)} unmarked OP journals vs {len(jira_comments)} Jira comments")
+
+    # Author validation: zip by position (both are in chronological order).
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for idx, (op_j, jira_c) in enumerate(zip(unmarked, jira_comments, strict=True)):
+        jira_account_id: str = jira_c.get("author_account_id", "")
+        expected_op_user_id = user_mapping.get(jira_account_id)
+        actual_op_user_id = op_j.get("user_id")
+        if expected_op_user_id is None or expected_op_user_id != actual_op_user_id:
+            return [], (
+                f"author mismatch at position {idx}: "
+                f"OP journal #{op_j['id']} has user_id={actual_op_user_id} "
+                f"but Jira comment {jira_c['id']} (account {jira_account_id!r}) "
+                f"maps to op_user_id={expected_op_user_id}"
+            )
+        pairs.append((op_j, jira_c))
+
+    return pairs, None
+
+
+# ---------------------------------------------------------------------------
+# Rails script builders
+# ---------------------------------------------------------------------------
+
+
+def _build_fetch_journals_script(wp_id: int) -> str:
+    """Ruby script: fetch un-marked journals for a single WP, ordered by created_at."""
+    return f"""
+require 'json'
+wp_id = {int(wp_id)}
+journals = Journal
+  .where(journable_type: 'WorkPackage', journable_id: wp_id)
+  .where.not(notes: [nil, ''])
+  .where("notes NOT LIKE '%j2o:jira-comment-id:%'")
+  .order(:created_at)
+  .pluck(:id, :journable_id, :user_id, :notes, :created_at)
+  .map {{|id, wid, user_id, notes, created_at|
+    {{
+      id: id,
+      wp_id: wid,
+      user_id: user_id,
+      notes: notes,
+      created_at: created_at
+    }}
+  }}
+{{journals: journals}}
+"""
+
+
+def _build_update_markers_script(
+    updates: list[tuple[int, str]],
+) -> str:
+    """Ruby script: patch journal notes in bulk using update_columns.
+
+    Uses ``update_columns`` (not ``save!``) so ActiveRecord callbacks are
+    bypassed — no new journal version is created, and validity_period /
+    data_type are left intact.
+
+    Args:
+        updates: List of ``(journal_id, new_notes_with_marker)`` tuples.
+    """
+    data = [{"id": jid, "notes": notes} for jid, notes in updates]
+    data_json = json.dumps(data, ensure_ascii=False)
+    return f"""
+require 'json'
+data = JSON.parse(<<-'J2O_DATA'
+{data_json}
+J2O_DATA
+)
+
+updated = 0
+data.each do |item|
+  j = Journal.find_by(id: item['id'])
+  if j
+    j.update_columns(notes: item['notes'])
+    updated += 1
+  end
+end
+{{updated: updated}}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Jira comment fetching
+# ---------------------------------------------------------------------------
+
+
+def _default_fetch_jira_comments(jira_issue_key: str) -> list[dict[str, Any]]:
+    """Fetch Jira comments for an issue key using the configured JiraClient.
+
+    Returns a list of dicts with keys ``id``, ``author_account_id``, ``body``.
+    """
+    # Lazy import to avoid side effects during tests.
+    from src.infrastructure.jira.jira_client import JiraClient  # noqa: PLC0415
+
+    client = JiraClient()
+    raw_comments = client.jira.comments(jira_issue_key)
+    result = []
+    for c in raw_comments:
+        author = getattr(c, "author", None)
+        account_id = ""
+        if author is not None:
+            account_id = getattr(author, "accountId", "") or ""
+        result.append(
+            {
+                "id": getattr(c, "id", ""),
+                "author_account_id": account_id,
+                "body": getattr(c, "body", ""),
+            }
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Core run() function
+# ---------------------------------------------------------------------------
+
+
+def run(
+    wp_mapping: list[dict[str, Any]],
+    user_mapping: dict[str, int],
+    fetch_jira_comments: Any,  # callable(jira_issue_key) -> list[dict]
+    op_client: Any,
+    *,
+    dry_run: bool,
+    logger: logging.Logger,
+) -> dict[str, int]:
+    """Backfill provenance markers onto un-marked OP journals.
+
+    Args:
+        wp_mapping: List of dicts, each with keys ``jira_key``,
+            ``openproject_id``, ``project_key``.
+        user_mapping: ``{jira_account_id: op_user_id}`` dict.
+        fetch_jira_comments: Callable ``(jira_issue_key: str) ->
+            list[dict]`` — each dict has ``id``, ``author_account_id``,
+            ``body``.  Injected so tests can mock without hitting Jira.
+        op_client: OpenProjectClient (or any object with
+            ``execute_query_to_json_file``).
+        dry_run: When ``True`` no Rails writes are issued.
+        logger: Configured logger instance.
+
+    Returns:
+        Dict with keys: ``wps_processed``, ``wps_skipped``,
+        ``would_update`` (dry-run), ``updated`` (apply),
+        ``skipped``, ``errors``.
+    """
+    mode = "DRY-RUN" if dry_run else "APPLY"
+    logger.info("Backfill provenance markers  Mode: %s  WPs: %d", mode, len(wp_mapping))
+
+    stats: dict[str, int] = {
+        "wps_processed": 0,
+        "skipped": 0,
+        "would_update": 0,
+        "updated": 0,
+        "errors": 0,
+    }
+
+    for entry in wp_mapping:
+        jira_key: str = entry["jira_key"]
+        op_wp_id: int = int(entry["openproject_id"])
+
+        # --- Fetch OP journals (unmarked) ---
+        try:
+            fetch_result = op_client.execute_query_to_json_file(_build_fetch_journals_script(op_wp_id))
+        except Exception as exc:
+            logger.error("WP#%d (%s): Rails fetch failed: %s", op_wp_id, jira_key, exc)
+            stats["errors"] += 1
+            continue
+
+        if not isinstance(fetch_result, dict):
+            logger.error("WP#%d (%s): unexpected fetch result type %r", op_wp_id, jira_key, type(fetch_result))
+            stats["errors"] += 1
+            continue
+
+        op_journals: list[dict[str, Any]] = fetch_result.get("journals", [])
+
+        # --- Fetch Jira comments ---
+        try:
+            jira_comments: list[dict[str, Any]] = fetch_jira_comments(jira_key)
+        except Exception as exc:
+            logger.error("WP#%d (%s): Jira fetch failed: %s", op_wp_id, jira_key, exc)
+            stats["errors"] += 1
+            continue
+
+        # --- Pair journals with comments ---
+        pairs, skip_reason = _pair_journals_with_comments(
+            op_journals=op_journals,
+            jira_comments=jira_comments,
+            user_mapping=user_mapping,
+        )
+
+        if skip_reason is not None:
+            logger.warning(
+                "WP#%d (%s): SKIP — %s",
+                op_wp_id,
+                jira_key,
+                skip_reason,
+            )
+            stats["skipped"] += 1
+            continue
+
+        if not pairs:
+            # All journals already marked — clean, nothing to do.
+            logger.debug("WP#%d (%s): all journals already marked — no-op", op_wp_id, jira_key)
+            stats["wps_processed"] += 1
+            continue
+
+        # --- Compute updates ---
+        updates: list[tuple[int, str]] = []
+        for op_j, jira_c in pairs:
+            new_notes = op_j["notes"] + "\n" + _COMMENT_PROVENANCE_MARKER.format(jira_comment_id=jira_c["id"])
+            updates.append((op_j["id"], new_notes))
+            logger.info(
+                "  [%s] WP#%d  Journal#%d  jira_comment_id=%s  marker=j2o:jira-comment-id:%s",
+                "UPDATE" if not dry_run else "WOULD UPDATE",
+                op_wp_id,
+                op_j["id"],
+                jira_c["id"],
+                jira_c["id"],
+            )
+
+        stats["wps_processed"] += 1
+
+        if dry_run:
+            stats["would_update"] += len(updates)
+            continue
+
+        # --- Apply updates ---
+        update_script = _build_update_markers_script(updates)
+        try:
+            update_result = op_client.execute_query_to_json_file(update_script)
+            n = update_result.get("updated", 0) if isinstance(update_result, dict) else 0
+            stats["updated"] += n
+            logger.info("WP#%d (%s): updated %d journal(s)", op_wp_id, jira_key, n)
+        except Exception as exc:
+            logger.error("WP#%d (%s): update failed: %s", op_wp_id, jira_key, exc)
+            stats["errors"] += 1
+
+    logger.info(
+        "Done.  processed=%d  skipped=%d  would_update=%d  updated=%d  errors=%d",
+        stats["wps_processed"],
+        stats["skipped"],
+        stats["would_update"],
+        stats["updated"],
+        stats["errors"],
+    )
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def _load_wp_mapping(data_dir: Path, project_key: str) -> list[dict[str, Any]]:
+    """Load work_package_mapping.json and filter to the given project key."""
+    mapping_path = data_dir / "work_package_mapping.json"
+    if not mapping_path.exists():
+        raise FileNotFoundError(f"Mapping file not found: {mapping_path}")
+
+    with mapping_path.open("r", encoding="utf-8") as fh:
+        raw: dict[str, Any] = json.load(fh)
+
+    result: list[dict[str, Any]] = []
+    for outer_key, value in raw.items():
+        if isinstance(value, dict):
+            jira_key = value.get("jira_key", outer_key)
+            op_id = value.get("openproject_id")
+            pk = value.get("project_key", "")
+        else:
+            # Legacy int-value shape — skip (no jira_key recoverable)
+            continue
+
+        if not op_id:
+            continue
+
+        # Filter to requested project: match the issue key prefix.
+        if not str(jira_key).upper().startswith(project_key.upper() + "-"):
+            continue
+
+        result.append(
+            {
+                "jira_key": str(jira_key),
+                "openproject_id": int(op_id),
+                "project_key": str(pk),
+            }
+        )
+
+    return result
+
+
+def _load_user_mapping(data_dir: Path) -> dict[str, int]:
+    """Load user_mapping.json and return ``{jira_account_id: op_user_id}``."""
+    mapping_path = data_dir / "user_mapping.json"
+    if not mapping_path.exists():
+        return {}
+
+    with mapping_path.open("r", encoding="utf-8") as fh:
+        raw: dict[str, Any] = json.load(fh)
+
+    result: dict[str, int] = {}
+    for jira_id, entry in raw.items():
+        if isinstance(entry, dict):
+            op_id = entry.get("openproject_id")
+            if op_id:
+                result[str(jira_id)] = int(op_id)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("project_key", help="Jira/OP project key (e.g. NRS)")
+    apply_grp = parser.add_mutually_exclusive_group()
+    apply_grp.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Actually write provenance markers.  Default is dry-run.",
+    )
+    apply_grp.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        dest="dry_run",
+        help="Analyse and report only; do not write (this is the default).",
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(_DEFAULT_DATA_DIR),
+        help=f"Directory containing mapping JSON files (default: {_DEFAULT_DATA_DIR})",
+    )
+    args = parser.parse_args(argv)
+
+    project_key = args.project_key.upper()
+    if not _PROJECT_KEY_RE.match(project_key):
+        sys.stderr.write(f"Invalid project key: {args.project_key!r}\n")
+        return 2
+
+    data_dir = Path(args.data_dir)
+    ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    log_path = Path("var/logs") / f"backfill_comment_provenance_markers_{ts}.log"
+
+    logger = _setup_logging(log_path)
+    logger.info("Log: %s", log_path)
+
+    try:
+        wp_mapping = _load_wp_mapping(data_dir, project_key)
+    except FileNotFoundError as exc:
+        logger.error("Cannot load work_package_mapping: %s", exc)
+        return 1
+    except Exception as exc:
+        logger.error("Failed to load work_package_mapping: %s", exc)
+        return 1
+
+    logger.info("Loaded %d WP entries for project %s", len(wp_mapping), project_key)
+
+    user_mapping = _load_user_mapping(data_dir)
+    logger.info("Loaded %d user mapping entries", len(user_mapping))
+
+    from src.infrastructure.openproject.openproject_client import OpenProjectClient  # noqa: PLC0415
+
+    op_client = OpenProjectClient()
+
+    try:
+        stats = run(
+            wp_mapping=wp_mapping,
+            user_mapping=user_mapping,
+            fetch_jira_comments=_default_fetch_jira_comments,
+            op_client=op_client,
+            dry_run=not args.apply,
+            logger=logger,
+        )
+    except Exception as exc:
+        logger.error("Fatal: %s", exc)
+        return 1
+
+    print(json.dumps(stats, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cleanup_anonymous_comment_duplicates.py
+++ b/scripts/cleanup_anonymous_comment_duplicates.py
@@ -26,13 +26,22 @@ This script deduplicates those journals **safely**:
 5. Log every deletion to stdout AND to
    ``var/logs/cleanup_anonymous_comment_duplicates_<ts>.log``.
 
+Additionally, when ``--also-delete-orphan-anonymous`` is passed: for every
+work package that has **both** real-author journals AND Anonymous journals,
+ALL of the Anonymous journals are deleted regardless of content similarity.
+This handles the case where the broken-run renderer produced different text
+(e.g. ``concourse~~ci`` vs ``concourse-ci``) so text-based dedup would not
+catch the duplicate.
+
 Defaults to ``--dry-run``.  Deletion requires explicit ``--apply``.
+``--also-delete-orphan-anonymous`` is opt-in (not the default).
 
 Usage::
 
     .venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS
     .venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS --dry-run
     .venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS --apply
+    .venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS --apply --also-delete-orphan-anonymous
 
 """
 
@@ -145,6 +154,33 @@ def _plan_deletions(
     return to_keep, to_delete
 
 
+def _plan_orphan_anonymous_deletions(
+    journals: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return all Anonymous journals from a WP that also has real-author journals.
+
+    This heuristic handles the case where broken-run Anonymous journals have
+    *different* text from the correctly-migrated real-author journals (e.g.
+    the old converter rendered ``concourse~~ci`` instead of ``concourse-ci``).
+    Text-based dedup misses these because the normalised notes don't match.
+
+    The heuristic is sound because:
+    - If a WP already has real-author journals the correct migration has run.
+    - Anonymous journals on such a WP are artifacts of pre-fix broken runs.
+    - It is safe to delete ALL Anonymous journals from such a WP.
+
+    When a WP has NO real-author journals the heuristic does not apply —
+    those Anonymous journals may be legitimately the only copies.
+
+    Returns:
+        List of Anonymous journals to delete (may be empty).
+    """
+    has_real = any(j["user_id"] != ANONYMOUS_USER_ID for j in journals)
+    if not has_real:
+        return []
+    return [j for j in journals if j["user_id"] == ANONYMOUS_USER_ID]
+
+
 def _build_fetch_script(project_key: str) -> str:
     """Ruby script to fetch all non-empty journals for WPs in the project."""
     safe_key = project_key.upper()
@@ -193,8 +229,22 @@ def run(
     apply: bool,
     logger: logging.Logger,
     op_client: Any,
+    also_delete_orphan_anonymous: bool = False,
 ) -> dict[str, int]:
     """Analyse and optionally clean up duplicate comment journals.
+
+    Args:
+        project_key: Jira/OP project key (e.g. ``NRS``).
+        apply: When ``True`` deletions are executed; when ``False`` (default)
+            the run is a dry-run — all analysis is performed but nothing is
+            deleted.
+        logger: Configured logger instance.
+        op_client: OpenProjectClient (or any object with
+            ``execute_query_to_json_file``).
+        also_delete_orphan_anonymous: When ``True``, for every WP that has
+            **both** real-author journals AND Anonymous journals, all Anonymous
+            journals are deleted regardless of whether their text matches a
+            real-author journal.  Defaults to ``False`` (opt-in).
 
     Returns:
         Dict with keys: ``wps_scanned``, ``duplicate_groups``, ``to_delete``,
@@ -202,7 +252,8 @@ def run(
 
     """
     mode = "APPLY" if apply else "DRY-RUN"
-    logger.info("Project: %s  Mode: %s", project_key, mode)
+    orphan_flag = " +orphan-anon" if also_delete_orphan_anonymous else ""
+    logger.info("Project: %s  Mode: %s%s", project_key, mode, orphan_flag)
 
     # Step 1: Fetch all non-empty journals
     logger.info("Fetching journals from OpenProject via Rails …")
@@ -236,38 +287,68 @@ def run(
         by_wp.setdefault(wp_id, []).append(j)
 
     all_to_delete: list[dict[str, Any]] = []
+    # Track IDs already scheduled for deletion to avoid double-counting when
+    # both text-based dedup AND the orphan heuristic flag the same journal.
+    to_delete_ids: set[int] = set()
     duplicate_group_count = 0
 
     for wp_id, wp_journals in by_wp.items():
-        _kept, to_delete = _plan_deletions(wp_journals)
-        if to_delete:
-            # Count the number of duplicate *groups* for this WP (each unique
-            # normalised note text that has more than one copy is one group).
-            # This is distinct from len(to_delete) which counts journals to remove.
+        wp_to_delete: list[dict[str, Any]] = []
+
+        # --- text-based dedup (always active) ---
+        _kept, text_to_delete = _plan_deletions(wp_journals)
+        for j in text_to_delete:
+            if j["id"] not in to_delete_ids:
+                wp_to_delete.append(j)
+                to_delete_ids.add(j["id"])
+
+        # Count duplicate groups (unique note texts with >1 copy for this WP)
+        if text_to_delete:
             groups: dict[str, list[dict[str, Any]]] = {}
             for j in wp_journals:
                 key = _strip_marker(j["notes"])
                 groups.setdefault(key, []).append(j)
             duplicate_group_count += sum(1 for g in groups.values() if len(g) > 1)
-            for j in to_delete:
-                reason = "Anonymous-author duplicate" if j["user_id"] == ANONYMOUS_USER_ID else "duplicate"
-                logger.info(
-                    "  [%s] WP#%d  Journal#%d  user_id=%d  created_at=%s  reason=%s",
-                    "DELETE" if apply else "WOULD DELETE",
-                    wp_id,
-                    j["id"],
-                    j["user_id"],
-                    j["created_at"],
-                    reason,
-                )
-                all_to_delete.append(j)
+
+        # --- orphan-anonymous heuristic (opt-in) ---
+        if also_delete_orphan_anonymous:
+            orphans = _plan_orphan_anonymous_deletions(wp_journals)
+            for j in orphans:
+                if j["id"] not in to_delete_ids:
+                    wp_to_delete.append(j)
+                    to_delete_ids.add(j["id"])
+
+        for j in wp_to_delete:
+            if j["user_id"] == ANONYMOUS_USER_ID and also_delete_orphan_anonymous:
+                # Check whether this was already flagged by text-based dedup or
+                # only by the orphan heuristic.
+                text_delete_ids = {x["id"] for x in text_to_delete}
+                if j["id"] not in text_delete_ids:
+                    reason = "Anonymous-orphan (WP also has real-author journals)"
+                else:
+                    reason = "Anonymous-author duplicate"
+            elif j["user_id"] == ANONYMOUS_USER_ID:
+                reason = "Anonymous-author duplicate"
+            else:
+                reason = "duplicate"
+
+            logger.info(
+                "  [%s] WP#%d  Journal#%d  user_id=%d  created_at=%s  reason=%s",
+                "DELETE" if apply else "WOULD DELETE",
+                wp_id,
+                j["id"],
+                j["user_id"],
+                j["created_at"],
+                reason,
+            )
+            all_to_delete.append(j)
 
     total_journals = len(journals_raw)
     total_to_delete = len(all_to_delete)
     logger.info(
-        "Summary: %d journals scanned, %d WPs with duplicates, %d journals to delete",
+        "Summary: %d journals scanned, %d WPs with deletions planned, %d journals to delete",
         total_journals,
-        len([wp for wp in by_wp.values() if any(j in all_to_delete for j in wp)]),
+        len({j["wp_id"] for j in all_to_delete}),
         total_to_delete,
     )
 
@@ -332,6 +413,19 @@ def main(argv: list[str] | None = None) -> int:
         dest="dry_run",
         help="Analyse and report only; do not delete (this is the default).",
     )
+    parser.add_argument(
+        "--also-delete-orphan-anonymous",
+        action="store_true",
+        default=False,
+        dest="also_delete_orphan_anonymous",
+        help=(
+            "For every WP that has both real-author journals AND Anonymous journals, "
+            "delete ALL Anonymous journals regardless of content similarity.  "
+            "This handles the case where broken-run renderers produced different text "
+            "so text-based dedup misses the duplicates.  "
+            "Off by default — operator must explicitly opt in."
+        ),
+    )
     args = parser.parse_args(argv)
 
     project_key = args.project_key.upper()
@@ -357,6 +451,7 @@ def main(argv: list[str] | None = None) -> int:
             apply=args.apply,
             logger=logger,
             op_client=op_client,
+            also_delete_orphan_anonymous=args.also_delete_orphan_anonymous,
         )
     except Exception as exc:
         logger.error("Fatal: %s", exc)

--- a/scripts/cleanup_anonymous_comment_duplicates.py
+++ b/scripts/cleanup_anonymous_comment_duplicates.py
@@ -28,10 +28,14 @@ This script deduplicates those journals **safely**:
 
 Additionally, when ``--also-delete-orphan-anonymous`` is passed: for every
 work package that has **both** real-author journals AND Anonymous journals,
-ALL of the Anonymous journals are deleted regardless of content similarity.
-This handles the case where the broken-run renderer produced different text
-(e.g. ``concourse~~ci`` vs ``concourse-ci``) so text-based dedup would not
-catch the duplicate.
+Anonymous journals that are **older** than the earliest real-author journal
+are deleted regardless of content similarity.  Anonymous journals that
+post-date (or share the timestamp of) the earliest real-author journal are
+kept — they may be legitimate comments from deactivated or unmapped Jira
+users.  This tightened heuristic handles the case where the broken-run
+renderer produced different text (e.g. ``concourse~~ci`` vs ``concourse-ci``)
+so text-based dedup would not catch the duplicate, while avoiding false
+deletions of legitimate newer Anonymous comments.
 
 Defaults to ``--dry-run``.  Deletion requires explicit ``--apply``.
 ``--also-delete-orphan-anonymous`` is opt-in (not the default).
@@ -157,17 +161,21 @@ def _plan_deletions(
 def _plan_orphan_anonymous_deletions(
     journals: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Return all Anonymous journals from a WP that also has real-author journals.
+    """Return Anonymous journals from a WP that are OLDER than the earliest real-author journal.
 
-    This heuristic handles the case where broken-run Anonymous journals have
-    *different* text from the correctly-migrated real-author journals (e.g.
-    the old converter rendered ``concourse~~ci`` instead of ``concourse-ci``).
-    Text-based dedup misses these because the normalised notes don't match.
+    This tightened heuristic handles the case where broken-run Anonymous
+    journals have *different* text from the correctly-migrated real-author
+    journals (e.g. the old converter rendered ``concourse~~ci`` instead of
+    ``concourse-ci``).  Text-based dedup misses these because the normalised
+    notes don't match.
 
     The heuristic is sound because:
     - If a WP already has real-author journals the correct migration has run.
-    - Anonymous journals on such a WP are artifacts of pre-fix broken runs.
-    - It is safe to delete ALL Anonymous journals from such a WP.
+    - Anonymous journals that PRE-DATE the earliest real-author journal are
+      artifacts of the pre-fix broken runs and can safely be deleted.
+    - Anonymous journals that POST-DATE (or share the same timestamp as) the
+      earliest real-author journal may be legitimate comments from deactivated
+      or unmapped Jira users — they are KEPT.
 
     When a WP has NO real-author journals the heuristic does not apply —
     those Anonymous journals may be legitimately the only copies.
@@ -175,10 +183,15 @@ def _plan_orphan_anonymous_deletions(
     Returns:
         List of Anonymous journals to delete (may be empty).
     """
-    has_real = any(j["user_id"] != ANONYMOUS_USER_ID for j in journals)
-    if not has_real:
+    real_timestamps = [j["created_at"] for j in journals if j["user_id"] != ANONYMOUS_USER_ID]
+    if not real_timestamps:
+        # No real-author journals → heuristic does not apply.
         return []
-    return [j for j in journals if j["user_id"] == ANONYMOUS_USER_ID]
+
+    earliest_real = min(real_timestamps)
+    # Only delete Anonymous journals that are strictly older than the earliest
+    # real-author journal.  Journals at the same timestamp or newer are kept.
+    return [j for j in journals if j["user_id"] == ANONYMOUS_USER_ID and j["created_at"] < earliest_real]
 
 
 def _build_fetch_script(project_key: str) -> str:
@@ -242,9 +255,12 @@ def run(
         op_client: OpenProjectClient (or any object with
             ``execute_query_to_json_file``).
         also_delete_orphan_anonymous: When ``True``, for every WP that has
-            **both** real-author journals AND Anonymous journals, all Anonymous
-            journals are deleted regardless of whether their text matches a
-            real-author journal.  Defaults to ``False`` (opt-in).
+            **both** real-author journals AND Anonymous journals, Anonymous
+            journals that are **older** than the earliest real-author journal
+            are deleted regardless of whether their text matches a real-author
+            journal.  Anonymous journals newer-than or equal-to the earliest
+            real-author journal are kept (they may be legitimate comments from
+            deactivated/unmapped Jira users).  Defaults to ``False`` (opt-in).
 
     Returns:
         Dict with keys: ``wps_scanned``, ``duplicate_groups``, ``to_delete``,
@@ -420,7 +436,11 @@ def main(argv: list[str] | None = None) -> int:
         dest="also_delete_orphan_anonymous",
         help=(
             "For every WP that has both real-author journals AND Anonymous journals, "
-            "delete ALL Anonymous journals regardless of content similarity.  "
+            "delete Anonymous journals that are OLDER than the earliest real-author "
+            "journal, regardless of content similarity.  "
+            "Anonymous journals newer-than or equal-to the earliest real-author "
+            "journal are kept (may be legitimate comments from deactivated/unmapped "
+            "Jira users).  "
             "This handles the case where broken-run renderers produced different text "
             "so text-based dedup misses the duplicates.  "
             "Off by default — operator must explicitly opt in."

--- a/tests/unit/test_backfill_comment_provenance_markers.py
+++ b/tests/unit/test_backfill_comment_provenance_markers.py
@@ -13,10 +13,7 @@ Specifically:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, call, patch
-
-import pytest
-
+from unittest.mock import MagicMock
 
 # ---------------------------------------------------------------------------
 # Helpers – minimal fake objects that mimic the data shapes the script uses.
@@ -160,7 +157,8 @@ class TestPairJournalsWithComments:
 
     def test_already_marked_journals_excluded(self) -> None:
         """Journals already carrying a provenance marker are excluded from pairing
-        (they are already idempotent — nothing to do)."""
+        (they are already idempotent — nothing to do).
+        """
         m = _import_module()
         user_mapping = {"acc-bjoern": 61}
         jira_comments = [
@@ -239,16 +237,15 @@ class TestBackfillRunFunction:
         # The fetch query may be called, but the update query must NOT be called
         for call_args in mock_op.execute_query_to_json_file.call_args_list:
             script: str = call_args[0][0]
-            assert "update_columns" not in script, (
-                "dry_run=True must never emit an update_columns Rails call"
-            )
+            assert "update_columns" not in script, "dry_run=True must never emit an update_columns Rails call"
 
         assert stats["updated"] == 0
         assert stats["would_update"] == 4
 
     def test_apply_mode_fires_update_columns(self) -> None:
         """dry_run=False (apply) must call execute_query_to_json_file with
-        update_columns for each WP that needs markers."""
+        update_columns for each WP that needs markers.
+        """
         m = _import_module()
         mock_op = MagicMock()
         mock_jira = MagicMock()
@@ -401,7 +398,8 @@ class TestBackfillRunFunction:
 
     def test_update_script_contains_journal_ids_and_markers(self) -> None:
         """The update_columns Rails script must reference the journal IDs and
-        embed the correct provenance marker strings."""
+        embed the correct provenance marker strings.
+        """
         m = _import_module()
         mock_op = MagicMock()
         mock_jira = MagicMock()
@@ -441,6 +439,5 @@ class TestBackfillRunFunction:
         assert "jc42" in script
         # Must NOT use .save or wp.save (would create a new journal version)
         assert ".save" not in script.replace("update_columns", ""), (
-            "Marker backfill must use update_columns, not save/save! "
-            "(save creates new journal versions)"
+            "Marker backfill must use update_columns, not save/save! (save creates new journal versions)"
         )

--- a/tests/unit/test_backfill_comment_provenance_markers.py
+++ b/tests/unit/test_backfill_comment_provenance_markers.py
@@ -1,0 +1,446 @@
+"""Unit tests for scripts/backfill_comment_provenance_markers.py.
+
+Tests the pure-Python pairing and validation logic without hitting Rails or Jira.
+Specifically:
+- Happy path: N OP journals + N Jira comments, author matches → N marker updates.
+- Count mismatch: 3 OP journals vs 4 Jira comments → SKIP + WARNING.
+- Author mismatch: one pair has wrong author → SKIP + WARNING.
+- Idempotent: OP journals already carry markers → no-op.
+- Dry-run: mutate=False → no Rails write calls.
+- Apply mode: mutate=True → Rails update_columns calls fired.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers – minimal fake objects that mimic the data shapes the script uses.
+# ---------------------------------------------------------------------------
+
+
+def _jira_comment(
+    comment_id: str,
+    account_id: str,
+    body: str = "Some comment body",
+) -> dict[str, Any]:
+    """Fake Jira comment dict (post-fetch, fields already extracted)."""
+    return {
+        "id": comment_id,
+        "author_account_id": account_id,
+        "body": body,
+    }
+
+
+def _op_journal(
+    journal_id: int,
+    wp_id: int,
+    user_id: int,
+    notes: str,
+    created_at: str = "2026-05-09T10:00:00Z",
+) -> dict[str, Any]:
+    """Fake OP journal dict as returned by the Rails query."""
+    return {
+        "id": journal_id,
+        "wp_id": wp_id,
+        "user_id": user_id,
+        "notes": notes,
+        "created_at": created_at,
+    }
+
+
+def _make_logger() -> MagicMock:
+    logger = MagicMock()
+    logger.info = MagicMock()
+    logger.warning = MagicMock()
+    logger.error = MagicMock()
+    logger.debug = MagicMock()
+    return logger
+
+
+# ---------------------------------------------------------------------------
+# Import helper (deferred to avoid import-time side effects)
+# ---------------------------------------------------------------------------
+
+
+def _import_module():
+    from scripts import backfill_comment_provenance_markers as m
+
+    return m
+
+
+# ---------------------------------------------------------------------------
+# _pair_journals_with_comments
+# ---------------------------------------------------------------------------
+
+
+class TestPairJournalsWithComments:
+    """Unit tests for the pure pairing logic."""
+
+    def test_happy_path_4x4_all_match(self) -> None:
+        m = _import_module()
+        # user_mapping: jira_account_id → op_user_id
+        user_mapping = {
+            "acc-bjoern": 61,
+            "acc-mikhail": 281,
+            "acc-anna": 300,
+            "acc-peter": 400,
+        }
+        jira_comments = [
+            _jira_comment("c1", "acc-bjoern"),
+            _jira_comment("c2", "acc-mikhail"),
+            _jira_comment("c3", "acc-anna"),
+            _jira_comment("c4", "acc-peter"),
+        ]
+        op_journals = [
+            _op_journal(101, 5040, 61, "Comment 1", "2026-05-09T10:01:00Z"),
+            _op_journal(102, 5040, 281, "Comment 2", "2026-05-09T10:02:00Z"),
+            _op_journal(103, 5040, 300, "Comment 3", "2026-05-09T10:03:00Z"),
+            _op_journal(104, 5040, 400, "Comment 4", "2026-05-09T10:04:00Z"),
+        ]
+        pairs, skip_reason = m._pair_journals_with_comments(
+            op_journals=op_journals,
+            jira_comments=jira_comments,
+            user_mapping=user_mapping,
+        )
+        assert skip_reason is None
+        assert len(pairs) == 4
+        # Verify pairings are in order
+        assert pairs[0] == (op_journals[0], jira_comments[0])
+        assert pairs[3] == (op_journals[3], jira_comments[3])
+
+    def test_count_mismatch_3_op_4_jira_skips(self) -> None:
+        m = _import_module()
+        user_mapping: dict[str, int] = {"acc-bjoern": 61}
+        jira_comments = [
+            _jira_comment("c1", "acc-bjoern"),
+            _jira_comment("c2", "acc-bjoern"),
+            _jira_comment("c3", "acc-bjoern"),
+            _jira_comment("c4", "acc-bjoern"),
+        ]
+        op_journals = [
+            _op_journal(101, 5040, 61, "Comment 1"),
+            _op_journal(102, 5040, 61, "Comment 2"),
+            _op_journal(103, 5040, 61, "Comment 3"),
+        ]
+        pairs, skip_reason = m._pair_journals_with_comments(
+            op_journals=op_journals,
+            jira_comments=jira_comments,
+            user_mapping=user_mapping,
+        )
+        assert pairs == []
+        assert skip_reason is not None
+        assert "count" in skip_reason.lower() or "mismatch" in skip_reason.lower()
+
+    def test_author_mismatch_one_pair_skips_whole_wp(self) -> None:
+        """If any author pair mismatches the whole WP is skipped (safe > throughput)."""
+        m = _import_module()
+        user_mapping = {"acc-bjoern": 61, "acc-mikhail": 281}
+        jira_comments = [
+            _jira_comment("c1", "acc-bjoern"),
+            _jira_comment("c2", "acc-mikhail"),
+        ]
+        op_journals = [
+            _op_journal(101, 5040, 61, "Comment 1"),
+            # Wrong user: journal says user_id=999 but Jira says acc-mikhail → op 281
+            _op_journal(102, 5040, 999, "Comment 2"),
+        ]
+        pairs, skip_reason = m._pair_journals_with_comments(
+            op_journals=op_journals,
+            jira_comments=jira_comments,
+            user_mapping=user_mapping,
+        )
+        assert pairs == []
+        assert skip_reason is not None
+        assert "author" in skip_reason.lower() or "mismatch" in skip_reason.lower()
+
+    def test_already_marked_journals_excluded(self) -> None:
+        """Journals already carrying a provenance marker are excluded from pairing
+        (they are already idempotent — nothing to do)."""
+        m = _import_module()
+        user_mapping = {"acc-bjoern": 61}
+        jira_comments = [
+            _jira_comment("c1", "acc-bjoern"),
+        ]
+        op_journals = [
+            # Already has a marker
+            _op_journal(
+                101,
+                5040,
+                61,
+                "Comment body\n<!-- j2o:jira-comment-id:c1 -->",
+            ),
+        ]
+        pairs, skip_reason = m._pair_journals_with_comments(
+            op_journals=op_journals,
+            jira_comments=jira_comments,
+            user_mapping=user_mapping,
+        )
+        # All journals already marked → nothing to pair, but it's not an error
+        assert pairs == []
+        assert skip_reason is None
+
+
+# ---------------------------------------------------------------------------
+# run() — integration with mocked Rails + Jira
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillRunFunction:
+    """Integration tests for the run() function with mocked external calls."""
+
+    def _make_wp_mapping(self) -> list[dict[str, Any]]:
+        """Return a minimal WP mapping list (project_key NRS, one WP)."""
+        return [
+            {
+                "jira_key": "NRS-4391",
+                "openproject_id": 5040,
+                "project_key": "NRS",
+            }
+        ]
+
+    def test_dry_run_no_rails_writes(self) -> None:
+        """dry_run=True must not call the Rails update_columns script."""
+        m = _import_module()
+        mock_op = MagicMock()
+        mock_jira = MagicMock()
+
+        # Rails returns 4 journals (no markers), Jira returns 4 comments
+        mock_op.execute_query_to_json_file.return_value = {
+            "journals": [
+                _op_journal(101, 5040, 61, "B1", "2026-05-09T10:01:00Z"),
+                _op_journal(102, 5040, 281, "B2", "2026-05-09T10:02:00Z"),
+                _op_journal(103, 5040, 61, "B3", "2026-05-09T10:03:00Z"),
+                _op_journal(104, 5040, 281, "B4", "2026-05-09T10:04:00Z"),
+            ]
+        }
+        mock_jira.return_value = [
+            _jira_comment("c1", "acc-bjoern"),
+            _jira_comment("c2", "acc-mikhail"),
+            _jira_comment("c3", "acc-bjoern"),
+            _jira_comment("c4", "acc-mikhail"),
+        ]
+
+        user_mapping = {"acc-bjoern": 61, "acc-mikhail": 281}
+
+        stats = m.run(
+            wp_mapping=self._make_wp_mapping(),
+            user_mapping=user_mapping,
+            fetch_jira_comments=mock_jira,
+            op_client=mock_op,
+            dry_run=True,
+            logger=_make_logger(),
+        )
+
+        # The fetch query may be called, but the update query must NOT be called
+        for call_args in mock_op.execute_query_to_json_file.call_args_list:
+            script: str = call_args[0][0]
+            assert "update_columns" not in script, (
+                "dry_run=True must never emit an update_columns Rails call"
+            )
+
+        assert stats["updated"] == 0
+        assert stats["would_update"] == 4
+
+    def test_apply_mode_fires_update_columns(self) -> None:
+        """dry_run=False (apply) must call execute_query_to_json_file with
+        update_columns for each WP that needs markers."""
+        m = _import_module()
+        mock_op = MagicMock()
+        mock_jira = MagicMock()
+
+        fetch_result = {
+            "journals": [
+                _op_journal(101, 5040, 61, "Björn comment 1", "2026-05-09T10:01:00Z"),
+                _op_journal(102, 5040, 281, "Mikhail comment", "2026-05-09T10:02:00Z"),
+                _op_journal(103, 5040, 61, "Björn comment 2", "2026-05-09T10:03:00Z"),
+                _op_journal(104, 5040, 61, "Björn comment 3", "2026-05-09T10:04:00Z"),
+            ]
+        }
+        update_result = {"updated": 4}
+
+        def side_effect(script: str):
+            if "update_columns" in script:
+                return update_result
+            return fetch_result
+
+        mock_op.execute_query_to_json_file.side_effect = side_effect
+
+        mock_jira.return_value = [
+            _jira_comment("jc1", "acc-bjoern"),
+            _jira_comment("jc2", "acc-mikhail"),
+            _jira_comment("jc3", "acc-bjoern"),
+            _jira_comment("jc4", "acc-bjoern"),
+        ]
+
+        user_mapping = {"acc-bjoern": 61, "acc-mikhail": 281}
+
+        stats = m.run(
+            wp_mapping=self._make_wp_mapping(),
+            user_mapping=user_mapping,
+            fetch_jira_comments=mock_jira,
+            op_client=mock_op,
+            dry_run=False,
+            logger=_make_logger(),
+        )
+
+        assert stats["updated"] > 0
+        # At least one call must contain update_columns
+        scripts = [c[0][0] for c in mock_op.execute_query_to_json_file.call_args_list]
+        assert any("update_columns" in s for s in scripts), (
+            "Expected at least one update_columns Rails call in apply mode"
+        )
+
+    def test_count_mismatch_skipped_logged(self) -> None:
+        """WP with count mismatch is skipped and a WARNING is emitted."""
+        m = _import_module()
+        mock_op = MagicMock()
+        mock_jira = MagicMock()
+
+        mock_op.execute_query_to_json_file.return_value = {
+            "journals": [
+                _op_journal(101, 5040, 61, "Comment 1"),
+                _op_journal(102, 5040, 61, "Comment 2"),
+                _op_journal(103, 5040, 61, "Comment 3"),
+            ]
+        }
+        # Jira has 4 but OP has 3
+        mock_jira.return_value = [
+            _jira_comment("c1", "acc-bjoern"),
+            _jira_comment("c2", "acc-bjoern"),
+            _jira_comment("c3", "acc-bjoern"),
+            _jira_comment("c4", "acc-bjoern"),
+        ]
+
+        logger = _make_logger()
+        stats = m.run(
+            wp_mapping=self._make_wp_mapping(),
+            user_mapping={"acc-bjoern": 61},
+            fetch_jira_comments=mock_jira,
+            op_client=mock_op,
+            dry_run=True,
+            logger=logger,
+        )
+
+        assert stats["skipped"] == 1
+        assert stats["updated"] == 0
+        assert stats["would_update"] == 0
+        warning_calls = [str(c) for c in logger.warning.call_args_list]
+        assert any("NRS-4391" in c or "5040" in c or "count" in c.lower() for c in warning_calls), (
+            "Expected a warning mentioning the WP or issue key with count mismatch"
+        )
+
+    def test_author_mismatch_skipped_logged(self) -> None:
+        """WP where one author pair mismatches is skipped with a WARNING."""
+        m = _import_module()
+        mock_op = MagicMock()
+        mock_jira = MagicMock()
+
+        mock_op.execute_query_to_json_file.return_value = {
+            "journals": [
+                _op_journal(101, 5040, 61, "Comment 1"),
+                # user_id=999 but Jira comment is by acc-mikhail → op 281
+                _op_journal(102, 5040, 999, "Comment 2"),
+            ]
+        }
+        mock_jira.return_value = [
+            _jira_comment("c1", "acc-bjoern"),
+            _jira_comment("c2", "acc-mikhail"),
+        ]
+
+        logger = _make_logger()
+        stats = m.run(
+            wp_mapping=self._make_wp_mapping(),
+            user_mapping={"acc-bjoern": 61, "acc-mikhail": 281},
+            fetch_jira_comments=mock_jira,
+            op_client=mock_op,
+            dry_run=True,
+            logger=logger,
+        )
+
+        assert stats["skipped"] == 1
+        assert stats["would_update"] == 0
+        warning_calls = [str(c) for c in logger.warning.call_args_list]
+        assert any("author" in c.lower() or "mismatch" in c.lower() for c in warning_calls), (
+            "Expected a warning mentioning author mismatch"
+        )
+
+    def test_already_marked_journals_are_noop(self) -> None:
+        """WP whose OP journals already carry provenance markers → no updates, no warnings."""
+        m = _import_module()
+        mock_op = MagicMock()
+        mock_jira = MagicMock()
+
+        mock_op.execute_query_to_json_file.return_value = {
+            # All journals already carry markers — returned as empty by the fetch
+            # (the Rails query filters out already-marked journals)
+            "journals": []
+        }
+        mock_jira.return_value = [
+            _jira_comment("c1", "acc-bjoern"),
+        ]
+
+        logger = _make_logger()
+        stats = m.run(
+            wp_mapping=self._make_wp_mapping(),
+            user_mapping={"acc-bjoern": 61},
+            fetch_jira_comments=mock_jira,
+            op_client=mock_op,
+            dry_run=True,
+            logger=logger,
+        )
+
+        assert stats["would_update"] == 0
+        assert stats["updated"] == 0
+        # No warnings for already-clean WPs
+        assert logger.warning.call_count == 0
+
+    def test_update_script_contains_journal_ids_and_markers(self) -> None:
+        """The update_columns Rails script must reference the journal IDs and
+        embed the correct provenance marker strings."""
+        m = _import_module()
+        mock_op = MagicMock()
+        mock_jira = MagicMock()
+
+        fetch_result = {
+            "journals": [
+                _op_journal(101, 5040, 61, "Björn note", "2026-05-09T10:01:00Z"),
+            ]
+        }
+
+        captured_scripts: list[str] = []
+
+        def capture_side_effect(script: str):
+            captured_scripts.append(script)
+            if "update_columns" in script:
+                return {"updated": 1}
+            return fetch_result
+
+        mock_op.execute_query_to_json_file.side_effect = capture_side_effect
+        mock_jira.return_value = [_jira_comment("jc42", "acc-bjoern")]
+
+        m.run(
+            wp_mapping=self._make_wp_mapping(),
+            user_mapping={"acc-bjoern": 61},
+            fetch_jira_comments=mock_jira,
+            op_client=mock_op,
+            dry_run=False,
+            logger=_make_logger(),
+        )
+
+        update_scripts = [s for s in captured_scripts if "update_columns" in s]
+        assert len(update_scripts) == 1
+        script = update_scripts[0]
+        # Must reference the journal id
+        assert "101" in script
+        # Must embed the Jira comment id in the marker
+        assert "jc42" in script
+        # Must NOT use .save or wp.save (would create a new journal version)
+        assert ".save" not in script.replace("update_columns", ""), (
+            "Marker backfill must use update_columns, not save/save! "
+            "(save creates new journal versions)"
+        )

--- a/tests/unit/test_backfill_comment_provenance_markers.py
+++ b/tests/unit/test_backfill_comment_provenance_markers.py
@@ -12,6 +12,9 @@ Specifically:
 
 from __future__ import annotations
 
+import logging
+import tempfile
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -323,7 +326,7 @@ class TestBackfillRunFunction:
             logger=logger,
         )
 
-        assert stats["skipped"] == 1
+        assert stats["wps_skipped"] == 1
         assert stats["updated"] == 0
         assert stats["would_update"] == 0
         warning_calls = [str(c) for c in logger.warning.call_args_list]
@@ -359,7 +362,7 @@ class TestBackfillRunFunction:
             logger=logger,
         )
 
-        assert stats["skipped"] == 1
+        assert stats["wps_skipped"] == 1
         assert stats["would_update"] == 0
         warning_calls = [str(c) for c in logger.warning.call_args_list]
         assert any("author" in c.lower() or "mismatch" in c.lower() for c in warning_calls), (
@@ -441,3 +444,327 @@ class TestBackfillRunFunction:
         assert ".save" not in script.replace("update_columns", ""), (
             "Marker backfill must use update_columns, not save/save! (save creates new journal versions)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1: Partial backfill — all-or-nothing semantics
+# ---------------------------------------------------------------------------
+
+
+class TestPartialBackfillAllOrNothing:
+    """Regression for review comment #1.
+
+    If some OP journals already have markers but others do not (partial
+    backfill), the old positional-zip logic silently pairs the wrong journals.
+    The correct behaviour is to SKIP the WP with a clear log line
+    "partially backfilled" rather than producing incorrect pairings.
+    """
+
+    def test_partial_backfill_skipped_not_count_mismatch(self) -> None:
+        """WP with 4 Jira comments + 4 OP journals where 1 is already marked.
+
+        The already-marked journal must NOT be included in the pairing pool.
+        After excluding it, 3 unmarked journals remain but Jira has 4 comments.
+        Old code reports "count mismatch 3 vs 4" which is misleading.
+        New code must report "partially backfilled, skipping".
+        """
+        m = _import_module()
+        user_mapping = {"acc-a": 61, "acc-b": 281, "acc-c": 300, "acc-d": 400}
+        jira_comments = [
+            _jira_comment("c1", "acc-a"),
+            _jira_comment("c2", "acc-b"),
+            _jira_comment("c3", "acc-c"),
+            _jira_comment("c4", "acc-d"),
+        ]
+        # Journal 101 already has a marker (was backfilled in a prior run).
+        op_journals = [
+            _op_journal(101, 5040, 61, "Comment 1\n<!-- j2o:jira-comment-id:c1 -->", "2026-05-09T10:01:00Z"),
+            _op_journal(102, 5040, 281, "Comment 2", "2026-05-09T10:02:00Z"),
+            _op_journal(103, 5040, 300, "Comment 3", "2026-05-09T10:03:00Z"),
+            _op_journal(104, 5040, 400, "Comment 4", "2026-05-09T10:04:00Z"),
+        ]
+        pairs, skip_reason = m._pair_journals_with_comments(
+            op_journals=op_journals,
+            jira_comments=jira_comments,
+            user_mapping=user_mapping,
+        )
+        # Must be skipped (not a silent mis-pairing)
+        assert pairs == []
+        assert skip_reason is not None
+        # The skip reason must say "partially" — not "count mismatch"
+        assert "partial" in skip_reason.lower(), f"Expected 'partial' in skip_reason, got: {skip_reason!r}"
+
+    def test_all_marked_is_noop_not_partial(self) -> None:
+        """If ALL journals are already marked, the WP is clean — not a partial backfill."""
+        m = _import_module()
+        user_mapping = {"acc-a": 61}
+        jira_comments = [_jira_comment("c1", "acc-a")]
+        op_journals = [
+            _op_journal(101, 5040, 61, "Comment 1\n<!-- j2o:jira-comment-id:c1 -->"),
+        ]
+        pairs, skip_reason = m._pair_journals_with_comments(
+            op_journals=op_journals,
+            jira_comments=jira_comments,
+            user_mapping=user_mapping,
+        )
+        # All marked → no-op, not a skip
+        assert pairs == []
+        assert skip_reason is None
+
+    def test_run_logs_partial_backfill_warning(self) -> None:
+        """run() must emit a WARNING (not ERROR) for partially-backfilled WPs."""
+        m = _import_module()
+        mock_op = MagicMock()
+        mock_jira = MagicMock()
+
+        # 1 of 4 journals already has a marker
+        mock_op.execute_query_to_json_file.return_value = {
+            "journals": [
+                _op_journal(101, 5040, 61, "C1\n<!-- j2o:jira-comment-id:c1 -->", "2026-05-09T10:01:00Z"),
+                _op_journal(102, 5040, 281, "C2", "2026-05-09T10:02:00Z"),
+                _op_journal(103, 5040, 300, "C3", "2026-05-09T10:03:00Z"),
+                _op_journal(104, 5040, 400, "C4", "2026-05-09T10:04:00Z"),
+            ]
+        }
+        mock_jira.return_value = [
+            _jira_comment("c1", "acc-a"),
+            _jira_comment("c2", "acc-b"),
+            _jira_comment("c3", "acc-c"),
+            _jira_comment("c4", "acc-d"),
+        ]
+
+        logger = _make_logger()
+        stats = m.run(
+            wp_mapping=[{"jira_key": "NRS-4391", "openproject_id": 5040, "project_key": "NRS"}],
+            user_mapping={"acc-a": 61, "acc-b": 281, "acc-c": 300, "acc-d": 400},
+            fetch_jira_comments=mock_jira,
+            op_client=mock_op,
+            dry_run=True,
+            logger=logger,
+        )
+
+        assert stats["wps_skipped"] == 1
+        assert stats["would_update"] == 0
+        warning_calls = [str(c) for c in logger.warning.call_args_list]
+        assert any("partial" in c.lower() for c in warning_calls), (
+            f"Expected warning mentioning 'partial', got: {warning_calls}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #2: _load_user_mapping schema — index by entry fields
+# ---------------------------------------------------------------------------
+
+
+class TestLoadUserMappingSchema:
+    """Regression for review comment #2.
+
+    user_mapping.json is keyed by display name (outer key), but comments
+    carry jira_key (e.g. JIRAUSER12345) as their author identifier.
+    _load_user_mapping must index by jira_key, jira_name, jira_display_name,
+    and jira_email from the entry values — not by the outer key alone.
+    """
+
+    def _write_user_mapping(self, path: Path, data: dict) -> None:
+        import json
+
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    def test_lookup_by_jira_key(self) -> None:
+        """A Jira comment whose author_account_id == jira_key resolves correctly."""
+        m = _import_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir)
+            self._write_user_mapping(
+                p / "user_mapping.json",
+                {
+                    "Anne Sophie Geißler": {
+                        "jira_display_name": "Anne Sophie Geißler",
+                        "jira_email": "anne.geissler@netresearch.de",
+                        "jira_key": "JIRAUSER18400",
+                        "jira_name": "anne.geissler",
+                        "matched_by": "user_mapping_backfill_alias",
+                        "openproject_id": 48,
+                    }
+                },
+            )
+            result = m._load_user_mapping(p)
+        # Must be findable by jira_key
+        assert "JIRAUSER18400" in result, (
+            f"Expected 'JIRAUSER18400' in user_mapping lookup, got keys: {list(result.keys())[:10]}"
+        )
+        assert result["JIRAUSER18400"] == 48
+
+    def test_lookup_by_jira_name(self) -> None:
+        """A Jira comment whose author is identified by jira_name resolves correctly."""
+        m = _import_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir)
+            self._write_user_mapping(
+                p / "user_mapping.json",
+                {
+                    "Some User": {
+                        "jira_display_name": "Some User",
+                        "jira_email": "some.user@example.com",
+                        "jira_key": "JIRAUSER99999",
+                        "jira_name": "some.user",
+                        "openproject_id": 77,
+                    }
+                },
+            )
+            result = m._load_user_mapping(p)
+        assert "some.user" in result, f"Expected 'some.user' in user_mapping lookup, got keys: {list(result.keys())}"
+        assert result["some.user"] == 77
+
+    def test_lookup_by_display_name(self) -> None:
+        """A Jira comment whose author is identified by display name resolves correctly."""
+        m = _import_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir)
+            self._write_user_mapping(
+                p / "user_mapping.json",
+                {
+                    "Display Name User": {
+                        "jira_display_name": "Display Name User",
+                        "jira_email": "display@example.com",
+                        "jira_key": "JIRAUSER77777",
+                        "jira_name": "display.user",
+                        "openproject_id": 55,
+                    }
+                },
+            )
+            result = m._load_user_mapping(p)
+        assert "Display Name User" in result, (
+            f"Expected 'Display Name User' in user_mapping lookup, got keys: {list(result.keys())}"
+        )
+        assert result["Display Name User"] == 55
+
+    def test_outer_key_also_indexed(self) -> None:
+        """When the outer key is the jira_key (e.g. 'JIRAUSER13400'), it must still resolve."""
+        m = _import_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir)
+            self._write_user_mapping(
+                p / "user_mapping.json",
+                {
+                    "JIRAUSER13400": {
+                        "jira_key": "JIRAUSER13400",
+                        "jira_name": "maria.haeglsperger",
+                        "jira_display_name": "Maria Haeglsperger",
+                        "jira_email": "maria.haeglsperger@axalta.com",
+                        "openproject_id": 232,
+                    }
+                },
+            )
+            result = m._load_user_mapping(p)
+        assert "JIRAUSER13400" in result
+        assert result["JIRAUSER13400"] == 232
+
+    def test_author_account_id_resolves_via_jira_key(self) -> None:
+        """End-to-end: _pair_journals_with_comments resolves author via jira_key lookup."""
+        m = _import_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir)
+            self._write_user_mapping(
+                p / "user_mapping.json",
+                {
+                    "Anne Sophie Geißler": {
+                        "jira_display_name": "Anne Sophie Geißler",
+                        "jira_email": "anne.geissler@netresearch.de",
+                        "jira_key": "JIRAUSER18400",
+                        "jira_name": "anne.geissler",
+                        "openproject_id": 48,
+                    }
+                },
+            )
+            user_mapping = m._load_user_mapping(p)
+
+        # The Jira comment has author_account_id == jira_key value
+        jira_comments = [_jira_comment("c1", "JIRAUSER18400")]
+        op_journals = [_op_journal(101, 5040, 48, "Comment body")]
+
+        pairs, skip_reason = m._pair_journals_with_comments(
+            op_journals=op_journals,
+            jira_comments=jira_comments,
+            user_mapping=user_mapping,
+        )
+        assert skip_reason is None, (
+            f"Expected successful pairing, got skip_reason={skip_reason!r}. "
+            f"user_mapping keys: {list(user_mapping.keys())[:10]}"
+        )
+        assert len(pairs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #6: stats dict key consistency — docstring vs code
+# ---------------------------------------------------------------------------
+
+
+class TestStatsKeyConsistency:
+    """Regression for review comment #6.
+
+    run() docstring lists 'wps_skipped' but code uses 'skipped'.
+    Either the code or docstring must be aligned.
+    """
+
+    def test_returned_stats_has_documented_keys(self) -> None:
+        """run() must return all keys documented in its docstring."""
+        m = _import_module()
+        mock_op = MagicMock()
+        mock_op.execute_query_to_json_file.return_value = {"journals": []}
+        mock_jira = MagicMock()
+        mock_jira.return_value = []
+
+        stats = m.run(
+            wp_mapping=[{"jira_key": "NRS-1", "openproject_id": 1, "project_key": "NRS"}],
+            user_mapping={},
+            fetch_jira_comments=mock_jira,
+            op_client=mock_op,
+            dry_run=True,
+            logger=_make_logger(),
+        )
+
+        # Docstring says: wps_processed, wps_skipped, would_update, updated, errors
+        # After fix, code and docstring must agree. Test that the documented key exists.
+        expected_keys = {"wps_processed", "wps_skipped", "would_update", "updated", "errors"}
+        actual_keys = set(stats.keys())
+        assert expected_keys == actual_keys, f"Stats keys mismatch. Expected: {expected_keys}, got: {actual_keys}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #7: _setup_logging idempotency (handler duplication)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupLoggingIdempotent:
+    """Regression for review comment #7.
+
+    Calling _setup_logging twice on the same logger must NOT add duplicate
+    handlers. The handler count must stay at 2 (stream + file) after
+    the second call.
+    """
+
+    def test_double_invocation_no_handler_duplication(self) -> None:
+        m = _import_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "test.log"
+            logger1 = m._setup_logging(log_path)
+            handler_count_after_first = len(logger1.handlers)
+
+            logger2 = m._setup_logging(log_path)
+            handler_count_after_second = len(logger2.handlers)
+
+        # Same logger object returned both times
+        assert logger1 is logger2
+        assert handler_count_after_second == handler_count_after_first, (
+            f"Handler count grew from {handler_count_after_first} to "
+            f"{handler_count_after_second} on second call — duplicate handlers added"
+        )
+
+    def teardown_method(self, _method) -> None:
+        # Close and remove all handlers to avoid cross-test pollution and
+        # to prevent ResourceWarning from unclosed FileHandler file objects.
+        logger = logging.getLogger("backfill_comment_provenance")
+        for h in list(logger.handlers):
+            h.close()
+            logger.removeHandler(h)

--- a/tests/unit/test_cleanup_anonymous_comment_duplicates.py
+++ b/tests/unit/test_cleanup_anonymous_comment_duplicates.py
@@ -467,3 +467,202 @@ class TestDuplicateGroupMetric:
             f"Expected 3 duplicate groups (one per WP), got {stats['duplicate_groups']}. "
             f"duplicate_groups must count groups, not individual journals to delete."
         )
+
+
+# ---------------------------------------------------------------------------
+# --also-delete-orphan-anonymous flag
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanAnonymousDeletion:
+    """Tests for the --also-delete-orphan-anonymous flag.
+
+    When a WP has *both* real-author journals AND Anonymous journals, the
+    Anonymous ones are artifacts of broken pre-fix migration runs.  When the
+    flag is set, every Anonymous journal in such a WP should be deleted
+    regardless of content similarity.
+
+    When the flag is NOT set the existing text-based dedup logic is the only
+    cleanup path (existing behaviour is unchanged).
+    """
+
+    def _make_logger(self) -> MagicMock:
+        logger = MagicMock()
+        logger.info = MagicMock()
+        logger.error = MagicMock()
+        logger.warning = MagicMock()
+        return logger
+
+    def test_flag_set_wp_with_real_and_anon_deletes_all_anon(self) -> None:
+        """WP with 1 real + 2 anonymous + flag → 2 deletions, 1 kept."""
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        ANON = 2
+        mock_op = MagicMock()
+        mock_op.execute_query_to_json_file.return_value = {
+            "project_id": 1,
+            "wp_ids_count": 1,
+            "journals": [
+                _journal(1, 5040, ANON, "concourse~~ci", "2026-05-07T09:00:00Z"),
+                _journal(2, 5040, ANON, "concourse-ci -~~f 30 ~~", "2026-05-07T10:00:00Z"),
+                _journal(3, 5040, 61, "concourse-ci -f 30 -", "2026-05-09T10:00:00Z"),
+            ],
+        }
+
+        stats = run(
+            "NRS",
+            apply=False,
+            logger=self._make_logger(),
+            op_client=mock_op,
+            also_delete_orphan_anonymous=True,
+        )
+
+        assert stats["to_delete"] == 2
+        assert stats["deleted"] == 0  # dry-run
+
+    def test_flag_set_wp_with_only_anon_no_extra_deletions(self) -> None:
+        """WP with only anonymous journals (no real) + flag → no orphan deletions
+        (existing text-based logic only — no real author present to displace them)."""
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        ANON = 2
+        mock_op = MagicMock()
+        mock_op.execute_query_to_json_file.return_value = {
+            "project_id": 1,
+            "wp_ids_count": 1,
+            "journals": [
+                _journal(1, 5040, ANON, "unique note A", "2026-05-07T09:00:00Z"),
+                _journal(2, 5040, ANON, "unique note B", "2026-05-07T10:00:00Z"),
+            ],
+        }
+
+        stats = run(
+            "NRS",
+            apply=False,
+            logger=self._make_logger(),
+            op_client=mock_op,
+            also_delete_orphan_anonymous=True,
+        )
+
+        # No real-author journals → orphan heuristic does NOT apply.
+        assert stats["to_delete"] == 0
+
+    def test_flag_set_wp_with_only_real_no_deletions(self) -> None:
+        """WP with only real-author journals + flag → no deletions."""
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        mock_op = MagicMock()
+        mock_op.execute_query_to_json_file.return_value = {
+            "project_id": 1,
+            "wp_ids_count": 1,
+            "journals": [
+                _journal(1, 5040, 61, "First real comment", "2026-05-09T09:00:00Z"),
+                _journal(2, 5040, 281, "Second real comment", "2026-05-09T10:00:00Z"),
+            ],
+        }
+
+        stats = run(
+            "NRS",
+            apply=False,
+            logger=self._make_logger(),
+            op_client=mock_op,
+            also_delete_orphan_anonymous=True,
+        )
+
+        assert stats["to_delete"] == 0
+
+    def test_flag_not_set_uses_only_text_based_dedup(self) -> None:
+        """Without --also-delete-orphan-anonymous, the divergent-text anon journals
+        are NOT deleted (existing behaviour).  Only exact-match (after marker strip)
+        duplicates are removed."""
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        ANON = 2
+        mock_op = MagicMock()
+        mock_op.execute_query_to_json_file.return_value = {
+            "project_id": 1,
+            "wp_ids_count": 1,
+            "journals": [
+                # These two anon notes differ from the real one — no text match.
+                _journal(1, 5040, ANON, "concourse~~ci", "2026-05-07T09:00:00Z"),
+                _journal(2, 5040, ANON, "concourse-ci -~~f 30 ~~", "2026-05-07T10:00:00Z"),
+                _journal(3, 5040, 61, "concourse-ci -f 30 -", "2026-05-09T10:00:00Z"),
+            ],
+        }
+
+        stats = run(
+            "NRS",
+            apply=False,
+            logger=self._make_logger(),
+            op_client=mock_op,
+            # flag NOT set (default)
+        )
+
+        # Without the flag, text-based dedup finds 3 distinct notes → 0 deletions.
+        assert stats["to_delete"] == 0
+
+    def test_flag_set_apply_deletes_orphan_anon_journals(self) -> None:
+        """With flag + --apply, orphan Anonymous journals are actually deleted."""
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        ANON = 2
+        mock_op = MagicMock()
+        fetch_result = {
+            "project_id": 1,
+            "wp_ids_count": 1,
+            "journals": [
+                _journal(10, 5040, ANON, "broken-render-A", "2026-05-07T09:00:00Z"),
+                _journal(11, 5040, ANON, "broken-render-B", "2026-05-07T10:00:00Z"),
+                _journal(12, 5040, 61, "correct render", "2026-05-09T10:00:00Z"),
+            ],
+        }
+        delete_result = {"deleted": 2}
+        mock_op.execute_query_to_json_file.side_effect = [fetch_result, delete_result]
+
+        stats = run(
+            "NRS",
+            apply=True,
+            logger=self._make_logger(),
+            op_client=mock_op,
+            also_delete_orphan_anonymous=True,
+        )
+
+        assert stats["to_delete"] == 2
+        assert stats["deleted"] == 2
+        # Delete call must contain ids 10 and 11, NOT 12
+        delete_script: str = mock_op.execute_query_to_json_file.call_args_list[1][0][0]
+        import json as _json
+        start = delete_script.find("[")
+        end = delete_script.find("]", start) + 1
+        ids = _json.loads(delete_script[start:end])
+        assert set(ids) == {10, 11}
+
+    def test_flag_set_logs_orphan_reason(self) -> None:
+        """Orphan deletions must be logged with the reason 'Anonymous-orphan ...'."""
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        ANON = 2
+        mock_op = MagicMock()
+        mock_op.execute_query_to_json_file.return_value = {
+            "project_id": 1,
+            "wp_ids_count": 1,
+            "journals": [
+                _journal(1, 5040, ANON, "broken text", "2026-05-07T09:00:00Z"),
+                _journal(2, 5040, 61, "correct text", "2026-05-09T10:00:00Z"),
+            ],
+        }
+
+        logger = self._make_logger()
+        run(
+            "NRS",
+            apply=False,
+            logger=logger,
+            op_client=mock_op,
+            also_delete_orphan_anonymous=True,
+        )
+
+        # At least one info call must mention the orphan reason
+        info_calls = [str(call) for call in logger.info.call_args_list]
+        assert any("Anonymous-orphan" in c for c in info_calls), (
+            "Expected at least one log message containing 'Anonymous-orphan'"
+        )

--- a/tests/unit/test_cleanup_anonymous_comment_duplicates.py
+++ b/tests/unit/test_cleanup_anonymous_comment_duplicates.py
@@ -669,3 +669,126 @@ class TestOrphanAnonymousDeletion:
         assert any("Anonymous-orphan" in c for c in info_calls), (
             "Expected at least one log message containing 'Anonymous-orphan'"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #5: Tightened orphan-Anonymous heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanAnonymousTightenedHeuristic:
+    """Regression for review comment #5.
+
+    The tightened rule: only delete Anonymous journals that are OLDER than
+    the earliest real-author journal on the same WP.
+
+    Rationale: if an Anonymous journal is NEWER than all real-author journals
+    it may be a legitimately-authored Anonymous comment (deactivated/unmapped
+    user) and must be kept.
+    """
+
+    def _make_logger(self) -> MagicMock:
+        logger = MagicMock()
+        logger.info = MagicMock()
+        logger.error = MagicMock()
+        logger.warning = MagicMock()
+        return logger
+
+    def test_anon_older_than_real_is_deleted(self) -> None:
+        """3 Anonymous (2026-05-07) + 2 real-author (2026-05-09).
+
+        All 3 anonymous journals are OLDER than the earliest real-author
+        journal → tightened rule deletes them.
+        """
+        from scripts.cleanup_anonymous_comment_duplicates import _plan_orphan_anonymous_deletions
+
+        ANON = 2
+        journals = [
+            _journal(1, 5040, ANON, "Anon A", "2026-05-07T10:00:00Z"),
+            _journal(2, 5040, ANON, "Anon B", "2026-05-07T11:00:00Z"),
+            _journal(3, 5040, ANON, "Anon C", "2026-05-07T12:00:00Z"),
+            _journal(4, 5040, 61, "Real A", "2026-05-09T09:00:00Z"),
+            _journal(5, 5040, 281, "Real B", "2026-05-09T10:00:00Z"),
+        ]
+        to_delete = _plan_orphan_anonymous_deletions(journals)
+        delete_ids = {j["id"] for j in to_delete}
+        # All 3 anon journals are older than earliest real (2026-05-09T09:00:00Z)
+        assert delete_ids == {1, 2, 3}, f"Expected anon journals 1,2,3 deleted (older than real), got: {delete_ids}"
+
+    def test_anon_newer_than_real_is_kept(self) -> None:
+        """1 Anonymous (2026-05-09 12:00) + 1 real-author (2026-05-09 11:00).
+
+        The Anonymous journal is NEWER than the only real-author journal →
+        tightened rule keeps it (may be a legitimate Anonymous comment).
+        Aggressive rule would delete it — tightened rule must not.
+        """
+        from scripts.cleanup_anonymous_comment_duplicates import _plan_orphan_anonymous_deletions
+
+        ANON = 2
+        journals = [
+            _journal(1, 5040, 61, "Real comment", "2026-05-09T11:00:00Z"),
+            _journal(2, 5040, ANON, "Anon comment", "2026-05-09T12:00:00Z"),
+        ]
+        to_delete = _plan_orphan_anonymous_deletions(journals)
+        # The anon journal is newer → must NOT be deleted by tightened rule
+        delete_ids = {j["id"] for j in to_delete}
+        assert 2 not in delete_ids, (
+            "Anonymous journal newer than earliest real-author must NOT be deleted "
+            "(tightened heuristic — may be a legitimate Anonymous comment)"
+        )
+
+    def test_anon_same_timestamp_as_real_is_kept(self) -> None:
+        """Anonymous with same timestamp as earliest real-author must be kept (boundary)."""
+        from scripts.cleanup_anonymous_comment_duplicates import _plan_orphan_anonymous_deletions
+
+        ANON = 2
+        ts = "2026-05-09T10:00:00Z"
+        journals = [
+            _journal(1, 5040, 61, "Real comment", ts),
+            _journal(2, 5040, ANON, "Anon comment", ts),
+        ]
+        to_delete = _plan_orphan_anonymous_deletions(journals)
+        delete_ids = {j["id"] for j in to_delete}
+        assert 2 not in delete_ids, "Anonymous journal at same timestamp as earliest real-author must NOT be deleted"
+
+    def test_wp_with_only_anon_not_touched(self) -> None:
+        """WP with only Anonymous journals: heuristic does not apply."""
+        from scripts.cleanup_anonymous_comment_duplicates import _plan_orphan_anonymous_deletions
+
+        ANON = 2
+        journals = [
+            _journal(1, 5040, ANON, "Anon A", "2026-05-07T10:00:00Z"),
+            _journal(2, 5040, ANON, "Anon B", "2026-05-07T11:00:00Z"),
+        ]
+        to_delete = _plan_orphan_anonymous_deletions(journals)
+        assert to_delete == [], "No real-author journals → heuristic must not delete anything"
+
+    def test_run_respects_tightened_heuristic(self) -> None:
+        """run() with also_delete_orphan_anonymous keeps newer Anonymous journals."""
+        from scripts.cleanup_anonymous_comment_duplicates import run
+
+        ANON = 2
+        mock_op = MagicMock()
+        mock_op.execute_query_to_json_file.return_value = {
+            "project_id": 1,
+            "wp_ids_count": 1,
+            "journals": [
+                # Real-author journal at 11:00
+                _journal(1, 5040, 61, "Real comment", "2026-05-09T11:00:00Z"),
+                # Anon journal at 12:00 — NEWER than real → must be KEPT
+                _journal(2, 5040, ANON, "Anon comment", "2026-05-09T12:00:00Z"),
+            ],
+        }
+
+        stats = run(
+            "NRS",
+            apply=False,
+            logger=self._make_logger(),
+            op_client=mock_op,
+            also_delete_orphan_anonymous=True,
+        )
+
+        # The anon is newer → must not be scheduled for deletion
+        assert stats["to_delete"] == 0, (
+            f"Expected 0 deletions (anon is newer than real-author), got {stats['to_delete']}"
+        )

--- a/tests/unit/test_cleanup_anonymous_comment_duplicates.py
+++ b/tests/unit/test_cleanup_anonymous_comment_duplicates.py
@@ -522,7 +522,8 @@ class TestOrphanAnonymousDeletion:
 
     def test_flag_set_wp_with_only_anon_no_extra_deletions(self) -> None:
         """WP with only anonymous journals (no real) + flag → no orphan deletions
-        (existing text-based logic only — no real author present to displace them)."""
+        (existing text-based logic only — no real author present to displace them).
+        """
         from scripts.cleanup_anonymous_comment_duplicates import run
 
         ANON = 2
@@ -574,7 +575,8 @@ class TestOrphanAnonymousDeletion:
     def test_flag_not_set_uses_only_text_based_dedup(self) -> None:
         """Without --also-delete-orphan-anonymous, the divergent-text anon journals
         are NOT deleted (existing behaviour).  Only exact-match (after marker strip)
-        duplicates are removed."""
+        duplicates are removed.
+        """
         from scripts.cleanup_anonymous_comment_duplicates import run
 
         ANON = 2
@@ -632,6 +634,7 @@ class TestOrphanAnonymousDeletion:
         # Delete call must contain ids 10 and 11, NOT 12
         delete_script: str = mock_op.execute_query_to_json_file.call_args_list[1][0][0]
         import json as _json
+
         start = delete_script.find("[")
         end = delete_script.find("]", start) + 1
         ids = _json.loads(delete_script[start:end])


### PR DESCRIPTION
## Evidence — WP 5040 (Jira NRS-4391)

After today's NRS content-only re-migration, WP 5040 has **9 journals with notes**:

```
user_id=2  Anonymous:       5  (broken May-7 runs, varying converter output)
user_id=61 Björn Marten:    3  (today's correct run, no provenance marker)
user_id=281 Mikhail Sarnov: 1  (today's correct run, no provenance marker)
```

Jira NRS-4391 has only **4 comments** (Björn ×3, Mikhail ×1). Expected end state: 4 journals.

## Gap in existing cleanup (Problem 1)

The existing `scripts/cleanup_anonymous_comment_duplicates.py` groups by normalised text content.  The broken-run Anonymous journals were rendered with the **old buggy converter**, so their text differs from today's correctly-rendered journals (e.g. `concourse~~ci` vs `concourse-ci`, `-~~f 30 ~~` vs `-f 30 -`).  The dedup misses them.

Result on WP 5040: only 4 of 5 Anonymous duplicates get flagged. After dry-run we still have **1 Anonymous + 4 real = 5 journals** (vs. desired 4).

## Fix 1 — `--also-delete-orphan-anonymous` flag

New flag on `scripts/cleanup_anonymous_comment_duplicates.py`:

- **Off by default** — operator must opt in.
- When set: for every WP that has ≥1 real-author journal AND ≥1 Anonymous journal, ALL Anonymous journals are deleted, regardless of text content.
- Reason logged as `Anonymous-orphan (WP also has real-author journals)`.
- Double-deletion guard: a journal already flagged by text-based dedup is not counted twice.

## Gap in future idempotency (Problem 2)

The real-author journals from today's correct run have no `<!-- j2o:jira-comment-id:{id} -->` provenance marker.  The next re-run of `--components work_packages_content` will treat them as "not yet migrated" and create another full duplicate set.

## Fix 2 — `scripts/backfill_comment_provenance_markers.py`

New script:

- Args: `project_key`, `--dry-run` (default), `--apply`.
- Per WP: fetch un-marked OP journals (Rails `NOT LIKE '%j2o:jira-comment-id:%'`), fetch Jira comments.
- **Count mismatch → SKIP + WARNING** (unsafe to pair).
- **Author mismatch on any pair → SKIP + WARNING** (validates via `user_mapping.json`).
- For safe WPs: pairs by `created_at` / Jira chronological order (zip), appends marker using `Journal.update_columns(notes: ...)` — bypasses ActiveRecord callbacks, no new journal version created.
- Default dry-run; `--apply` required for writes.

## Recommended operator runbook

```bash
# 1. Dry-run cleanup (see what would be deleted)
.venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS \
    --also-delete-orphan-anonymous

# 2. Apply cleanup
.venv/bin/python -m scripts.cleanup_anonymous_comment_duplicates NRS \
    --apply --also-delete-orphan-anonymous

# 3. Dry-run backfill (see what markers would be added)
.venv/bin/python -m scripts.backfill_comment_provenance_markers NRS

# 4. Apply backfill
.venv/bin/python -m scripts.backfill_comment_provenance_markers NRS --apply

# 5. Verify with Rails query
# Journal.where(journable_type: 'WorkPackage', journable_id: 5040)
#   .where.not(notes: [nil, ''])
#   .pluck(:id, :user_id, :notes)
```

## Test plan

- [ ] `pytest tests/unit/test_cleanup_anonymous_comment_duplicates.py -W error -q` → 29 passed
- [ ] `pytest tests/unit/test_backfill_comment_provenance_markers.py -W error -q` → 10 passed
- [ ] `ruff check scripts/cleanup_anonymous_comment_duplicates.py scripts/backfill_comment_provenance_markers.py` → no errors
- [ ] `mypy src/` → 0 errors (scripts excluded per pyproject.toml)
- [ ] `--also-delete-orphan-anonymous` is off by default (existing behaviour unchanged)
- [ ] Backfill skips WPs with count/author mismatch (safety over throughput)
- [ ] Backfill uses `update_columns` not `save!` (no new journal versions)