### PR TITLE
fix(deps): bump starlette to 1.1.0 (PYSEC-2026-161)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1286,14 +1286,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Raises the locked `starlette` transitive dependency from 1.0.0 to 1.1.0 to clear **PYSEC-2026-161** (fixed in 1.0.1).

The `pip-audit --strict` job in `security.yml` exports the frozen runtime graph and fails on starlette 1.0.0. This was blocking *every* open PR, including the Renovate Docker-action bump https://github.com/netresearch/jira-to-openproject/pull/254.

## Change

- `uv.lock`: starlette `1.0.0` → `1.1.0` (only line changed). starlette is pulled in transitively via `fastapi`.

## Verification

Reproduced the CI audit locally against the updated lock:

\`\`\`
uv export --frozen --no-hashes --no-dev --no-emit-project -o /tmp/runtime-requirements.txt
pip-audit --strict -r /tmp/runtime-requirements.txt
# -> No known vulnerabilities found (exit 0)
\`\`\`

## Follow-up

A broader dependency refresh (fastapi, uvicorn, pydantic, etc.) is worth doing separately — mypy 1.20→2.x and ruff bumps need their own PR since the major bumps likely require code fixes on the type-check / lint gates.