### PR TITLE
fix(backfill): probe canonical Jira identifiers (Server uses name/key, not accountId)

### DIFF
--- a/scripts/backfill_comment_provenance_markers.py
+++ b/scripts/backfill_comment_provenance_markers.py
@@ -103,6 +103,54 @@ def _setup_logging(log_path: Path) -> logging.Logger:
 # ---------------------------------------------------------------------------
 
 
+# Canonical probe order for resolving a Jira comment author to an OP user.
+# Mirrors ``IssueTransformer._JOURNAL_AUTHOR_PROBE_KEYS`` and the comment
+# dict fields populated by ``_make_jira_fetcher``:
+#   accountId  → author_account_id   (Cloud only)
+#   name       → author_name         (Server/DC login)
+#   key        → author_key          (Server/DC internal key, e.g. JIRAUSER12345)
+#   emailAddress → author_email
+#   displayName  → author_display_name
+_COMMENT_AUTHOR_PROBE_FIELDS: tuple[str, ...] = (
+    "author_account_id",
+    "author_name",
+    "author_key",
+    "author_email",
+    "author_display_name",
+)
+
+
+def _resolve_comment_author(
+    jira_comment: dict[str, Any],
+    user_mapping: dict[str, int],
+) -> int | None:
+    """Resolve a Jira comment's author to an OP user id.
+
+    Probes each author field in canonical order (Cloud ``accountId`` first,
+    then Server/DC ``name`` and ``key``, then ``emailAddress``,
+    ``displayName``).  Returns the first matching OP user id or ``None``
+    when the author cannot be resolved.
+
+    Args:
+        jira_comment: Comment dict as returned by :func:`_make_jira_fetcher`.
+            Must contain the ``author_*`` fields populated by that function.
+        user_mapping: Flat ``{identifier: op_user_id}`` dict built by
+            :func:`_load_user_mapping`.  Indexed by every probe value so a
+            single dict lookup per probe is O(1).
+
+    Returns:
+        The resolved ``openproject_id`` (int) or ``None``.
+    """
+    for field in _COMMENT_AUTHOR_PROBE_FIELDS:
+        value = jira_comment.get(field)
+        if not value:
+            continue
+        op_user_id = user_mapping.get(str(value))
+        if op_user_id is not None:
+            return op_user_id
+    return None
+
+
 def _pair_journals_with_comments(
     op_journals: list[dict[str, Any]],
     jira_comments: list[dict[str, Any]],
@@ -119,9 +167,13 @@ def _pair_journals_with_comments(
         op_journals: OP journal dicts with keys ``id``, ``wp_id``,
             ``user_id``, ``notes``, ``created_at``.
         jira_comments: Jira comment dicts with keys ``id``,
-            ``author_account_id``, ``body``.  Must be in chronological order
-            (Jira REST API default).
-        user_mapping: ``{jira_account_id: op_user_id}`` dict.
+            ``author_account_id``, ``author_name``, ``author_key``,
+            ``author_email``, ``author_display_name``, ``body``.  Must be in
+            chronological order (Jira REST API default).
+        user_mapping: Flat ``{identifier: op_user_id}`` dict built by
+            :func:`_load_user_mapping`.  Each Jira user is indexed by every
+            probe field (``jira_key``, ``jira_name``, ``jira_display_name``,
+            ``jira_email``) so a single dict lookup per probe is O(1).
 
     Returns:
         ``(pairs, skip_reason)`` where ``pairs`` is a list of
@@ -151,16 +203,21 @@ def _pair_journals_with_comments(
         return [], (f"count mismatch: {len(unmarked)} unmarked OP journals vs {len(jira_comments)} Jira comments")
 
     # Author validation: zip by position (both are in chronological order).
+    # Probe author fields in canonical order (Cloud accountId first, then
+    # Server/DC name/key, then emailAddress, displayName) so this works for
+    # both Jira Cloud and Jira Server deployments.
     pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
     for idx, (op_j, jira_c) in enumerate(zip(unmarked, jira_comments, strict=True)):
-        jira_account_id: str = jira_c.get("author_account_id", "")
-        expected_op_user_id = user_mapping.get(jira_account_id)
+        expected_op_user_id = _resolve_comment_author(jira_c, user_mapping)
         actual_op_user_id = op_j.get("user_id")
         if expected_op_user_id is None or expected_op_user_id != actual_op_user_id:
+            # Build a compact representation of the probed author fields for
+            # the diagnostic (mirrors the old "account {account_id!r}" line).
+            probed = {f: jira_c.get(f) for f in _COMMENT_AUTHOR_PROBE_FIELDS if jira_c.get(f)}
             return [], (
                 f"author mismatch at position {idx}: "
                 f"OP journal #{op_j['id']} has user_id={actual_op_user_id} "
-                f"but Jira comment {jira_c['id']} (account {jira_account_id!r}) "
+                f"but Jira comment {jira_c['id']} (author fields {probed!r}) "
                 f"maps to op_user_id={expected_op_user_id}"
             )
         pairs.append((op_j, jira_c))
@@ -242,6 +299,10 @@ def _make_jira_fetcher(jira_client: Any) -> Any:
     ``(jira_issue_key: str) -> list[dict]`` expected by :func:`run`.
     Constructing the client once and binding it here avoids per-call
     reconnection overhead.
+
+    The returned comment dicts carry all author-identifying fields so that
+    :func:`_pair_journals_with_comments` can probe them in canonical order
+    (``accountId`` first for Cloud, then ``name`` / ``key`` for Server/DC).
     """
 
     def _fetch(jira_issue_key: str) -> list[dict[str, Any]]:
@@ -250,12 +311,24 @@ def _make_jira_fetcher(jira_client: Any) -> Any:
         for c in raw_comments:
             author = getattr(c, "author", None)
             account_id = ""
+            name = ""
+            key = ""
+            email = ""
+            display_name = ""
             if author is not None:
                 account_id = getattr(author, "accountId", "") or ""
+                name = getattr(author, "name", "") or ""
+                key = getattr(author, "key", "") or ""
+                email = getattr(author, "emailAddress", "") or ""
+                display_name = getattr(author, "displayName", "") or ""
             result.append(
                 {
                     "id": getattr(c, "id", ""),
                     "author_account_id": account_id,
+                    "author_name": name,
+                    "author_key": key,
+                    "author_email": email,
+                    "author_display_name": display_name,
                     "body": getattr(c, "body", ""),
                 }
             )

--- a/scripts/backfill_comment_provenance_markers.py
+++ b/scripts/backfill_comment_provenance_markers.py
@@ -104,20 +104,26 @@ def _setup_logging(log_path: Path) -> logging.Logger:
 
 
 # Canonical probe order for resolving a Jira comment author to an OP user.
-# Mirrors ``IssueTransformer._JOURNAL_AUTHOR_PROBE_KEYS`` and the comment
-# dict fields populated by ``_make_jira_fetcher``:
-#   accountId  → author_account_id   (Cloud only)
-#   name       → author_name         (Server/DC login)
-#   key        → author_key          (Server/DC internal key, e.g. JIRAUSER12345)
+# Single source of truth: maps the internal comment-dict key to the
+# attribute name on the Jira SDK ``author`` object.  Used both to extract
+# fields in ``_make_jira_fetcher`` AND to probe in
+# ``_resolve_comment_author``, so adding a new probe key is a one-line
+# change.
+#
+# Order mirrors ``IssueTransformer._JOURNAL_AUTHOR_PROBE_KEYS``:
+#   accountId    → author_account_id   (Cloud only)
+#   name         → author_name         (Server/DC login)
+#   key          → author_key          (Server/DC internal key, e.g. JIRAUSER12345)
 #   emailAddress → author_email
 #   displayName  → author_display_name
-_COMMENT_AUTHOR_PROBE_FIELDS: tuple[str, ...] = (
-    "author_account_id",
-    "author_name",
-    "author_key",
-    "author_email",
-    "author_display_name",
+_COMMENT_AUTHOR_FIELDS: tuple[tuple[str, str], ...] = (
+    ("author_account_id", "accountId"),
+    ("author_name", "name"),
+    ("author_key", "key"),
+    ("author_email", "emailAddress"),
+    ("author_display_name", "displayName"),
 )
+_COMMENT_AUTHOR_PROBE_FIELDS: tuple[str, ...] = tuple(internal for internal, _ in _COMMENT_AUTHOR_FIELDS)
 
 
 def _resolve_comment_author(
@@ -310,28 +316,13 @@ def _make_jira_fetcher(jira_client: Any) -> Any:
         result = []
         for c in raw_comments:
             author = getattr(c, "author", None)
-            account_id = ""
-            name = ""
-            key = ""
-            email = ""
-            display_name = ""
-            if author is not None:
-                account_id = getattr(author, "accountId", "") or ""
-                name = getattr(author, "name", "") or ""
-                key = getattr(author, "key", "") or ""
-                email = getattr(author, "emailAddress", "") or ""
-                display_name = getattr(author, "displayName", "") or ""
-            result.append(
-                {
-                    "id": getattr(c, "id", ""),
-                    "author_account_id": account_id,
-                    "author_name": name,
-                    "author_key": key,
-                    "author_email": email,
-                    "author_display_name": display_name,
-                    "body": getattr(c, "body", ""),
-                }
-            )
+            entry: dict[str, Any] = {
+                "id": getattr(c, "id", ""),
+                "body": getattr(c, "body", ""),
+            }
+            for internal, attr in _COMMENT_AUTHOR_FIELDS:
+                entry[internal] = (getattr(author, attr, "") or "") if author is not None else ""
+            result.append(entry)
         return result
 
     return _fetch

--- a/tests/unit/test_backfill_comment_provenance_markers.py
+++ b/tests/unit/test_backfill_comment_provenance_markers.py
@@ -768,3 +768,181 @@ class TestSetupLoggingIdempotent:
         for h in list(logger.handlers):
             h.close()
             logger.removeHandler(h)
+
+
+# ---------------------------------------------------------------------------
+# Issue: Jira Server uses name/key — not accountId — as canonical identifier
+# ---------------------------------------------------------------------------
+
+
+class TestJiraServerProbeOrder:
+    """Regression for the 98%-SKIP rate on NRS (Jira Server 9.12.3).
+
+    Live evidence (2026-05-09 dry-run on NRS):
+        WARNING  WP#806 (NRS-207): SKIP — author mismatch at position 0:
+                 OP journal #128549 has user_id=110 but Jira comment 39281
+                 (account '') maps to op_user_id=None
+
+    Root cause: Jira Server stores the canonical identifier in ``name`` /
+    ``key`` (e.g. ``bmarten``, ``JIRAUSER12345``), never in ``accountId``
+    (which is a Cloud-only field and is always empty/absent on Server).
+    The pairing logic must probe ``name`` and ``key`` as fallbacks when
+    ``accountId`` is empty, mirroring
+    ``IssueTransformer._JOURNAL_AUTHOR_PROBE_KEYS``.
+    """
+
+    def _write_user_mapping(self, path: Path, data: dict) -> None:
+        import json
+
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    def test_server_name_field_resolves_to_op_user(self) -> None:
+        """Comment with only name='bmarten' (no accountId) must pair successfully.
+
+        This is the core regression: on Jira Server the comment author dict
+        has ``name`` but NOT ``accountId``.  The current code reads only
+        ``author_account_id`` (extracted from ``accountId``) and gets an
+        empty string, causing every comment to resolve to None → SKIP.
+        """
+        import tempfile
+
+        m = _import_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir)
+            self._write_user_mapping(
+                p / "user_mapping.json",
+                {
+                    "Björn Marten": {
+                        "jira_key": "JIRAUSER12345",
+                        "jira_name": "bmarten",
+                        "jira_email": "bjoern@netresearch.de",
+                        "jira_display_name": "Björn Marten",
+                        "openproject_id": 61,
+                    }
+                },
+            )
+            user_mapping = m._load_user_mapping(p)
+
+        # Jira Server comment: author has name but NOT accountId
+        jira_comments = [
+            {
+                "id": "39281",
+                "author_account_id": "",  # always empty on Jira Server
+                "author_name": "bmarten",  # Server login name
+                "author_key": "",
+                "author_email": "",
+                "author_display_name": "Björn Marten",
+                "body": "Some comment body",
+            }
+        ]
+        op_journals = [_op_journal(128549, 806, 61, "Some comment body")]
+
+        pairs, skip_reason = m._pair_journals_with_comments(
+            op_journals=op_journals,
+            jira_comments=jira_comments,
+            user_mapping=user_mapping,
+        )
+
+        assert skip_reason is None, (
+            f"Expected successful pairing for Jira Server comment (name='bmarten'), "
+            f"got skip_reason={skip_reason!r}. "
+            f"user_mapping keys: {list(user_mapping.keys())[:15]}"
+        )
+        assert len(pairs) == 1
+        assert pairs[0][0]["id"] == 128549
+        assert pairs[0][1]["id"] == "39281"
+
+    def test_server_key_field_resolves_to_op_user(self) -> None:
+        """Comment with only key='JIRAUSER12345' (no accountId) must pair successfully."""
+        import tempfile
+
+        m = _import_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir)
+            self._write_user_mapping(
+                p / "user_mapping.json",
+                {
+                    "Björn Marten": {
+                        "jira_key": "JIRAUSER12345",
+                        "jira_name": "bmarten",
+                        "jira_email": "bjoern@netresearch.de",
+                        "jira_display_name": "Björn Marten",
+                        "openproject_id": 61,
+                    }
+                },
+            )
+            user_mapping = m._load_user_mapping(p)
+
+        # Jira Server comment: author has key but NOT accountId
+        jira_comments = [
+            {
+                "id": "39281",
+                "author_account_id": "",
+                "author_name": "",
+                "author_key": "JIRAUSER12345",
+                "author_email": "",
+                "author_display_name": "",
+                "body": "Some comment body",
+            }
+        ]
+        op_journals = [_op_journal(128549, 806, 61, "Some comment body")]
+
+        pairs, skip_reason = m._pair_journals_with_comments(
+            op_journals=op_journals,
+            jira_comments=jira_comments,
+            user_mapping=user_mapping,
+        )
+
+        assert skip_reason is None, (
+            f"Expected successful pairing for Jira Server comment (key='JIRAUSER12345'), "
+            f"got skip_reason={skip_reason!r}."
+        )
+        assert len(pairs) == 1
+
+    def test_make_jira_fetcher_captures_server_fields(self) -> None:
+        """_make_jira_fetcher must extract name/key/emailAddress/displayName from
+        the Jira comment author — not only accountId.
+
+        This ensures that when _pair_journals_with_comments probes those fields
+        they are actually present in the comment dict.
+        """
+        m = _import_module()
+
+        # Simulate a Jira Server comment author object
+        author = type(
+            "Author",
+            (),
+            {
+                "accountId": "",
+                "name": "bmarten",
+                "key": "JIRAUSER12345",
+                "emailAddress": "bjoern@netresearch.de",
+                "displayName": "Björn Marten",
+            },
+        )()
+        comment = type(
+            "Comment",
+            (),
+            {
+                "id": "39281",
+                "author": author,
+                "body": "some body",
+            },
+        )()
+
+        class FakeJiraClient:
+            class jira:
+                @staticmethod
+                def comments(_key: str) -> list[Any]:
+                    return [comment]
+
+        result = m._make_jira_fetcher(FakeJiraClient())("NRS-207")
+        assert len(result) == 1
+        c = result[0]
+        assert c["author_name"] == "bmarten", (
+            f"Expected author_name='bmarten', got {c!r}. "
+            "_make_jira_fetcher must capture 'name' from Jira Server author objects."
+        )
+        assert c["author_key"] == "JIRAUSER12345"
+        assert c["author_email"] == "bjoern@netresearch.de"
+        assert c["author_display_name"] == "Björn Marten"


### PR DESCRIPTION
## Problem

Dry-run on NRS (Jira Server 9.12.3) produced 4013 SKIPs out of 4082 WPs (98%):

```
WARNING  WP#806 (NRS-207): SKIP — author mismatch at position 0:
         OP journal #128549 has user_id=110 but Jira comment 39281 (account '')
         maps to op_user_id=None
WARNING  WP#809 (NRS-199): SKIP — author mismatch at position 0:
         OP journal #128565 has user_id=110 but Jira comment 52998 (account '')
         maps to op_user_id=None
... (4011 more like this)
```

## Root cause

`_make_jira_fetcher` extracted only `author.accountId` from each Jira comment, which is a **Cloud-only field** — on Jira Server 9.x it is always empty. `_pair_journals_with_comments` then called `user_mapping.get("")` which returned `None` for every comment, triggering the author-mismatch SKIP for the entire WP.

The canonical identifier on Jira Server is `name` (login, e.g. `bmarten`) or `key` (e.g. `JIRAUSER12345`). `_load_user_mapping` already indexes by those fields (built by PR #249 review fix `4e92703`) — the lookup *call* was the missing piece.

## Fix

- **`_make_jira_fetcher`**: extract all five author-identifying fields from each raw Jira comment object (`accountId`, `name`, `key`, `emailAddress`, `displayName`) and store them as `author_account_id`, `author_name`, `author_key`, `author_email`, `author_display_name`.
- **`_resolve_comment_author`** (new helper): probes those fields in canonical order — matching `IssueTransformer._JOURNAL_AUTHOR_PROBE_KEYS` — against the flat `user_mapping` dict. Returns the first matching OP user id (O(1) per probe, no behavioural change for Cloud deployments where `accountId` is populated).
- **`_pair_journals_with_comments`**: delegates author resolution to the new helper. The diagnostic log line now shows all probed fields rather than only `account_id`.

## Test plan

- `TestJiraServerProbeOrder::test_server_name_field_resolves_to_op_user` — comment with only `name='bmarten'` (no `accountId`) pairs to OP user_id=61.
- `TestJiraServerProbeOrder::test_server_key_field_resolves_to_op_user` — comment with only `key='JIRAUSER12345'` pairs correctly.
- `TestJiraServerProbeOrder::test_make_jira_fetcher_captures_server_fields` — verifies the fetcher populates `author_name`, `author_key`, `author_email`, `author_display_name` from a Jira Server-style author object.
- All 20 pre-existing tests continue to pass (23 total, 0 failures).
- Ruff lint/format clean, mypy 0 errors on `src/`.