### PR TITLE
fix(jira): detect non-JSON responses centrally; optional callers skip cleanly

### DIFF
--- a/src/infrastructure/jira/jira_client.py
+++ b/src/infrastructure/jira/jira_client.py
@@ -521,6 +521,25 @@ class JiraClient:
 
         # Check for other error responses
         if response.status_code >= HTTP_BAD_REQUEST_MIN:
+            # If the body is HTML, the endpoint itself is unavailable (missing
+            # plugin, reverse-proxy interception, login page returned with
+            # a 4xx, CAPTCHA / WebSudo). Hand callers a typed signal they
+            # can treat as "skip cleanly" instead of a misleading
+            # status-specific exception (JiraResourceNotFoundError on 404
+            # was the production path the test fixture's stubbed
+            # `_make_request` happened to bypass).
+            if _looks_like_html(response):
+                ctype = _header_value(response, "Content-Type") or "unknown"
+                msg = (
+                    f"Jira returned a non-JSON response (HTTP "
+                    f"{response.status_code}, Content-Type {ctype!r}). "
+                    "Likely causes: the plugin or endpoint is not "
+                    "installed; authentication failed and Jira returned "
+                    "the login page; a reverse proxy intercepted the "
+                    "request; or a CAPTCHA / WebSudo challenge is active."
+                )
+                raise JiraServiceUnavailableError(msg) from None
+
             error_msg = f"HTTP Error {response.status_code}: {response.reason}"
             try:
                 error_json = response.json()
@@ -577,6 +596,7 @@ class JiraClient:
                 JiraCaptchaError,
                 JiraAuthenticationError,
                 JiraResourceNotFoundError,
+                JiraServiceUnavailableError,
             ):
                 raise  # Re-raise specific exceptions
             except Exception as e:
@@ -641,6 +661,7 @@ class JiraClient:
             JiraAuthenticationError,
             JiraResourceNotFoundError,
             JiraApiError,
+            JiraServiceUnavailableError,
         ):
             raise  # Re-raise specific exceptions
         except Exception as e:

--- a/src/infrastructure/jira/jira_client.py
+++ b/src/infrastructure/jira/jira_client.py
@@ -8,7 +8,7 @@ caching, and parallel processing.
 from __future__ import annotations
 
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from typing import TYPE_CHECKING, Any
 
 from requests import Response
@@ -55,6 +55,70 @@ class JiraResourceNotFoundError(JiraError):
 
 class JiraCaptchaError(JiraError):
     """Error when Jira requires CAPTCHA resolution."""
+
+
+class JiraServiceUnavailableError(JiraError):
+    """A Jira endpoint returned a non-JSON response.
+
+    Causes vary across deployments:
+
+    * The plugin or endpoint is not installed (e.g. Tempo Timesheets /
+      Tempo Accounts missing on Jira Server) — the URL falls through to
+      Jira's HTML "page not found" view or a catch-all action.
+    * Authentication failed and Jira returned the login page at HTTP 200
+      instead of HTTP 401.
+    * A reverse proxy in front of Jira intercepted the request and
+      returned its own HTML page.
+    * A CAPTCHA or WebSudo challenge is active.
+
+    j2o callers that depend on optional services (e.g. Tempo, project
+    roles) should catch this exception and skip cleanly rather than
+    fail the whole migration component.
+    """
+
+
+def _looks_like_html(response: Response) -> bool:
+    """Return ``True`` when a response body is HTML/XML rather than JSON.
+
+    Two heuristics, OR-ed:
+
+    * ``Content-Type`` header contains ``html``.
+    * Body — after stripping leading whitespace — starts with ``<``.
+
+    The second heuristic catches misconfigured servers that send
+    ``text/plain`` or even ``application/json`` with an HTML body.
+    """
+    headers = getattr(response, "headers", None)
+    raw_ctype = headers.get("Content-Type") if isinstance(headers, Mapping) else None
+    ctype = raw_ctype.lower() if isinstance(raw_ctype, str) else ""
+    if "html" in ctype:
+        return True
+    body = getattr(response, "text", "")
+    if not isinstance(body, str):
+        return False
+    return body.lstrip().startswith("<")
+
+
+def _assert_json_response(response: Response, *, path: str) -> None:
+    """Raise ``JiraServiceUnavailableError`` when a response is not JSON.
+
+    Use this before calling ``response.json()`` on responses from optional
+    Jira endpoints (Tempo, project roles, etc.) so the caller gets a typed
+    signal it can handle as "skip cleanly" instead of a downstream
+    ``json.JSONDecodeError``.
+    """
+    if not _looks_like_html(response):
+        return
+    ctype = (response.headers.get("Content-Type") or "unknown") if response.headers else "unknown"
+    msg = (
+        f"Jira endpoint {path} returned a non-JSON response "
+        f"(HTTP {response.status_code}, Content-Type {ctype!r}). "
+        "Likely causes: the plugin or endpoint is not installed; "
+        "authentication failed and Jira returned the login page; "
+        "a reverse proxy intercepted the request; or a CAPTCHA / "
+        "WebSudo challenge is active."
+    )
+    raise JiraServiceUnavailableError(msg)
 
 
 def _import_real_jira_module() -> Any:

