### PR TITLE
chore(renovate): enable weekly lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 4am on monday"
+    ]
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "timezone": "Europe/Berlin",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [


### PR DESCRIPTION
## Summary

Enables Renovate `lockFileMaintenance` (weekly, before 4am Monday) so the full `uv.lock` is periodically re-resolved.

## Why

`config:recommended` only bumps **direct** dependencies declared in `pyproject.toml`. **Transitive** locked versions in `uv.lock` are never refreshed. That is exactly how `starlette` 1.0.0 (PYSEC-2026-161) sat in the lock and blocked *every* PR through the strict `pip-audit` job until it was bumped manually (#256 / #257).

With `lockFileMaintenance`, Renovate re-resolves the whole lock on a schedule, keeping transitive deps current and preventing this class of audit blocker from recurring.

## Change

`renovate.json`:

\`\`\`json
"lockFileMaintenance": {
  "enabled": true,
  "schedule": ["before 4am on monday"]
}
\`\`\`