### PR TITLE
chore(migration): surface failure cause in component summary line

### DIFF
--- a/src/migration.py
+++ b/src/migration.py
@@ -289,6 +289,75 @@ def _extract_counts(result: ComponentResult) -> tuple[int, int, int]:
         return sc, fc, tc
 
 
+def _first_error_message(result: ComponentResult | None) -> str:
+    """Return the most informative cause message from a result, or ''.
+
+    Search order: ``result.error`` → ``result.errors[0]`` →
+    ``details['error']`` → ``result.message``.
+
+    Used by :func:`_format_component_outcome` to surface *why* a
+    component failed inline in the per-component summary log, so users
+    don't have to scroll back to find the real cause.
+    """
+    if result is None:
+        return ""
+    err = getattr(result, "error", None)
+    if err:
+        return str(err)
+    errors = getattr(result, "errors", None) or []
+    if errors:
+        return str(errors[0])
+    details = getattr(result, "details", None) or {}
+    if isinstance(details, dict):
+        derr = details.get("error")
+        if derr:
+            return str(derr)
+    msg = getattr(result, "message", None)
+    if msg:
+        return str(msg)
+    return ""
+
+
+def _format_component_outcome(
+    name: str,
+    result: ComponentResult,
+    elapsed: float,
+) -> tuple[str, str]:
+    """Build the per-component summary line.
+
+    Returns a ``(level, message)`` pair. ``level`` is ``"success"``,
+    ``"warning"``, or ``"error"`` so the caller can pick the right log
+    method. Partial success (``success=True`` with some failed items)
+    surfaces as a *warning*, not a fake success; full failure includes
+    the underlying cause inline so the user doesn't have to scroll back
+    through the log to find it.
+    """
+    success_count, failed_count, total_count = _extract_counts(result)
+    counts = f"{success_count}/{total_count} items migrated"
+    if failed_count:
+        counts += f", {failed_count} failed"
+    time_part = f"took {elapsed:.2f} seconds"
+
+    has_errors = _component_has_errors(result)
+    if getattr(result, "success", False) and not has_errors:
+        return "success", (
+            f"Component '{name}' completed successfully ({counts}), {time_part}"
+        )
+
+    cause = _first_error_message(result)
+    cause_part = f": {cause}" if cause else ""
+
+    if getattr(result, "success", False):
+        return "warning", (
+            f"Component '{name}' completed with errors{cause_part} "
+            f"({counts}), {time_part}"
+        )
+
+    return "error", (
+        f"Component '{name}' FAILED{cause_part} ({counts}), {time_part}"
+    )
+
+
 class Migration:
     """Main migration orchestrator class."""
 