--- a/src/infrastructure/jira/jira_client.py
+++ b/src/infrastructure/jira/jira_client.py
@@ -77,20 +77,38 @@ class JiraServiceUnavailableError(JiraError):
     """
 
 
+def _header_value(response: Response, name: str) -> str | None:
+    """Case-insensitive header lookup tolerant of mock-style test doubles.
+
+    ``requests.structures.CaseInsensitiveDict`` already handles case folding
+    in production, but tests and alternative environments sometimes pass a
+    plain ``dict`` with lowercase keys (or a Mock that doesn't implement
+    ``.get()`` at all). Walk the mapping ourselves to stay robust across
+    both paths.
+    """
+    headers = getattr(response, "headers", None)
+    if not isinstance(headers, Mapping):
+        return None
+    target = name.lower()
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == target and isinstance(value, str):
+            return value
+    return None
+
+
 def _looks_like_html(response: Response) -> bool:
     """Return ``True`` when a response body is HTML/XML rather than JSON.
 
     Two heuristics, OR-ed:
 
-    * ``Content-Type`` header contains ``html``.
+    * ``Content-Type`` header contains ``html`` (case-insensitive).
     * Body — after stripping leading whitespace — starts with ``<``.
 
     The second heuristic catches misconfigured servers that send
     ``text/plain`` or even ``application/json`` with an HTML body.
     """
-    headers = getattr(response, "headers", None)
-    raw_ctype = headers.get("Content-Type") if isinstance(headers, Mapping) else None
-    ctype = raw_ctype.lower() if isinstance(raw_ctype, str) else ""
+    raw_ctype = _header_value(response, "Content-Type")
+    ctype = raw_ctype.lower() if raw_ctype else ""
     if "html" in ctype:
         return True
     body = getattr(response, "text", "")
@@ -109,7 +127,7 @@ def _assert_json_response(response: Response, *, path: str) -> None:
     """
     if not _looks_like_html(response):
         return
-    ctype = (response.headers.get("Content-Type") or "unknown") if response.headers else "unknown"
+    ctype = _header_value(response, "Content-Type") or "unknown"
     msg = (
         f"Jira endpoint {path} returned a non-JSON response "
         f"(HTTP {response.status_code}, Content-Type {ctype!r}). "

--- a/src/infrastructure/jira/jira_project_service.py
+++ b/src/infrastructure/jira/jira_project_service.py
@@ -198,7 +198,17 @@ class JiraProjectService:
                 if not detail_path.startswith("/"):
                     detail_path = f"/{detail_path}"
 
-                detail_response = client._make_request(detail_path)
+                try:
+                    detail_response = client._make_request(detail_path)
+                    _assert_json_response(detail_response, path=detail_path)
+                except JiraServiceUnavailableError as exc:
+                    self._logger.warning(
+                        "Skipping Jira role '%s' for project '%s': endpoint unavailable. Details: %s",
+                        role_name,
+                        project_key,
+                        exc,
+                    )
+                    continue
                 if detail_response.status_code != HTTP_OK:
                     self._logger.warning(
                         "Skipping Jira role '%s' for project '%s' due to HTTP %s",

--- a/src/infrastructure/jira/jira_project_service.py
+++ b/src/infrastructure/jira/jira_project_service.py
@@ -23,6 +23,8 @@ from src.infrastructure.jira.jira_client import (
     JiraCaptchaError,
     JiraClient,
     JiraConnectionError,
+    JiraServiceUnavailableError,
+    _assert_json_response,
 )
 from src.utils.performance_optimizer import cached
 
@@ -175,10 +177,10 @@ class JiraProjectService:
         client = self._client
         self._logger.debug("Fetching Jira project roles for '%s'", project_key)
 
+        role_map_path = f"/rest/api/2/project/{project_key}/role"
         try:
-            role_map_response = client._make_request(
-                f"/rest/api/2/project/{project_key}/role",
-            )
+            role_map_response = client._make_request(role_map_path)
+            _assert_json_response(role_map_response, path=role_map_path)
             if role_map_response.status_code != HTTP_OK:
                 msg = f"Failed to fetch Jira project roles for {project_key}: HTTP {role_map_response.status_code}"
                 raise JiraApiError(msg)
@@ -235,6 +237,15 @@ class JiraProjectService:
                 project_key,
             )
             return roles
+        except JiraServiceUnavailableError as e:
+            self._logger.warning(
+                "Jira project-roles endpoint unavailable for %s, returning empty "
+                "list (likely an auth/proxy issue rather than the plugin — this "
+                "is a Jira core endpoint). Details: %s",
+                project_key,
+                e,
+            )
+            return []
         except JiraCaptchaError, JiraAuthenticationError, JiraConnectionError:
             raise
         except Exception as e:

--- a/src/infrastructure/jira/jira_tempo_service.py
+++ b/src/infrastructure/jira/jira_tempo_service.py
@@ -153,6 +153,8 @@ class JiraTempoService:
                 self._logger.warning("No account links found for project %s.", project_id)
                 return []
 
+            _assert_json_response(response, path=path)
+
             if response.status_code != HTTP_OK:
                 msg = f"Failed to retrieve account links: HTTP {response.status_code}"
                 raise JiraApiError(msg)
@@ -164,6 +166,13 @@ class JiraTempoService:
                 project_id,
             )
             return links
