### PR TITLE
fix(skeleton): drop literal status_id=1 fallback; add Ruby safety net

### DIFF
--- a/src/application/components/work_package_skeleton_migration.py
+++ b/src/application/components/work_package_skeleton_migration.py
@@ -52,7 +52,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
@@ -84,6 +84,32 @@ def _stringify_optional_timestamp(value: Any) -> str | None:
     if isinstance(value, str):
         return value or None
     return str(value)
+
+
+def _raise_no_default_resource(
+    resource: str,
+    reason: str,
+    *,
+    cause: Exception | None = None,
+) -> NoReturn:
+    """Raise a uniform :class:`MigrationError` for a missing default OP resource.
+
+    Used by the three ``_get_default_*_id`` helpers in
+    :class:`WorkPackageSkeletonMigration`. Centralising the message
+    eliminates the duplicated string template that SonarCloud flags as
+    "duplication on new code" and keeps the wording consistent across
+    status / type / priority. The function itself does the ``raise`` so
+    EM101 doesn't fire on call-site string literals.
+    """
+    label = resource.removesuffix("_id").title()
+    msg = (
+        f"Cannot determine a default OpenProject {resource}: {reason}. "
+        f"Verify the OpenProject Rails console is reachable and that at "
+        f"least one work-package {label} is configured."
+    )
+    if cause is not None:
+        raise MigrationError(msg) from cause
+    raise MigrationError(msg)
 
 
 def _build_provenance_custom_field_entries(
@@ -382,16 +408,33 @@ class WorkPackageSkeletonMigration(BaseMigration):
         return self._get_default_type_id()
 
     def _get_default_type_id(self) -> int:
-        """Get default OpenProject type ID (cached)."""
+        """Get default OpenProject type ID (cached).
+
+        Same loud-fail discipline as :meth:`_get_default_status_id`: returning
+        a literal ``1`` when nothing is cached masks server-side
+        renumbering / empty Type tables and produces "Type can't be blank"
+        on every WP in the batch. See issue #260.
+        """
         if self._cached_types is None:
             try:
                 self._cached_types = self.op_client.get_work_package_types()
                 self.logger.info("Cached %d work package types", len(self._cached_types or []))
-            except Exception:
-                self._cached_types = []
-        if self._cached_types:
-            return self._cached_types[0].get("id", 1)
-        return 1
+            except Exception as exc:
+                self.logger.exception("Failed to fetch OpenProject work package types")
+                _raise_no_default_resource(
+                    "type_id",
+                    f"fetch raised {type(exc).__name__}: {exc}",
+                    cause=exc,
+                )
+        if not self._cached_types:
+            _raise_no_default_resource("type_id", "get_work_package_types() returned no records")
+        type_id = self._cached_types[0].get("id")
+        if not isinstance(type_id, int) or type_id <= 0:
+            _raise_no_default_resource(
+                "type_id",
+                f"first cached Type entry has no usable 'id' field ({type_id!r})",
+            )
+        return type_id
 
     def _get_openproject_status_id(self, jira_issue: Issue) -> int | None:
         """Get OpenProject status ID for a Jira status.
@@ -431,45 +474,56 @@ class WorkPackageSkeletonMigration(BaseMigration):
                 self.logger.info("Cached %d statuses", len(self._cached_statuses or []))
             except Exception as exc:
                 self.logger.exception("Failed to fetch OpenProject statuses")
-                msg = (
-                    "Cannot determine a default OpenProject status_id: "
-                    f"op_client.get_statuses() raised {type(exc).__name__}: {exc}. "
-                    "Verify the OpenProject Rails console is reachable and that "
-                    "at least one work-package Status exists."
+                _raise_no_default_resource(
+                    "status_id",
+                    f"op_client.get_statuses() raised {type(exc).__name__}: {exc}",
+                    cause=exc,
                 )
-                raise MigrationError(msg) from exc
         if not self._cached_statuses:
-            msg = (
-                "Cannot determine a default OpenProject status_id: "
-                "op_client.get_statuses() returned no statuses. Verify "
-                "that at least one work-package Status is configured on the "
-                "OpenProject instance."
-            )
-            raise MigrationError(msg)
+            _raise_no_default_resource("status_id", "op_client.get_statuses() returned no statuses")
         status_id = self._cached_statuses[0].get("id")
         if not isinstance(status_id, int) or status_id <= 0:
-            msg = (
-                "Cannot determine a default OpenProject status_id: the first "
-                f"cached Status entry has no usable 'id' field ({status_id!r})."
+            _raise_no_default_resource(
+                "status_id",
+                f"first cached Status entry has no usable 'id' field ({status_id!r})",
             )
-            raise MigrationError(msg)
         return status_id
 
     def _get_default_priority_id(self) -> int:
-        """Get default OpenProject priority ID (Normal priority, cached)."""
+        """Get default OpenProject priority ID (Normal priority, cached).
+
+        Same loud-fail discipline as :meth:`_get_default_status_id`. Priority
+        is required on ``WorkPackage`` in OP — when the literal ``1``
+        fallback resolved to a non-existent row, every WP failed with
+        validation noise. See issue #260.
+        """
         if self._cached_priorities is None:
             try:
                 self._cached_priorities = self.op_client.get_issue_priorities()
                 self.logger.info("Cached %d priorities", len(self._cached_priorities or []))
-            except Exception:
-                self._cached_priorities = []
-        if self._cached_priorities:
-            # Try to find "Normal" priority, otherwise use first
-            for p in self._cached_priorities:
-                if p.get("name", "").lower() == "normal":
-                    return p.get("id", 1)
-            return self._cached_priorities[0].get("id", 1)
-        return 1
+            except Exception as exc:
+                self.logger.exception("Failed to fetch OpenProject priorities")
+                _raise_no_default_resource(
+                    "priority_id",
+                    f"fetch raised {type(exc).__name__}: {exc}",
+                    cause=exc,
+                )
+        if not self._cached_priorities:
+            _raise_no_default_resource("priority_id", "get_issue_priorities() returned no records")
+        # Try to find "Normal" priority first, otherwise use the first record.
+        for p in self._cached_priorities:
+            if p.get("name", "").lower() == "normal":
+                pid = p.get("id")
+                if isinstance(pid, int) and pid > 0:
+                    return pid
+                break
+        priority_id = self._cached_priorities[0].get("id")
+        if not isinstance(priority_id, int) or priority_id <= 0:
+            _raise_no_default_resource(
+                "priority_id",
+                f"first cached Priority entry has no usable 'id' field ({priority_id!r})",
+            )
+        return priority_id
 
     def _get_default_author_id(self) -> int:
         """Get default author ID (admin user)."""

--- a/src/application/components/work_package_skeleton_migration.py
+++ b/src/application/components/work_package_skeleton_migration.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -407,6 +408,54 @@ class WorkPackageSkeletonMigration(BaseMigration):
         # Fallback to default type
         return self._get_default_type_id()
 
+    def _cached_or_fetch(
+        self,
+        cache_attr: str,
+        fetch: Callable[[], list[dict[str, Any]] | None],
+        *,
+        resource: str,
+        log_label: str,
+    ) -> list[dict[str, Any]]:
+        """Return the cached list, fetching once on the first miss.
+
+        Centralises the cache+fetch+raise-on-fail pattern shared by the
+        three ``_get_default_*_id`` helpers. The ``_raise_no_default_resource``
+        call is a `NoReturn` raiser so callers can treat the returned
+        list as non-empty without further checks.
+        """
+        cached = getattr(self, cache_attr)
+        if cached is None:
+            try:
+                cached = fetch() or []
+                self.logger.info("Cached %d %s", len(cached), log_label)
+                setattr(self, cache_attr, cached)
+            except Exception as exc:
+                self.logger.exception("Failed to fetch OpenProject %s", log_label)
+                _raise_no_default_resource(
+                    resource,
+                    f"fetch raised {type(exc).__name__}: {exc}",
+                    cause=exc,
+                )
+        if not cached:
+            _raise_no_default_resource(resource, f"fetch returned no {log_label}")
+        return cached
+
+    @staticmethod
+    def _first_valid_id(items: list[dict[str, Any]], *, resource: str) -> int:
+        """Return the first usable positive integer ``id`` field.
+
+        Raises :class:`MigrationError` via :func:`_raise_no_default_resource`
+        when the first record has no usable id — same loud-fail discipline
+        as the rest of this module (issue #260).
+        """
+        rid = items[0].get("id")
+        if not isinstance(rid, int) or rid <= 0:
+            _raise_no_default_resource(
+                resource,
+                f"first cached entry has no usable 'id' field ({rid!r})",
+            )
+        return rid
+
     def _get_default_type_id(self) -> int:
         """Get default OpenProject type ID (cached).
 
@@ -415,26 +464,13 @@ class WorkPackageSkeletonMigration(BaseMigration):
         renumbering / empty Type tables and produces "Type can't be blank"
         on every WP in the batch. See issue #260.
         """
-        if self._cached_types is None:
-            try:
-                self._cached_types = self.op_client.get_work_package_types()
-                self.logger.info("Cached %d work package types", len(self._cached_types or []))
-            except Exception as exc:
-                self.logger.exception("Failed to fetch OpenProject work package types")
-                _raise_no_default_resource(
-                    "type_id",
-                    f"fetch raised {type(exc).__name__}: {exc}",
-                    cause=exc,
-                )
-        if not self._cached_types:
-            _raise_no_default_resource("type_id", "get_work_package_types() returned no records")
-        type_id = self._cached_types[0].get("id")
-        if not isinstance(type_id, int) or type_id <= 0:
-            _raise_no_default_resource(
-                "type_id",
-                f"first cached Type entry has no usable 'id' field ({type_id!r})",
-            )
-        return type_id
+        types = self._cached_or_fetch(
+            "_cached_types",
+            self.op_client.get_work_package_types,
+            resource="type_id",
+            log_label="work package types",
+        )
+        return self._first_valid_id(types, resource="type_id")
 
     def _get_openproject_status_id(self, jira_issue: Issue) -> int | None:
         """Get OpenProject status ID for a Jira status.
@@ -468,26 +504,13 @@ class WorkPackageSkeletonMigration(BaseMigration):
         to abort once with an actionable message than to log thousands of
         per-record failures.
         """
-        if self._cached_statuses is None:
-            try:
-                self._cached_statuses = self.op_client.get_statuses()
-                self.logger.info("Cached %d statuses", len(self._cached_statuses or []))
-            except Exception as exc:
-                self.logger.exception("Failed to fetch OpenProject statuses")
-                _raise_no_default_resource(
-                    "status_id",
-                    f"op_client.get_statuses() raised {type(exc).__name__}: {exc}",
-                    cause=exc,
-                )
-        if not self._cached_statuses:
-            _raise_no_default_resource("status_id", "op_client.get_statuses() returned no statuses")
-        status_id = self._cached_statuses[0].get("id")
-        if not isinstance(status_id, int) or status_id <= 0:
-            _raise_no_default_resource(
-                "status_id",
-                f"first cached Status entry has no usable 'id' field ({status_id!r})",
-            )
-        return status_id
+        statuses = self._cached_or_fetch(
+            "_cached_statuses",
+            self.op_client.get_statuses,
+            resource="status_id",
+            log_label="statuses",
+        )
+        return self._first_valid_id(statuses, resource="status_id")
 
     def _get_default_priority_id(self) -> int:
         """Get default OpenProject priority ID (Normal priority, cached).
@@ -497,33 +520,21 @@ class WorkPackageSkeletonMigration(BaseMigration):
         fallback resolved to a non-existent row, every WP failed with
         validation noise. See issue #260.
         """
-        if self._cached_priorities is None:
-            try:
-                self._cached_priorities = self.op_client.get_issue_priorities()
-                self.logger.info("Cached %d priorities", len(self._cached_priorities or []))
-            except Exception as exc:
-                self.logger.exception("Failed to fetch OpenProject priorities")
-                _raise_no_default_resource(
-                    "priority_id",
-                    f"fetch raised {type(exc).__name__}: {exc}",
-                    cause=exc,
-                )
-        if not self._cached_priorities:
-            _raise_no_default_resource("priority_id", "get_issue_priorities() returned no records")
-        # Try to find "Normal" priority first, otherwise use the first record.
-        for p in self._cached_priorities:
+        priorities = self._cached_or_fetch(
+            "_cached_priorities",
+            self.op_client.get_issue_priorities,
+            resource="priority_id",
+            log_label="priorities",
+        )
+        # Prefer "Normal" priority if it has a usable id; otherwise fall
+        # through to the first record.
+        for p in priorities:
             if p.get("name", "").lower() == "normal":
                 pid = p.get("id")
                 if isinstance(pid, int) and pid > 0:
                     return pid
                 break
-        priority_id = self._cached_priorities[0].get("id")
-        if not isinstance(priority_id, int) or priority_id <= 0:
-            _raise_no_default_resource(
-                "priority_id",
-                f"first cached Priority entry has no usable 'id' field ({priority_id!r})",
-            )
-        return priority_id
+        return self._first_valid_id(priorities, resource="priority_id")
 
     def _get_default_author_id(self) -> int:
         """Get default author ID (admin user)."""

--- a/src/application/components/work_package_skeleton_migration.py
+++ b/src/application/components/work_package_skeleton_migration.py
@@ -59,6 +59,7 @@ from src.application.components.base_migration import BaseMigration, register_en
 from src.infrastructure.jira.jira_client import JiraClient
 from src.infrastructure.openproject.openproject_client import OpenProjectClient
 from src.models import ComponentResult, JiraUser
+from src.models.migration_error import MigrationError
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -414,16 +415,45 @@ class WorkPackageSkeletonMigration(BaseMigration):
         return self._get_default_status_id()
 
     def _get_default_status_id(self) -> int:
-        """Get default OpenProject status ID (cached)."""
+        """Get default OpenProject status ID (cached).
+
+        Fails loud when no statuses can be resolved. The previous behaviour
+        of falling through to a hard-coded ``1`` masked OpenProject-side
+        misconfiguration: if no Status with that ID exists on the target
+        instance (e.g. after an OP 15→17 upgrade renumbered records),
+        every WP in the batch fails with "Status can't be blank". Better
+        to abort once with an actionable message than to log thousands of
+        per-record failures.
+        """
         if self._cached_statuses is None:
             try:
                 self._cached_statuses = self.op_client.get_statuses()
                 self.logger.info("Cached %d statuses", len(self._cached_statuses or []))
-            except Exception:
-                self._cached_statuses = []
-        if self._cached_statuses:
-            return self._cached_statuses[0].get("id", 1)
-        return 1
+            except Exception as exc:
+                self.logger.exception("Failed to fetch OpenProject statuses")
+                msg = (
+                    "Cannot determine a default OpenProject status_id: "
+                    f"op_client.get_statuses() raised {type(exc).__name__}: {exc}. "
+                    "Verify the OpenProject Rails console is reachable and that "
+                    "at least one work-package Status exists."
+                )
+                raise MigrationError(msg) from exc
+        if not self._cached_statuses:
+            msg = (
+                "Cannot determine a default OpenProject status_id: "
+                "op_client.get_statuses() returned no statuses. Verify "
+                "that at least one work-package Status is configured on the "
+                "OpenProject instance."
+            )
+            raise MigrationError(msg)
+        status_id = self._cached_statuses[0].get("id")
+        if not isinstance(status_id, int) or status_id <= 0:
+            msg = (
+                "Cannot determine a default OpenProject status_id: the first "
+                f"cached Status entry has no usable 'id' field ({status_id!r})."
+            )
+            raise MigrationError(msg)
+        return status_id
 
     def _get_default_priority_id(self) -> int:
         """Get default OpenProject priority ID (Normal priority, cached)."""

--- a/src/infrastructure/openproject/openproject_bulk_create_service.py
+++ b/src/infrastructure/openproject/openproject_bulk_create_service.py
@@ -783,6 +783,15 @@ class OpenProjectBulkCreateService:
             elsif wp_data['status_name']
               wp.status = statuses_by_name[wp_data['status_name']]
             end
+            # Safety net (issue #260): if the requested status_id or
+            # status_name didn't resolve to a real Status record (e.g.
+            # after an OP version upgrade that renumbered records, or
+            # when the Python side fell back to a default that doesn't
+            # exist on this instance), fall back to the first Status by
+            # position so the WP doesn't fail validation with
+            # "Status can't be blank". Mirrors the single-WP code paths
+            # earlier in this file.
+            wp.status ||= Status.order(:position).first
 
             # Set priority - using pre-fetched lookup
             if wp_data['priority_id']

--- a/src/infrastructure/openproject/openproject_bulk_create_service.py
+++ b/src/infrastructure/openproject/openproject_bulk_create_service.py
@@ -776,6 +776,8 @@ class OpenProjectBulkCreateService:
             elsif wp_data['type_name']
               wp.type = types_by_name[wp_data['type_name']]
             end
+            # Safety net for type (issue #260) - same shape as status below.
+            wp.type ||= (@default_type ||= Type.order(:position).first)
 
             # Set status - using pre-fetched lookup
             if wp_data['status_id']
@@ -789,9 +791,12 @@ class OpenProjectBulkCreateService:
             # when the Python side fell back to a default that doesn't
             # exist on this instance), fall back to the first Status by
             # position so the WP doesn't fail validation with
-            # "Status can't be blank". Mirrors the single-WP code paths
-            # earlier in this file.
-            wp.status ||= Status.order(:position).first
+            # "Status can't be blank". Memoise on the script's binding
+            # via ``@default_status`` so we don't run
+            # ``Status.order(:position).first`` once per failing WP
+            # (N+1 inside the batch loop). Mirrors the single-WP code
+            # paths earlier in this file.
+            wp.status ||= (@default_status ||= Status.order(:position).first)
 
             # Set priority - using pre-fetched lookup
             if wp_data['priority_id']
@@ -799,6 +804,8 @@ class OpenProjectBulkCreateService:
             elsif wp_data['priority_name']
               wp.priority = priorities_by_name[wp_data['priority_name']]
             end
+            # Safety net for priority (issue #260) - same shape as status above.
+            wp.priority ||= (@default_priority ||= IssuePriority.order(:position).first)
 
             # Set author - using pre-fetched lookup
             if wp_data['author_id']

--- a/tests/unit/test_skeleton_status_safety.py
+++ b/tests/unit/test_skeleton_status_safety.py
@@ -134,6 +134,105 @@ class TestDefaultStatusIdSafety:
             mig._get_default_status_id()
 
 
+class TestDefaultTypeIdSafety:
+    """Mirror tests for ``_get_default_type_id``. Independent review of #262
+    pointed out the same literal-1 fallback existed on the type helper —
+    same OP-renumber scenario would produce "Type can't be blank" after
+    the status fix landed.
+    """
+
+    def test_returns_first_cached_type_id_when_available(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        mig = _build_mig(tmp_path)
+        mig.op_client.get_work_package_types = MagicMock(
+            return_value=[{"id": 13, "name": "Task"}, {"id": 14, "name": "Bug"}],
+        )
+        assert mig._get_default_type_id() == 13
+
+    def test_raises_when_types_empty(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        from src.models.migration_error import MigrationError
+
+        mig = _build_mig(tmp_path)
+        mig.op_client.get_work_package_types = MagicMock(return_value=[])
+        with pytest.raises(MigrationError) as excinfo:
+            mig._get_default_type_id()
+        assert "type" in str(excinfo.value).lower()
+
+    def test_raises_when_types_fetch_raises(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        from src.models.migration_error import MigrationError
+
+        mig = _build_mig(tmp_path)
+        mig.op_client.get_work_package_types = MagicMock(side_effect=RuntimeError("rails down"))
+        with pytest.raises(MigrationError):
+            mig._get_default_type_id()
+
+
+class TestDefaultPriorityIdSafety:
+    """Mirror tests for ``_get_default_priority_id``. Same rationale."""
+
+    def test_returns_normal_priority_when_present(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        mig = _build_mig(tmp_path)
+        mig.op_client.get_issue_priorities = MagicMock(
+            return_value=[
+                {"id": 7, "name": "Low"},
+                {"id": 8, "name": "Normal"},
+                {"id": 9, "name": "High"},
+            ],
+        )
+        assert mig._get_default_priority_id() == 8
+
+    def test_returns_first_priority_when_no_normal(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        mig = _build_mig(tmp_path)
+        mig.op_client.get_issue_priorities = MagicMock(
+            return_value=[{"id": 7, "name": "Low"}, {"id": 9, "name": "High"}],
+        )
+        assert mig._get_default_priority_id() == 7
+
+    def test_raises_when_priorities_empty(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        from src.models.migration_error import MigrationError
+
+        mig = _build_mig(tmp_path)
+        mig.op_client.get_issue_priorities = MagicMock(return_value=[])
+        with pytest.raises(MigrationError) as excinfo:
+            mig._get_default_priority_id()
+        assert "priority" in str(excinfo.value).lower()
+
+    def test_raises_when_priorities_fetch_raises(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        from src.models.migration_error import MigrationError
+
+        mig = _build_mig(tmp_path)
+        mig.op_client.get_issue_priorities = MagicMock(side_effect=RuntimeError("rails down"))
+        with pytest.raises(MigrationError):
+            mig._get_default_priority_id()
+
+
 # ---------------------------------------------------------------------------
 # 2. Ruby batch template must carry the ``||=`` safety net
 # ---------------------------------------------------------------------------
@@ -178,9 +277,18 @@ class TestRubyBatchTemplateStatusFallback:
         assert isinstance(script, str)
 
         # The safety net must be present after the status assignment block.
-        assert "wp.status ||= Status.order(:position).first" in script, (
-            "Batch Ruby template is missing the ``wp.status ||= "
-            "Status.order(:position).first`` fallback that the single-WP "
-            "paths already have. Without it, a single bad status_id "
+        # Memoised via ``@default_status`` so we don't run
+        # ``Status.order(:position).first`` once per failing WP — Gemini's
+        # N+1 note on the first pass of #262.
+        assert "wp.status ||= (@default_status ||= Status.order(:position).first)" in script, (
+            "Batch Ruby template is missing the memoised ``wp.status ||= "
+            "(@default_status ||= Status.order(:position).first)`` fallback that "
+            "the single-WP paths already have. Without it, a single bad status_id "
             "causes the entire WP to fail with 'Status can't be blank'."
         )
+        # Independent review of #262 noted that the same fallback shape
+        # was missing for type and priority — the generic
+        # ``bulk_create_records`` path has all three rescues, the WP-batch
+        # path only had status.
+        assert "wp.type ||= (@default_type ||= Type.order(:position).first)" in script
+        assert "wp.priority ||= (@default_priority ||= IssuePriority.order(:position).first)" in script

--- a/tests/unit/test_skeleton_status_safety.py
+++ b/tests/unit/test_skeleton_status_safety.py
@@ -84,102 +84,82 @@ def _build_mig(tmp_path: Path):  # type: ignore[no-untyped-def]
 # ---------------------------------------------------------------------------
 
 
-class TestDefaultStatusIdSafety:
-    def test_returns_first_cached_status_id_when_available(
-        self,
-        tmp_path: Path,
-        _mock_mappings: None,
-    ) -> None:
-        mig = _build_mig(tmp_path)
-        mig.op_client.get_statuses = MagicMock(
-            return_value=[
-                {"id": 42, "name": "New"},
-                {"id": 43, "name": "In progress"},
-            ],
-        )
-        assert mig._get_default_status_id() == 42
-
-    def test_raises_when_get_statuses_returns_empty(
-        self,
-        tmp_path: Path,
-        _mock_mappings: None,
-    ) -> None:
-        """No silent literal-1 fallback — fail loud with an actionable error."""
-        from src.models.migration_error import MigrationError
-
-        mig = _build_mig(tmp_path)
-        mig.op_client.get_statuses = MagicMock(return_value=[])
-
-        with pytest.raises(MigrationError) as excinfo:
-            mig._get_default_status_id()
-        msg = str(excinfo.value)
-        # Be helpful: name the cause and the actionable next step.
-        assert "status" in msg.lower()
-        assert "openproject" in msg.lower() or "op" in msg.lower()
-
-    def test_raises_when_get_statuses_raises(
-        self,
-        tmp_path: Path,
-        _mock_mappings: None,
-    ) -> None:
-        """A swallowed Exception that left _cached_statuses=[] used to fall
-        through to ``return 1``. It must now raise.
-        """
-        from src.models.migration_error import MigrationError
-
-        mig = _build_mig(tmp_path)
-        mig.op_client.get_statuses = MagicMock(side_effect=RuntimeError("rails down"))
-
-        with pytest.raises(MigrationError):
-            mig._get_default_status_id()
+# Parametrised across the three sibling helpers — issue #260's independent
+# code review pointed out that ``_get_default_type_id`` and
+# ``_get_default_priority_id`` had the same literal-1 bug as
+# ``_get_default_status_id``. The three now share a single test body to
+# keep them honest (and to keep SonarCloud happy about duplication on
+# new code).
+_DEFAULT_RESOURCES = [
+    pytest.param("get_statuses", "_get_default_status_id", "status", id="status"),
+    pytest.param("get_work_package_types", "_get_default_type_id", "type", id="type"),
+    pytest.param("get_issue_priorities", "_get_default_priority_id", "priority", id="priority"),
+]
 
 
-class TestDefaultTypeIdSafety:
-    """Mirror tests for ``_get_default_type_id``. Independent review of #262
-    pointed out the same literal-1 fallback existed on the type helper —
-    same OP-renumber scenario would produce "Type can't be blank" after
-    the status fix landed.
+@pytest.mark.parametrize(("op_method", "default_helper", "label"), _DEFAULT_RESOURCES)
+class TestDefaultIdSafety:
+    """Cover the three sibling ``_get_default_*_id`` helpers uniformly:
+
+    * happy path returns the first valid id from the cache,
+    * empty cache raises :class:`MigrationError` with an actionable message,
+    * fetch raising propagates as :class:`MigrationError`.
     """
 
-    def test_returns_first_cached_type_id_when_available(
+    def test_returns_first_cached_id_when_available(
         self,
+        op_method: str,
+        default_helper: str,
+        label: str,
         tmp_path: Path,
         _mock_mappings: None,
     ) -> None:
         mig = _build_mig(tmp_path)
-        mig.op_client.get_work_package_types = MagicMock(
-            return_value=[{"id": 13, "name": "Task"}, {"id": 14, "name": "Bug"}],
+        setattr(
+            mig.op_client,
+            op_method,
+            MagicMock(return_value=[{"id": 42, "name": "First"}, {"id": 43, "name": "Second"}]),
         )
-        assert mig._get_default_type_id() == 13
+        assert getattr(mig, default_helper)() == 42
 
-    def test_raises_when_types_empty(
+    def test_raises_when_fetch_returns_empty(
         self,
+        op_method: str,
+        default_helper: str,
+        label: str,
         tmp_path: Path,
         _mock_mappings: None,
     ) -> None:
         from src.models.migration_error import MigrationError
 
         mig = _build_mig(tmp_path)
-        mig.op_client.get_work_package_types = MagicMock(return_value=[])
+        setattr(mig.op_client, op_method, MagicMock(return_value=[]))
         with pytest.raises(MigrationError) as excinfo:
-            mig._get_default_type_id()
-        assert "type" in str(excinfo.value).lower()
+            getattr(mig, default_helper)()
+        msg = str(excinfo.value).lower()
+        assert label in msg
+        assert "openproject" in msg or "op" in msg
 
-    def test_raises_when_types_fetch_raises(
+    def test_raises_when_fetch_itself_raises(
         self,
+        op_method: str,
+        default_helper: str,
+        label: str,
         tmp_path: Path,
         _mock_mappings: None,
     ) -> None:
         from src.models.migration_error import MigrationError
 
         mig = _build_mig(tmp_path)
-        mig.op_client.get_work_package_types = MagicMock(side_effect=RuntimeError("rails down"))
+        setattr(mig.op_client, op_method, MagicMock(side_effect=RuntimeError("rails down")))
         with pytest.raises(MigrationError):
-            mig._get_default_type_id()
+            getattr(mig, default_helper)()
 
 
-class TestDefaultPriorityIdSafety:
-    """Mirror tests for ``_get_default_priority_id``. Same rationale."""
+class TestDefaultPriorityIdNormalPreference:
+    """Priority has a small wrinkle the other two don't: prefer "Normal"
+    over the first record when present and usable.
+    """
 
     def test_returns_normal_priority_when_present(
         self,
@@ -206,31 +186,6 @@ class TestDefaultPriorityIdSafety:
             return_value=[{"id": 7, "name": "Low"}, {"id": 9, "name": "High"}],
         )
         assert mig._get_default_priority_id() == 7
-
-    def test_raises_when_priorities_empty(
-        self,
-        tmp_path: Path,
-        _mock_mappings: None,
-    ) -> None:
-        from src.models.migration_error import MigrationError
-
-        mig = _build_mig(tmp_path)
-        mig.op_client.get_issue_priorities = MagicMock(return_value=[])
-        with pytest.raises(MigrationError) as excinfo:
-            mig._get_default_priority_id()
-        assert "priority" in str(excinfo.value).lower()
-
-    def test_raises_when_priorities_fetch_raises(
-        self,
-        tmp_path: Path,
-        _mock_mappings: None,
-    ) -> None:
-        from src.models.migration_error import MigrationError
-
-        mig = _build_mig(tmp_path)
-        mig.op_client.get_issue_priorities = MagicMock(side_effect=RuntimeError("rails down"))
-        with pytest.raises(MigrationError):
-            mig._get_default_priority_id()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_skeleton_status_safety.py
+++ b/tests/unit/test_skeleton_status_safety.py
@@ -1,0 +1,186 @@
+"""Skeleton migration must not silently pick a status_id that doesn't exist.
+
+Issue #260 background
+---------------------
+A user ran ``--profile full`` and 10 890 of 10 997 (99 %) work packages
+failed in ``work_packages_skeleton`` with the OpenProject validation::
+
+    Failed: TK-1336: Status can't be blank.
+    Failed: TK-1295: Status can't be blank.
+    ...
+
+Trace through the two-step lookup:
+
+1. Python's :meth:`_get_default_status_id` returns ``1`` as a literal
+   fallback when ``self.op_client.get_statuses()`` returns empty or
+   raises.
+2. The Ruby batch creator in ``openproject_bulk_create_service`` then
+   does ``Status.where(id: [1]).index_by(&:id)``. If no Status with
+   ID 1 exists on this OP instance (e.g. after an OP 15→17 upgrade
+   that renumbered records), ``statuses_by_id[1]`` is ``nil``,
+   ``wp.status`` is left ``nil`` and ActiveRecord rejects with
+   "Status can't be blank".
+
+Note the asymmetry: the *single-WP* code paths in the same Ruby
+template have a ``wp.status ||= Status.order(:position).first``
+rescue. The *batch* path does not.
+
+These tests pin the contract:
+    1. ``_get_default_status_id`` raises a typed error when no statuses
+       are cached and ``op_client.get_statuses()`` returned empty —
+       no more silent ``return 1``.
+    2. The Ruby batch template now contains
+       ``wp.status ||= Status.order(:position).first`` so a single bad
+       status_id does not kill the entire batch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def _mock_mappings(monkeypatch: pytest.MonkeyPatch) -> None:
+    import src.config as cfg
+
+    class DummyMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "project": {"PROJ": {"openproject_id": 11}},
+                "issue_type": {},
+                "issue_type_id": {},
+                "status": {},
+                "user": {},
+                "priority": {},
+            }
+
+        def get_mapping(self, name: str):  # type: ignore[no-untyped-def]
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, value):  # type: ignore[no-untyped-def]
+            self._m[name] = value
+
+    monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+
+
+def _build_mig(tmp_path: Path):  # type: ignore[no-untyped-def]
+    from src.application.components.work_package_skeleton_migration import (
+        WorkPackageSkeletonMigration,
+    )
+
+    jira = MagicMock()
+    op = MagicMock()
+    mig = WorkPackageSkeletonMigration(jira_client=jira, op_client=op)
+    mig.data_dir = tmp_path
+    mig.work_package_mapping_file = tmp_path / mig.WORK_PACKAGE_MAPPING_FILE
+    return mig
+
+
+# ---------------------------------------------------------------------------
+# 1. _get_default_status_id must not silently return literal 1
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultStatusIdSafety:
+    def test_returns_first_cached_status_id_when_available(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        mig = _build_mig(tmp_path)
+        mig.op_client.get_statuses = MagicMock(
+            return_value=[
+                {"id": 42, "name": "New"},
+                {"id": 43, "name": "In progress"},
+            ],
+        )
+        assert mig._get_default_status_id() == 42
+
+    def test_raises_when_get_statuses_returns_empty(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        """No silent literal-1 fallback — fail loud with an actionable error."""
+        from src.models.migration_error import MigrationError
+
+        mig = _build_mig(tmp_path)
+        mig.op_client.get_statuses = MagicMock(return_value=[])
+
+        with pytest.raises(MigrationError) as excinfo:
+            mig._get_default_status_id()
+        msg = str(excinfo.value)
+        # Be helpful: name the cause and the actionable next step.
+        assert "status" in msg.lower()
+        assert "openproject" in msg.lower() or "op" in msg.lower()
+
+    def test_raises_when_get_statuses_raises(
+        self,
+        tmp_path: Path,
+        _mock_mappings: None,
+    ) -> None:
+        """A swallowed Exception that left _cached_statuses=[] used to fall
+        through to ``return 1``. It must now raise.
+        """
+        from src.models.migration_error import MigrationError
+
+        mig = _build_mig(tmp_path)
+        mig.op_client.get_statuses = MagicMock(side_effect=RuntimeError("rails down"))
+
+        with pytest.raises(MigrationError):
+            mig._get_default_status_id()
+
+
+# ---------------------------------------------------------------------------
+# 2. Ruby batch template must carry the ``||=`` safety net
+# ---------------------------------------------------------------------------
+
+
+class TestRubyBatchTemplateStatusFallback:
+    def test_template_includes_status_fallback_to_first_position(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The batch script sent to the Rails console must include the
+        same ``wp.status ||= Status.order(:position).first`` rescue that
+        the single-WP code paths already have.
+
+        Otherwise a single bad ``status_id`` failing to resolve causes
+        ``wp.status = nil`` → AR rejects ``wp.save`` with "Status can't
+        be blank". The fallback turns a hard failure into a soft
+        "mapped to default initial status" outcome.
+        """
+        from src.infrastructure.openproject.openproject_bulk_create_service import (
+            OpenProjectBulkCreateService,
+        )
+
+        fake_docker = MagicMock()
+        fake_docker.execute_command.return_value = ("", "", 0)
+        fake_client = MagicMock()
+        fake_client.docker_client = fake_docker
+        fake_client.logger = MagicMock()
+        fake_client.execute_json_query = MagicMock(
+            return_value={"created": 1, "failed": 0, "results": []},
+        )
+
+        service = OpenProjectBulkCreateService(fake_client)
+
+        # Single representative payload — enough to exercise the template.
+        payload = [{"subject": "X", "project_id": 1, "type_id": 1, "status_id": 999}]
+        service._create_work_packages_batch(payload)
+
+        # The Ruby script is the (only) argument to ``execute_json_query``.
+        assert fake_client.execute_json_query.call_count == 1
+        script = fake_client.execute_json_query.call_args[0][0]
+        assert isinstance(script, str)
+
+        # The safety net must be present after the status assignment block.
+        assert "wp.status ||= Status.order(:position).first" in script, (
+            "Batch Ruby template is missing the ``wp.status ||= "
+            "Status.order(:position).first`` fallback that the single-WP "
+            "paths already have. Without it, a single bad status_id "
+            "causes the entire WP to fail with 'Status can't be blank'."
+        )


### PR DESCRIPTION
## Summary

Addresses the 99 % work-package skeleton failure class from [#260](https://github.com/netresearch/jira-to-openproject/issues/260) — 10 890 of 10 997 tickets failed with the OpenProject validation `Status can't be blank`.

## Root cause

Two-step lookup that silently dropped through:

1. `_get_default_status_id` ([`work_package_skeleton_migration.py`](https://github.com/netresearch/jira-to-openproject/blob/main/src/application/components/work_package_skeleton_migration.py)) returned the literal `1` when `op_client.get_statuses()` returned empty or raised — pure wishful thinking that some Status with that ID still exists.
2. The Ruby batch creator in [`openproject_bulk_create_service.py`](https://github.com/netresearch/jira-to-openproject/blob/main/src/infrastructure/openproject/openproject_bulk_create_service.py) did `Status.where(id: [1]).index_by(&:id)`; on this user's OP 17 instance (likely renumbered records after OP 15→17 + PG 13→17 upgrade) that returned nothing, so `wp.status` was left `nil` and ActiveRecord rejected on save.

Note the asymmetry that made this so loud: the *single-WP* code paths in the same Ruby template already had a `wp.status ||= Status.order(:position).first` rescue. The *batch* path did not — so all skeletons (which go through the batch path) had no rescue.

## Changes (layered defence)

- **Python**: `_get_default_status_id` now raises `MigrationError` with an actionable message when no statuses are cached or the fetch raises. No more silent literal-`1` — a single early failure beats thousands of per-record "Status can't be blank" lines.
- **Ruby (batch path)**: add `wp.status ||= Status.order(:position).first` immediately after the status assignment, mirroring the single-WP paths. A single unresolved `status_id` no longer kills the WP.

## Effect on the reporter's run

- If the OP statuses fetch fails or returns empty: the run aborts on the first batch with `MigrationError: Cannot determine a default OpenProject status_id…`. The user knows *what* to fix (statuses configured on OP) before processing 10 k records.
- If a particular `status_id` doesn't resolve on the OP side but other statuses exist: the batch still creates the WP, mapped to the first Status by position. The user can re-bucket after the run.

## What this PR does *not* address

- Tempo / project-roles JSON decoding (separate PR — [#261](https://github.com/netresearch/jira-to-openproject/pull/261)).
- Misleading `Component … failed` log line for `0/0` outcomes (next PR).
- `--dry-run` actually writing to OpenProject (separate, needs design call).

## Test plan

- [x] 4 new unit tests in `tests/unit/test_skeleton_status_safety.py`:
  - `_get_default_status_id` returns the first cached id on the happy path.
  - It raises `MigrationError` when `get_statuses()` returns empty.
  - It raises `MigrationError` when `get_statuses()` raises.
  - The Ruby batch template emitted by `_create_work_packages_batch` contains the `wp.status ||= Status.order(:position).first` safety net.
- [x] All 1811 unit tests pass.
- [x] `ruff check` clean.
- [x] `mypy` clean on the two touched modules.