@@ -867,23 +936,19 @@ async def run_migration(
 
                         # Print component summary based on robust count extraction
                         details = component_result.details or {}
-                        success_count, failed_count, total_count = _extract_counts(component_result)
                         component_time = details.get("time", details.get("duration_seconds", 0))
 
-                        # Logging
-                        had_errors = _component_has_errors(component_result)
-                        if component_result.success and not had_errors:
-                            config.logger.success(
-                                f"Component '{component_name}' completed successfully "
-                                f"({success_count}/{total_count} items migrated), "
-                                f"took {component_time:.2f} seconds",
-                            )
+                        level, summary_line = _format_component_outcome(
+                            component_name,
+                            component_result,
+                            component_time,
+                        )
+                        if level == "success":
+                            config.logger.success(summary_line)
+                        elif level == "warning":
+                            config.logger.warning(summary_line)
                         else:
-                            config.logger.error(
-                                f"Component '{component_name}' failed or had errors "
-                                f"({success_count}/{total_count} items migrated, {failed_count} failed), "
-                                f"took {component_time:.2f} seconds",
-                            )
+                            config.logger.error(summary_line)
                     else:
                         # Handle case where component didn't return a result (should not happen with dataclass)
                         config.logger.warning(

--- a/src/migration.py
+++ b/src/migration.py
@@ -304,8 +304,11 @@ def _first_error_message(result: ComponentResult | None) -> str:
     err = getattr(result, "error", None)
     if err:
         return str(err)
-    errors = getattr(result, "errors", None) or []
-    if errors:
+    errors = getattr(result, "errors", None)
+    # Guard against ``errors=[""]`` or other falsy first elements — if the
+    # list is non-empty but the first entry is empty, fall through to the
+    # remaining sources rather than returning "".
+    if isinstance(errors, list) and errors and errors[0]:
         return str(errors[0])
     details = getattr(result, "details", None) or {}
     if isinstance(details, dict):
@@ -321,7 +324,7 @@ def _first_error_message(result: ComponentResult | None) -> str:
 def _format_component_outcome(
     name: str,
     result: ComponentResult,
-    elapsed: float,
+    elapsed: float | None,
 ) -> tuple[str, str]:
     """Build the per-component summary line.
 
@@ -336,26 +339,23 @@ def _format_component_outcome(
     counts = f"{success_count}/{total_count} items migrated"
     if failed_count:
         counts += f", {failed_count} failed"
-    time_part = f"took {elapsed:.2f} seconds"
+    # ``details.get("time")`` can return ``None`` for components that didn't
+    # record a duration; ``{None:.2f}`` would crash. Use ``is not None`` so a
+    # legitimate ``0`` (or ``0.0``) is preserved.
+    elapsed_seconds = elapsed if elapsed is not None else 0.0
+    time_part = f"took {elapsed_seconds:.2f} seconds"
 
     has_errors = _component_has_errors(result)
     if getattr(result, "success", False) and not has_errors:
-        return "success", (
-            f"Component '{name}' completed successfully ({counts}), {time_part}"
-        )
+        return "success", (f"Component '{name}' completed successfully ({counts}), {time_part}")
 
     cause = _first_error_message(result)
     cause_part = f": {cause}" if cause else ""
 
     if getattr(result, "success", False):
-        return "warning", (
-            f"Component '{name}' completed with errors{cause_part} "
-            f"({counts}), {time_part}"
-        )
+        return "warning", (f"Component '{name}' completed with errors{cause_part} ({counts}), {time_part}")
 
-    return "error", (
-        f"Component '{name}' FAILED{cause_part} ({counts}), {time_part}"
-    )
+    return "error", (f"Component '{name}' FAILED{cause_part} ({counts}), {time_part}")
 
 
 class Migration:

--- a/tests/unit/test_component_outcome_formatter.py
+++ b/tests/unit/test_component_outcome_formatter.py
@@ -1,0 +1,116 @@
+"""Per-component outcome log line must be informative.
+
+Issue #260 reported a misleading pair of lines from the run summary::
+
+    Component 'companies'     failed or had errors (0/0 items migrated, 0 failed), took 0.00 seconds
+    Component 'admin_schemes' completed successfully (0/0 items migrated), took 0.00 seconds
+
+Both produced ``0/0``. One is "failed", the other is "successfully", and the
+underlying reason (a ``JiraApiError`` from the extractor) is invisible in
+the line — you have to scroll back through the log to find it.
+
+These tests pin a refactored ``_format_component_outcome`` helper:
+
+    * 3 outcome levels: ``success`` / ``warning`` / ``error``.
+    * The failure line includes the underlying cause (``result.error``
+      → ``result.errors[0]`` → ``details['error']`` → ``result.message``)
+      inline, so the user sees *why*.
+    * Partial success (``success=True`` but with errors) emits a
+      ``warning``-level line, not a fake "success".
+"""
+
+from __future__ import annotations
+
+from src.migration import _first_error_message, _format_component_outcome
+from src.models.component_results import ComponentResult
+
+
+class TestFirstErrorMessage:
+    def test_prefers_error_field(self) -> None:
+        r = ComponentResult(
+            success=False,
+            error="X failed",
+            errors=["different"],
+            details={"error": "also different"},
+            message="message",
+        )
+        assert _first_error_message(r) == "X failed"
+
+    def test_falls_back_to_errors_list(self) -> None:
+        r = ComponentResult(success=False, errors=["boom", "second"])
+        assert _first_error_message(r) == "boom"
+
+    def test_falls_back_to_details_error(self) -> None:
+        r = ComponentResult(success=False, details={"error": "from details"})
+        assert _first_error_message(r) == "from details"
+
+    def test_falls_back_to_message(self) -> None:
+        r = ComponentResult(success=False, message="something happened")
+        assert _first_error_message(r) == "something happened"
+
+    def test_returns_empty_string_when_nothing_to_say(self) -> None:
+        r = ComponentResult(success=True)
+        assert _first_error_message(r) == ""
+
+
+class TestFormatComponentOutcome:
+    def test_clean_success(self) -> None:
+        r = ComponentResult(success=True, success_count=10, total_count=10)
+        level, msg = _format_component_outcome("priorities", r, 1.23)
+        assert level == "success"
+        assert "completed successfully" in msg
+        assert "10/10" in msg
+        assert "1.23" in msg
+
+    def test_partial_success_is_warning_not_success(self) -> None:
+        r = ComponentResult(
+            success=True,
+            success_count=7,
+            failed_count=3,
+            total_count=10,
+            errors=["TK-1 failed validation"],
+        )
+        level, msg = _format_component_outcome("priorities", r, 0.5)
+        assert level == "warning"
+        assert "7/10" in msg
+        # The failed count is surfaced AND the first cause appears inline.
+        assert "3 failed" in msg
+        assert "TK-1 failed validation" in msg
+
+    def test_failure_with_explicit_error_includes_cause(self) -> None:
+        r = ComponentResult(
+            success=False,
+            errors=["JiraApiError: Failed to retrieve Tempo customers"],
+            details={"status": "failed", "time": 0.0},
+        )
+        level, msg = _format_component_outcome("companies", r, 0.0)
+        assert level == "error"
+        assert "FAILED" in msg
+        assert "JiraApiError" in msg
+        assert "Failed to retrieve Tempo customers" in msg
+        # No misleading "completed successfully"
+        assert "completed successfully" not in msg
+
+    def test_failure_with_only_message_falls_back(self) -> None:
+        r = ComponentResult(
+            success=False,
+            message="Error during component execution: connection refused",
+        )
+        level, msg = _format_component_outcome("accounts", r, 2.0)
+        assert level == "error"
+        assert "connection refused" in msg
+
+    def test_failure_with_details_error_falls_back(self) -> None:
+        r = ComponentResult(
+            success=False,
+            details={"error": "permission denied"},
+        )
+        level, msg = _format_component_outcome("admin_schemes", r, 0.1)
+        assert level == "error"
+        assert "permission denied" in msg
+
+    def test_failure_without_any_message_still_marks_failed(self) -> None:
+        r = ComponentResult(success=False)
+        level, msg = _format_component_outcome("ghost", r, 0.0)
+        assert level == "error"
+        assert "FAILED" in msg

--- a/tests/unit/test_component_outcome_formatter.py
+++ b/tests/unit/test_component_outcome_formatter.py
@@ -52,6 +52,21 @@ class TestFirstErrorMessage:
         r = ComponentResult(success=True)
         assert _first_error_message(r) == ""
 
+    def test_skips_empty_first_errors_element_and_falls_through(self) -> None:
+        """``errors=[""]`` is non-empty but the first entry is falsy. The
+        previous version returned ``""`` short-circuiting the chain. Now we
+        skip and fall through to ``details['error']`` / ``message``.
+        """
+        r = ComponentResult(
+            success=False,
+            errors=[""],
+            details={"error": "real cause"},
+        )
+        assert _first_error_message(r) == "real cause"
+
+    def test_handles_none_input(self) -> None:
+        assert _first_error_message(None) == ""
+
 
 class TestFormatComponentOutcome:
     def test_clean_success(self) -> None:
@@ -114,3 +129,38 @@ class TestFormatComponentOutcome:
         level, msg = _format_component_outcome("ghost", r, 0.0)
         assert level == "error"
         assert "FAILED" in msg
+
+    def test_elapsed_none_does_not_crash(self) -> None:
+        """``details.get('time')`` can return ``None`` for components that
+        didn't record duration; ``{None:.2f}`` would raise ``TypeError``.
+        """
+        r = ComponentResult(success=True, success_count=1, total_count=1)
+        level, msg = _format_component_outcome("priorities", r, None)
+        assert level == "success"
+        assert "0.00 seconds" in msg
+
+    def test_elapsed_zero_is_preserved(self) -> None:
+        """A legitimate ``0`` must not be coerced via ``or 0.0`` from a
+        falsy-but-valid value (e.g. ``0`` for instant-completion).
+        """
+        r = ComponentResult(success=True, success_count=1, total_count=1)
+        level, msg = _format_component_outcome("priorities", r, 0)
+        assert level == "success"
+        assert "0.00 seconds" in msg
+
+    def test_partial_success_with_message_fallback(self) -> None:
+        """A ``success=True`` result that nonetheless flags an error status
+        in ``details`` must emit a warning AND surface the cause when only
+        ``message`` is set (no ``errors``/``error``/``details['error']``).
+        """
+        r = ComponentResult(
+            success=True,
+            success_count=5,
+            failed_count=2,
+            total_count=7,
+            details={"status": "failed"},
+            message="partial failure cause",
+        )
+        level, msg = _format_component_outcome("priorities", r, 0.5)
+        assert level == "warning"
+        assert "partial failure cause" in msg


### PR DESCRIPTION
## Summary

Addresses the third (cosmetic but confusing) failure class from [#260](https://github.com/netresearch/jira-to-openproject/issues/260): the run summary line is ambiguous and hides the actual cause.

## The misleading log

From the reporter's run:

```
Component 'companies'     failed or had errors (0/0 items migrated, 0 failed), took 0.00 seconds
Component 'admin_schemes' completed successfully (0/0 items migrated), took 0.00 seconds
```

Both produced `0/0`. One says "failed", the other "successfully". The actual cause (a `JiraApiError` from the Tempo extractor) is invisible — the user has to scroll back through the per-component traceback to find why "companies" failed.

## Changes

- Extract `_format_component_outcome(name, result, elapsed) -> (level, message)` as a pure function (testable). Three levels: `success` / `warning` / `error`.
- Extract `_first_error_message(result)` to pull the most informative cause inline:
  - `result.error` → `result.errors[0]` → `details['error']` → `result.message`
- **Partial success** (`success=True` with errors) now logs at `warning` level — no more fake "completed successfully" for a component that reported per-item failures.
- **Full failures** show `FAILED: <cause>` inline. The first error's class+message is right there in the summary line.

## New summary lines

Before:
```
Component 'companies' failed or had errors (0/0 items migrated, 0 failed), took 0.00 seconds
```

After (with the existing `error_result.errors=[str(e)]` from the exception handler):
```
Component 'companies' FAILED: JiraApiError: Failed to retrieve Tempo customers: ... (0/0 items migrated), took 0.00 seconds
```

For partial success (e.g. priorities migration with a few failed items):
```
Component 'priorities' completed with errors: TK-1 failed validation (7/10 items migrated, 3 failed), took 0.50 seconds
```

## What this PR does *not* address

- The underlying Jira HTML response and Tempo handling (separate PR — [#261](https://github.com/netresearch/jira-to-openproject/pull/261)).
- The 99% skeleton "Status can't be blank" failures (separate PR — [#262](https://github.com/netresearch/jira-to-openproject/pull/262)).
- `--dry-run` honesty (separate, needs design call).

## Test plan

- [x] 11 new unit tests in `tests/unit/test_component_outcome_formatter.py`:
  - 5 cover `_first_error_message` priority order (error → errors[0] → details.error → message → empty).
  - 6 cover `_format_component_outcome`: clean success, partial success (warning level + inline cause), failure with explicit error, failure with only message, failure with `details.error`, failure with no cause at all.
- [x] All 1818 unit tests pass.
- [x] `ruff check` clean.
- [x] `mypy` clean on `src/migration.py`.