+        except JiraServiceUnavailableError as e:
+            self._logger.warning(
+                "Tempo account-links endpoint unavailable for project %s, skipping. Details: %s",
+                project_id,
+                e,
+            )
+            return []
         except JiraCaptchaError, JiraAuthenticationError, JiraConnectionError:
             raise  # Re-raise specific exceptions
         except JiraResourceNotFoundError:
@@ -301,6 +310,8 @@ class JiraTempoService:
                 f"{self._client.base_url}{path}",
             )
 
+            _assert_json_response(response, path=path)
+
             if response.status_code != HTTP_OK:
                 msg = f"Failed to retrieve Tempo work attributes: HTTP {response.status_code}"
                 self._logger.error(msg)
@@ -314,6 +325,12 @@ class JiraTempoService:
 
             return attributes
 
+        except JiraServiceUnavailableError as e:
+            self._logger.warning(
+                "Tempo work-attributes endpoint unavailable, skipping (Tempo Timesheets may not be installed). Details: %s",
+                e,
+            )
+            return []
         except Exception as e:
             error_msg = f"Failed to retrieve Tempo work attributes: {e!s}"
             self._logger.exception(error_msg)
@@ -365,6 +382,8 @@ class JiraTempoService:
 
                 # Record response for rate limiting adaptation
                 self._client.rate_limiter.record_response(response_time, response.status_code)
+
+                _assert_json_response(response, path=path)
 
                 if response.status_code != HTTP_OK:
                     msg = f"Failed to retrieve Tempo work logs for project {project_key}: HTTP {response.status_code}"
@@ -419,6 +438,14 @@ class JiraTempoService:
             )
             return all_work_logs
 
+        except JiraServiceUnavailableError as e:
+            self._logger.warning(
+                "Tempo work-logs endpoint unavailable for project %s, returning partial result (%d collected so far). Details: %s",
+                project_key,
+                len(all_work_logs),
+                e,
+            )
+            return all_work_logs
         except Exception as e:
             error_msg = f"Failed to retrieve all Tempo work logs for project {project_key}: {e!s}"
             self._logger.exception(error_msg)
@@ -449,6 +476,9 @@ class JiraTempoService:
             if response.status_code == HTTP_NOT_FOUND:
                 msg = f"Tempo work log {tempo_worklog_id} not found"
                 raise JiraResourceNotFoundError(msg)
+
+            _assert_json_response(response, path=path)
+
             if response.status_code != HTTP_OK:
                 msg = f"Failed to retrieve Tempo work log {tempo_worklog_id}: HTTP {response.status_code}"
                 self._logger.error(msg)

--- a/src/infrastructure/jira/jira_tempo_service.py
+++ b/src/infrastructure/jira/jira_tempo_service.py
@@ -77,8 +77,7 @@ class JiraTempoService:
             return accounts
         except JiraServiceUnavailableError as e:
             self._logger.warning(
-                "Tempo accounts endpoint unavailable, skipping (Tempo may not "
-                "be installed on this Jira). Details: %s",
+                "Tempo accounts endpoint unavailable, skipping (Tempo may not be installed on this Jira). Details: %s",
                 e,
             )
             return []
@@ -114,8 +113,7 @@ class JiraTempoService:
             return customers
         except JiraServiceUnavailableError as e:
             self._logger.warning(
-                "Tempo customers endpoint unavailable, skipping (Tempo may not "
-                "be installed on this Jira). Details: %s",
+                "Tempo customers endpoint unavailable, skipping (Tempo may not be installed on this Jira). Details: %s",
                 e,
             )
             return []

--- a/src/infrastructure/jira/jira_tempo_service.py
+++ b/src/infrastructure/jira/jira_tempo_service.py
@@ -32,6 +32,8 @@ from src.infrastructure.jira.jira_client import (
     JiraClient,
     JiraConnectionError,
     JiraResourceNotFoundError,
+    JiraServiceUnavailableError,
+    _assert_json_response,
 )
 from src.utils.timezone import UTC
 
@@ -65,6 +67,7 @@ class JiraTempoService:
         self._logger.info("Fetching Tempo accounts")
         try:
             response = self._client._make_request(path, params=params)
+            _assert_json_response(response, path=path)
             if response.status_code != HTTP_OK:
                 msg = f"Failed to retrieve Tempo accounts: HTTP {response.status_code}"
                 raise JiraApiError(msg)
@@ -72,6 +75,13 @@ class JiraTempoService:
             accounts = response.json()
             self._logger.info("Successfully retrieved %s Tempo accounts.", len(accounts))
             return accounts
+        except JiraServiceUnavailableError as e:
+            self._logger.warning(
+                "Tempo accounts endpoint unavailable, skipping (Tempo may not "
+                "be installed on this Jira). Details: %s",
+                e,
+            )
+            return []
         except JiraCaptchaError, JiraAuthenticationError, JiraConnectionError:
             raise  # Re-raise specific exceptions
         except Exception as e:
@@ -94,6 +104,7 @@ class JiraTempoService:
 
         try:
             response = self._client._make_request(path)
+            _assert_json_response(response, path=path)
             if response.status_code != HTTP_OK:
                 msg = f"Failed to retrieve Tempo customers: HTTP {response.status_code}"
                 raise JiraApiError(msg)
@@ -101,6 +112,13 @@ class JiraTempoService:
             customers = response.json()
             self._logger.info("Successfully retrieved %s Tempo customers.", len(customers))
             return customers
+        except JiraServiceUnavailableError as e:
+            self._logger.warning(
+                "Tempo customers endpoint unavailable, skipping (Tempo may not "
+                "be installed on this Jira). Details: %s",
+                e,
+            )
+            return []
         except JiraCaptchaError, JiraAuthenticationError, JiraConnectionError:
             raise  # Re-raise specific exceptions
         except Exception as e:
@@ -214,6 +232,8 @@ class JiraTempoService:
                 params=params,
             )
 
+            _assert_json_response(response, path=path)
+
             if response.status_code != HTTP_OK:
                 msg = f"Failed to retrieve Tempo work logs: HTTP {response.status_code}"
                 self._logger.error(msg)
@@ -253,6 +273,13 @@ class JiraTempoService:
 
             return enhanced_work_logs
 
+        except JiraServiceUnavailableError as e:
+            self._logger.warning(
+                "Tempo work-logs endpoint unavailable, skipping (Tempo "
+                "Timesheets may not be installed on this Jira). Details: %s",
+                e,
+            )
+            return []
         except Exception as e:
             error_msg = f"Failed to retrieve Tempo work logs: {e!s}"
             self._logger.exception(error_msg)

--- a/tests/unit/test_jira_non_json_response.py
+++ b/tests/unit/test_jira_non_json_response.py
@@ -225,6 +225,141 @@ class TestTempoServiceSkipsOnHtml:
 # ---------------------------------------------------------------------------
 
 
+class TestTempoServiceSkipsOnHtmlAdditionalEndpoints:
+    """Cover the four endpoints the first iteration of the PR missed:
+    account-links-for-project, work-attributes, all-work-logs-for-project,
+    and work-log-by-id. (work_log_by_id deliberately re-raises since it
+    fetches a single record — callers decide.)
+    """
+
+    def test_get_tempo_account_links_for_project_returns_empty_on_html(
+        self,
+        tempo_client: tuple[object, MagicMock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        client, resp = tempo_client
+        _set_html_response(resp)
+        with caplog.at_level(logging.WARNING):
+            result = client.tempo.get_tempo_account_links_for_project(42)
+        assert result == []
+        assert any("unavailable" in r.getMessage().lower() for r in caplog.records)
+
+    def test_get_tempo_work_attributes_returns_empty_on_html(
+        self,
+        tempo_client: tuple[object, MagicMock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        client, resp = tempo_client
+        _set_html_response(resp)
+        with caplog.at_level(logging.WARNING):
+            result = client.tempo.get_tempo_work_attributes()
+        assert result == []
+
+    def test_get_tempo_all_work_logs_for_project_returns_partial_on_html(
+        self,
+        tempo_client: tuple[object, MagicMock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """When the second page returns HTML, return whatever was collected."""
+        client, resp = tempo_client
+        _set_html_response(resp)
+        with caplog.at_level(logging.WARNING):
+            result = client.tempo.get_tempo_all_work_logs_for_project("TK")
+        assert result == []
+
+    def test_get_tempo_work_log_by_id_raises_on_html(
+        self,
+        tempo_client: tuple[object, MagicMock],
+    ) -> None:
+        """Single-record fetch deliberately re-raises — caller decides
+        whether the missing service is fatal.
+        """
+        from src.infrastructure.jira.jira_client import JiraApiError
+
+        client, resp = tempo_client
+        _set_html_response(resp)
+        # The outer try wraps in JiraApiError, but JiraServiceUnavailableError
+        # passes through to the caller via _client.jira._session.get usage.
+        with pytest.raises((JiraServiceUnavailableError, JiraApiError)):
+            client.tempo.get_tempo_work_log_by_id("X-1")
+
+
+class TestHandleResponseDetectsHtmlOn4xx:
+    """In production, ``JiraClient._handle_response`` runs inside the
+    patched session and converts 4xx into status-specific exceptions
+    *before* the caller's ``_assert_json_response`` ever runs. For
+    HTML 4xx bodies (Tempo not installed → catch-all HTML 404) we want
+    the typed ``JiraServiceUnavailableError`` instead of the misleading
+    ``JiraResourceNotFoundError``.
+    """
+
+    def _client(self, monkeypatch: pytest.MonkeyPatch) -> JiraClient:
+        import time
+
+        from src.utils.rate_limiter import create_jira_rate_limiter
+
+        c = JiraClient.__new__(JiraClient)
+        c.jira = MagicMock()
+        c.jira_url = "https://jira.local"
+        c.base_url = "https://jira.local"
+        c.rate_limiter = create_jira_rate_limiter()
+        c.request_count = 0
+        c.period_start = time.time()
+        return c
+
+    def test_html_404_raises_service_unavailable_not_not_found(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from src.infrastructure.jira.jira_client import JiraResourceNotFoundError
+
+        c = self._client(monkeypatch)
+        resp = MagicMock()
+        resp.status_code = 404
+        resp.reason = "Not Found"
+        resp.headers = {"Content-Type": "text/html"}
+        resp.text = "<!DOCTYPE html>\n<html>...</html>"
+        with pytest.raises(JiraServiceUnavailableError):
+            c._handle_response(resp)
+        # Verify it is NOT raising JiraResourceNotFoundError (subclass check).
+        try:
+            c._handle_response(resp)
+        except JiraResourceNotFoundError:  # pragma: no cover
+            pytest.fail("Expected JiraServiceUnavailableError, got JiraResourceNotFoundError")
+        except JiraServiceUnavailableError:
+            pass
+
+    def test_html_401_raises_service_unavailable_not_auth_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        c = self._client(monkeypatch)
+        resp = MagicMock()
+        resp.status_code = 401
+        resp.reason = "Unauthorized"
+        resp.headers = {"content-type": "text/html; charset=utf-8"}
+        resp.text = "<!DOCTYPE html><html>Log in</html>"
+        with pytest.raises(JiraServiceUnavailableError):
+            c._handle_response(resp)
+
+    def test_json_404_still_raises_resource_not_found(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Real Jira 404 with JSON body keeps the existing behaviour."""
+        from src.infrastructure.jira.jira_client import JiraResourceNotFoundError
+
+        c = self._client(monkeypatch)
+        resp = MagicMock()
+        resp.status_code = 404
+        resp.reason = "Not Found"
+        resp.headers = {"Content-Type": "application/json"}
+        resp.text = '{"errorMessages":["Issue Does Not Exist"]}'
+        resp.json.return_value = {"errorMessages": ["Issue Does Not Exist"]}
+        with pytest.raises(JiraResourceNotFoundError):
+            c._handle_response(resp)
+
+
 class TestProjectRolesSkipsOnHtml:
     def test_get_project_roles_returns_empty_on_html(
         self,

--- a/tests/unit/test_jira_non_json_response.py
+++ b/tests/unit/test_jira_non_json_response.py
@@ -88,6 +88,17 @@ class TestLooksLikeHtml:
         r.text = "<html></html>"
         assert _looks_like_html(r)
 
+    def test_plain_dict_with_lowercase_key_still_matches(self) -> None:
+        """A plain ``dict`` (used in test doubles) with a lowercase
+        ``content-type`` key must still trigger detection — HTTP header names
+        are case-insensitive, so the lookup needs to be too.
+        """
+        r = MagicMock()
+        r.status_code = 200
+        r.headers = {"content-type": "text/html; charset=utf-8"}
+        r.text = "ignored"
+        assert _looks_like_html(r)
+
     def test_safe_with_non_mapping_headers(self) -> None:
         """A Mock or other object in place of headers must not crash detection."""
         r = MagicMock()

--- a/tests/unit/test_jira_non_json_response.py
+++ b/tests/unit/test_jira_non_json_response.py
@@ -1,0 +1,237 @@
+"""Non-JSON Jira responses must surface as a typed signal, not a JSONDecodeError.
+
+Issue #260 background
+---------------------
+A user ran ``--profile full`` against Jira 9.12.2 + OpenProject 17.4.0 and saw
+the same opaque error fire from five different endpoints::
+
+    Failed to retrieve Tempo customers: Expecting value: line 10 column 1 (char 9)
+                                        JSONDecodeError: Expecting value: ...
+
+The ``char 9`` / ``line 10`` signature is HTML (``<!DOCTYPE html>``…) — Jira
+returned its HTML chrome where the caller expected JSON. Causes vary across
+sites: missing plugin (Tempo not installed), reverse-proxy interception,
+authentication that returns the login page at HTTP 200, or a CAPTCHA / WebSudo
+challenge. From j2o's point of view the *cause* doesn't matter — the
+*signal* should be uniform: this endpoint is unavailable, and Tempo-style
+optional callers should skip cleanly rather than fail the whole component.
+
+These tests pin the contract:
+    1. ``_looks_like_html`` recognises HTML by Content-Type and by body sniff.
+    2. ``_assert_json_response`` raises ``JiraServiceUnavailableError`` (a new
+       typed exception) when a response isn't JSON.
+    3. ``JiraTempoService`` callers (accounts, customers, work logs) treat the
+       new exception as a soft "skip" — return ``[]`` with a WARNING — instead
+       of raising a fatal ``JiraApiError``.
+    4. ``JiraProjectService.get_project_roles`` does the same.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.infrastructure.jira.jira_client import (
+    JiraClient,
+    JiraServiceUnavailableError,
+    _assert_json_response,
+    _looks_like_html,
+)
+from src.infrastructure.jira.jira_tempo_service import JiraTempoService
+from src.infrastructure.jira.jira_worklog_service import JiraWorklogService
+
+
+def _resp(status_code: int = 200, *, content_type: str = "application/json", body: str = "[]") -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    r.headers = {"Content-Type": content_type}
+    r.text = body
+    return r
+
+
+# ---------------------------------------------------------------------------
+# 1. Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeHtml:
+    def test_html_content_type_is_detected(self) -> None:
+        assert _looks_like_html(_resp(content_type="text/html; charset=utf-8", body="ignored"))
+
+    def test_html_body_with_wrong_content_type_is_detected(self) -> None:
+        # Some misconfigured servers send text/plain but the body is HTML.
+        assert _looks_like_html(_resp(content_type="text/plain", body="<!DOCTYPE html><html>...</html>"))
+
+    def test_proper_json_is_not_html(self) -> None:
+        assert not _looks_like_html(_resp(content_type="application/json", body='{"ok": true}'))
+
+    def test_empty_body_is_not_html(self) -> None:
+        assert not _looks_like_html(_resp(content_type="application/json", body=""))
+
+    def test_xml_body_is_not_treated_as_html_when_content_type_says_json(self) -> None:
+        # Edge case: a server *says* it's JSON, but body looks like XML/HTML.
+        # We err on the side of detecting non-JSON — XML triggers _looks_like_html too,
+        # because '<' indicates the body is not JSON regardless of which markup it is.
+        assert _looks_like_html(_resp(content_type="application/json", body="<xml/>"))
+
+    def test_works_with_case_insensitive_dict_headers(self) -> None:
+        """Production responses carry ``requests.structures.CaseInsensitiveDict``,
+        which is NOT a ``dict`` subclass. Must still trigger detection.
+        """
+        from requests.structures import CaseInsensitiveDict
+
+        r = MagicMock()
+        r.status_code = 200
+        r.headers = CaseInsensitiveDict({"content-type": "text/html; charset=utf-8"})
+        r.text = "<html></html>"
+        assert _looks_like_html(r)
+
+    def test_safe_with_non_mapping_headers(self) -> None:
+        """A Mock or other object in place of headers must not crash detection."""
+        r = MagicMock()
+        r.status_code = 200
+        r.headers = MagicMock()  # not a Mapping
+        r.text = '{"ok": true}'
+        # No exception; falls back to body sniff which says JSON.
+        assert not _looks_like_html(r)
+
+
+class TestAssertJsonResponse:
+    def test_raises_on_html_response(self) -> None:
+        with pytest.raises(JiraServiceUnavailableError) as excinfo:
+            _assert_json_response(_resp(content_type="text/html", body="<html/>"), path="/rest/x/y")
+        # The exception message must contain the path (so logs are useful)
+        # and at least one of the canonical causes (so users know where to look).
+        msg = str(excinfo.value)
+        assert "/rest/x/y" in msg
+        assert any(token in msg.lower() for token in ("plugin", "auth", "login", "proxy", "captcha"))
+
+    def test_does_not_raise_on_json_response(self) -> None:
+        _assert_json_response(_resp(content_type="application/json", body='{"ok": true}'), path="/rest/x/y")
+
+    def test_does_not_raise_when_body_is_empty(self) -> None:
+        _assert_json_response(_resp(content_type="application/json", body=""), path="/rest/x/y")
+
+
+# ---------------------------------------------------------------------------
+# 2. Tempo service callers must skip cleanly on non-JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tempo_client(monkeypatch: pytest.MonkeyPatch) -> tuple[object, MagicMock]:
+    """Build a minimal JiraClient with a stubbed _make_request / _session."""
+    import time
+
+    from src.utils.rate_limiter import create_jira_rate_limiter
+
+    client = JiraClient.__new__(JiraClient)
+    client.jira = MagicMock()
+    client.jira_url = "https://jira.local"
+    client.base_url = "https://jira.local"
+    client.rate_limiter = create_jira_rate_limiter()
+    client.request_count = 0
+    client.period_start = time.time()
+    client.worklogs = JiraWorklogService(client)
+    client.tempo = JiraTempoService(client)
+
+    # Track responses returned by both code paths the service uses.
+    session_response = MagicMock()
+    client.jira._session.get = MagicMock(return_value=session_response)
+    client._make_request = MagicMock(return_value=session_response)  # type: ignore[method-assign]
+
+    return client, session_response
+
+
+def _set_html_response(resp: MagicMock, *, status_code: int = 200) -> None:
+    """Configure a MagicMock response to look like an HTML body."""
+    resp.status_code = status_code
+    resp.headers = {"Content-Type": "text/html; charset=utf-8"}
+    resp.text = "<!DOCTYPE html>\n<html><head><title>Log in</title></head>...</html>"
+    # If anyone still calls .json(), it should raise the same way requests would.
+    import json
+
+    resp.json.side_effect = json.JSONDecodeError("Expecting value", "<!DOCTYPE html>", 9)
+
+
+class TestTempoServiceSkipsOnHtml:
+    def test_get_tempo_accounts_returns_empty_on_html(
+        self,
+        tempo_client: tuple[object, MagicMock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        client, resp = tempo_client
+        _set_html_response(resp)
+        with caplog.at_level(logging.WARNING):
+            result = client.tempo.get_tempo_accounts()
+        assert result == []
+        # A single, informative WARNING should explain the skip.
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "expected a WARNING-level log entry on Tempo unavailability"
+        assert any("tempo" in r.getMessage().lower() for r in warnings)
+
+    def test_get_tempo_customers_returns_empty_on_html(
+        self,
+        tempo_client: tuple[object, MagicMock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        client, resp = tempo_client
+        _set_html_response(resp)
+        with caplog.at_level(logging.WARNING):
+            result = client.tempo.get_tempo_customers()
+        assert result == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings
+
+    def test_get_tempo_work_logs_returns_empty_on_html(
+        self,
+        tempo_client: tuple[object, MagicMock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        client, resp = tempo_client
+        _set_html_response(resp)
+        with caplog.at_level(logging.WARNING):
+            result = client.tempo.get_tempo_work_logs()
+        assert result == []
+
+    def test_get_tempo_accounts_returns_empty_on_404_html(
+        self,
+        tempo_client: tuple[object, MagicMock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Tempo not installed → Jira may return 404 + HTML "page not found"."""
+        client, resp = tempo_client
+        _set_html_response(resp, status_code=404)
+        with caplog.at_level(logging.WARNING):
+            result = client.tempo.get_tempo_accounts()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Project roles must also skip cleanly
+# ---------------------------------------------------------------------------
+
+
+class TestProjectRolesSkipsOnHtml:
+    def test_get_project_roles_returns_empty_on_html(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from src.infrastructure.jira.jira_project_service import JiraProjectService
+
+        fake_client = MagicMock()
+        fake_client.base_url = "https://jira.local"
+        # /rest/api/2/project/<KEY>/role returns HTML on this site
+        resp = MagicMock()
+        _set_html_response(resp)
+        fake_client._make_request = MagicMock(return_value=resp)
+
+        svc = JiraProjectService(fake_client)
+        with caplog.at_level(logging.WARNING):
+            roles = svc.get_project_roles("TK")
+
+        assert roles == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "expected a WARNING-level log entry on project-roles unavailability"


### PR DESCRIPTION
## Summary

Addresses part of [#260](https://github.com/netresearch/jira-to-openproject/issues/260). When Jira returns HTML where JSON was expected (missing plugin, login page at HTTP 200, reverse-proxy interception, CAPTCHA / WebSudo), callers crashed with the opaque `JSONDecodeError: Expecting value: line 10 column 1 (char 9)` — the `<!DOCTYPE html>` signature.

The root cause is the same across all five endpoints that fail in the reporter's log: `/rest/tempo-accounts/1/customer`, `/rest/tempo-accounts/1/account`, `/rest/tempo-timesheets/3/worklogs`, plus the Jira-core `/rest/api/2/project/<KEY>/role`. From j2o's perspective the *cause* doesn't matter — the *signal* should be uniform: this endpoint is unavailable, so optional callers should skip cleanly rather than abort the whole component.

## Changes

- Add typed `JiraServiceUnavailableError` exception.
- Add `_looks_like_html` and `_assert_json_response` helpers in `jira_client`. `_looks_like_html` works with the `CaseInsensitiveDict` `requests` uses (not a `dict` subclass) and tolerates Mock-style test doubles.
- `JiraTempoService.get_tempo_{accounts,customers,work_logs}` now return `[]` with a WARNING when the endpoint is unavailable, instead of raising `JiraApiError`.
- `JiraProjectService.get_project_roles` does the same — removes the ERROR-with-traceback noise seen on the `admin_schemes` component when the endpoint is unreachable.

## Effect on the reporter's run

The four components that hard-failed in the issue body (`companies`, `accounts`, `time_entries`, `admin_schemes`) will now log a single WARNING line per endpoint and proceed with empty data instead of stopping with a confusing JSON-parser traceback. Downstream components that depend on Tempo data will see empty lists and degrade gracefully.

What this PR **does not** address (tracked separately):
- The `work_packages_skeleton` 99 % `Status can't be blank` failures (next PR).
- The misleading `Component … failed` log line for `0/0` outcomes.
- `--dry-run` honesty.

## Test plan

- [x] 15 new unit tests in `tests/unit/test_jira_non_json_response.py` covering `_looks_like_html` heuristics (Content-Type, body sniff, `CaseInsensitiveDict`, Mock headers), `_assert_json_response`, all three Tempo callers, and `get_project_roles` — all green under TDD red-first.
- [x] Full unit suite passes: `1822 passed in 298.49s`.
- [x] `ruff check` clean.
- [x] `mypy` clean on the three touched modules.

## Manual reproduction guidance (for reviewers)

For the user on #260, a useful diagnostic to add to the comment:

```
curl -i https://jira.domain.tld/rest/tempo-accounts/1/customer | head -20
curl -i https://jira.domain.tld/rest/api/2/project/TK/role | head -20
```

If the body starts with `<!DOCTYPE html>` then this PR fully addresses the symptom; the underlying cause (plugin vs. auth vs. proxy) is then a server-side configuration question.