### PR TITLE
feat(migration): gate --dry-run on declared component safety

### DIFF
--- a/src/application/components/base_migration.py
+++ b/src/application/components/base_migration.py
@@ -211,6 +211,14 @@ class BaseMigration:
     # access through ``_mapping_repo`` exclusively and retire the proxy.
     _mapping_repo: MappingRepository
 
+    # Honest --dry-run support flag (issue #260, PR D). Subclasses opt
+    # in by setting `DRY_RUN_SAFE = True`; the orchestrator's startup
+    # gate refuses to run under --dry-run when any requested component
+    # leaves this at the default False, unless --allow-unsafe-dry-run
+    # is passed. The `noqa: ERA001` keeps ruff from flagging the
+    # example-style explanation above as commented-out code.
+    DRY_RUN_SAFE: ClassVar[bool] = False
+
     def __init__(
         self,
         jira_client: JiraClient | None = None,

--- a/src/application/components/company_migration.py
+++ b/src/application/components/company_migration.py
@@ -32,7 +32,7 @@ out-of-scope and otherwise untouched.
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
@@ -57,6 +57,9 @@ class CompanyMigration(BaseMigration):
     - Tempo Account → Custom field in OpenProject projects and work packages
     - Jira Project → OpenProject project with account information stored in custom fields
     """
+
+    # Honours ``config.migration_config["dry_run"]`` (PR D, issue #260).
+    DRY_RUN_SAFE: ClassVar[bool] = True
 
     def __init__(
         self,

--- a/src/application/components/issue_type_migration.py
+++ b/src/application/components/issue_type_migration.py
@@ -35,7 +35,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
@@ -53,6 +53,10 @@ class IssueTypeMigration(BaseMigration):
     1. Generate a Ruby script for manual execution via Rails console (traditional approach)
     2. Execute commands directly on the Rails console using pexpect (direct approach)
     """
+
+    # Honours ``config.migration_config["dry_run"]`` by passing
+    # ``dry_run=True`` to the Rails type-create path (PR D, issue #260).
+    DRY_RUN_SAFE: ClassVar[bool] = True
 
     def __init__(
         self,

--- a/src/application/components/link_type_migration.py
+++ b/src/application/components/link_type_migration.py
@@ -21,7 +21,7 @@ deferred. Behaviour preserved.
 import json
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
@@ -76,6 +76,10 @@ class LinkTypeMigration(BaseMigration):
     2. Mapping Jira link types to OpenProject's built-in relation types
     3. Creating custom fields for unmapped link types
     """
+
+    # Honours ``config.migration_config["dry_run"]`` by skipping the
+    # custom-field creation step for unmapped link types (PR D, #260).
+    DRY_RUN_SAFE: ClassVar[bool] = True
 
     def __init__(self, jira_client: JiraClient, op_client: OpenProjectClient) -> None:
         """Initialize the link type migration tools.

--- a/src/application/components/project_migration.py
+++ b/src/application/components/project_migration.py
@@ -56,7 +56,7 @@ import json
 import re
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import ValidationError
 
@@ -107,6 +107,12 @@ class ProjectMigration(BaseMigration):
     - Jira projects as sub-projects under their respective Tempo company parent projects
     - Projects with account information stored in custom fields
     """
+
+    # Honours ``config.migration_config["dry_run"]`` by skipping the
+    # Rails-side ``projects:create_project_attributes`` script call (see
+    # ``DRY RUN: Skipping Rails script execution.`` log line); the
+    # orchestrator gate uses this flag in PR D (issue #260).
+    DRY_RUN_SAFE: ClassVar[bool] = True
 
     def __init__(
         self,

--- a/src/application/components/status_migration.py
+++ b/src/application/components/status_migration.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from src import config
 from src.application.components.base_migration import BaseMigration, register_entity_types
@@ -52,6 +52,11 @@ class StatusMigration(BaseMigration):
     2. Creating corresponding statuses in OpenProject
     3. Creating and maintaining the status mapping
     """
+
+    # Honours ``config.migration_config["dry_run"]`` by simulating
+    # mapping creation instead of running Rails-side Status.create
+    # (PR D, issue #260).
+    DRY_RUN_SAFE: ClassVar[bool] = True
 
     def __init__(
         self,

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -387,6 +387,9 @@ def update_from_cli_args(args: object) -> None:
     if hasattr(args, "dry_run") and args.dry_run:
         migration_config["dry_run"] = True
         logger.debug("Setting dry_run=True from CLI arguments")
+    if hasattr(args, "allow_unsafe_dry_run") and args.allow_unsafe_dry_run:
+        migration_config["allow_unsafe_dry_run"] = True
+        logger.debug("Setting allow_unsafe_dry_run=True from CLI arguments")
 
     if hasattr(args, "no_backup") and args.no_backup:
         migration_config["no_backup"] = True

--- a/src/main.py
+++ b/src/main.py
@@ -160,7 +160,21 @@ def main() -> None:
     migrate_parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Run without making changes to OpenProject",
+        help=(
+            "Run in dry-run mode. Refuses to run when the selected "
+            "components include any that do not honour the flag (would "
+            "still write to OpenProject); pass --allow-unsafe-dry-run "
+            "to override."
+        ),
+    )
+    migrate_parser.add_argument(
+        "--allow-unsafe-dry-run",
+        action="store_true",
+        help=(
+            "Allow --dry-run to proceed even when the selected components "
+            "include migrations that will still write to OpenProject. "
+            "A loud WARNING enumerates which components are unsafe."
+        ),
     )
     migrate_parser.add_argument(
         "--components",

--- a/src/migration.py
+++ b/src/migration.py
@@ -358,6 +358,100 @@ def _format_component_outcome(
     return "error", (f"Component '{name}' FAILED{cause_part} ({counts}), {time_part}")
 
 
+# ---------------------------------------------------------------------------
+# Dry-run safety registry (issue #260, PR D)
+#
+# This frozenset enumerates the components that internally honour
+# ``config.migration_config["dry_run"]`` and skip OpenProject writes when
+# the flag is set. Each named component also declares
+# ``DRY_RUN_SAFE: ClassVar[bool] = True`` on its class — the drift guard
+# at ``tests/unit/test_dry_run_safety_gate.py::TestRegistryClassAttributeDriftGuard``
+# keeps the two views in sync.
+#
+# All other components write to OpenProject regardless of ``--dry-run``;
+# the startup gate aborts when any of them is in scope, unless the
+# operator passes ``--allow-unsafe-dry-run`` to acknowledge the risk.
+# ---------------------------------------------------------------------------
+DRY_RUN_SAFE_COMPONENTS: frozenset[str] = frozenset(
+    {
+        "projects",
+        "issue_types",
+        "link_types",
+        "companies",
+        "status_types",
+    },
+)
+
+
+def _dry_run_safety_partition(requested: list[str]) -> tuple[list[str], list[str]]:
+    """Split requested component names into (safe, unsafe) under ``--dry-run``.
+
+    Unknown component names fall into ``unsafe`` — fail-closed for a flag
+    whose contract is "no changes to OpenProject".
+    """
+    safe = [name for name in requested if name in DRY_RUN_SAFE_COMPONENTS]
+    unsafe = [name for name in requested if name not in DRY_RUN_SAFE_COMPONENTS]
+    return safe, unsafe
+
+
+def _build_dry_run_banner(
+    *,
+    requested: list[str],
+    allow_unsafe: bool,
+) -> tuple[str, list[str], bool]:
+    """Build the dry-run startup banner.
+
+    Returns ``(level, lines, abort)``:
+
+    * ``level`` — ``"warning"`` or ``"error"``; selects the logger.
+    * ``lines`` — log lines to emit, or ``[]`` for nothing to say.
+    * ``abort`` — ``True`` when the orchestrator should refuse to run.
+    """
+    if not requested:
+        return "warning", [], False
+
+    safe, unsafe = _dry_run_safety_partition(requested)
+
+    if not unsafe:
+        return (
+            "warning",
+            [
+                "Running in DRY RUN mode.",
+                f"All requested components honour --dry-run: {', '.join(safe)}.",
+                "No changes will be made to OpenProject for these components.",
+            ],
+            False,
+        )
+
+    if not allow_unsafe:
+        return (
+            "error",
+            [
+                "Refusing to run --dry-run: the following requested components "
+                "do NOT honour the flag and would write to OpenProject:",
+                *(f"  - {name}" for name in unsafe),
+                "",
+                "Either restrict the run to dry-run-safe components "
+                f"({', '.join(sorted(DRY_RUN_SAFE_COMPONENTS))}), or pass "
+                "--allow-unsafe-dry-run to acknowledge that real writes will "
+                "still happen for the components above.",
+            ],
+            True,
+        )
+
+    safe_line = f"Safe (honour --dry-run): {', '.join(safe) or 'none'}." if safe else "Safe (honour --dry-run): none."
+    return (
+        "warning",
+        [
+            "Running in DRY RUN mode with --allow-unsafe-dry-run.",
+            safe_line,
+            "The following components will still write to OpenProject:",
+            *(f"  - {name}" for name in unsafe),
+        ],
+        False,
+    )
+
+
 class Migration:
     """Main migration orchestrator class."""
 
@@ -567,9 +661,21 @@ async def run_migration(
     try:
         # Check if we need a migration mode header
         if config.migration_config.get("dry_run", False):
-            config.logger.warning(
-                "Running in DRY RUN mode - no changes will be made to OpenProject",
+            allow_unsafe = bool(config.migration_config.get("allow_unsafe_dry_run", False))
+            level, lines, abort = _build_dry_run_banner(
+                requested=list(components or []),
+                allow_unsafe=allow_unsafe,
             )
+            log = config.logger.error if level == "error" else config.logger.warning
+            for line in lines:
+                log(line)
+            if abort:
+                msg = (
+                    "Aborting --dry-run: requested components include "
+                    "unsafe migrations. See log above; pass "
+                    "--allow-unsafe-dry-run to acknowledge."
+                )
+                raise SystemExit(msg)
             import asyncio as _asyncio
 
             await _asyncio.sleep(1)  # Give the user a moment to see this warning

--- a/src/migration.py
+++ b/src/migration.py
@@ -659,11 +659,19 @@ async def run_migration(
 
     """
     try:
+        # Resolve the effective component list NOW so the dry-run gate
+        # sees the same set the orchestrator will execute. Without this,
+        # a bare ``--dry-run`` (no ``--components``, no ``--profile``)
+        # arrives with ``components=None``; default expansion happens
+        # later in this function, and the gate would see an empty list
+        # and let the run proceed — re-introducing the #260 honesty bug.
+        effective_components = list(components) if components else list(DEFAULT_COMPONENT_SEQUENCE)
+
         # Check if we need a migration mode header
         if config.migration_config.get("dry_run", False):
             allow_unsafe = bool(config.migration_config.get("allow_unsafe_dry_run", False))
             level, lines, abort = _build_dry_run_banner(
-                requested=list(components or []),
+                requested=effective_components,
                 allow_unsafe=allow_unsafe,
             )
             log = config.logger.error if level == "error" else config.logger.warning
@@ -676,9 +684,10 @@ async def run_migration(
                     "--allow-unsafe-dry-run to acknowledge."
                 )
                 raise SystemExit(msg)
-            import asyncio as _asyncio
+            if lines:
+                import asyncio as _asyncio
 
-            await _asyncio.sleep(1)  # Give the user a moment to see this warning
+                await _asyncio.sleep(1)  # Give the user a moment to see this warning
             mode = "DRY RUN"
         else:
             mode = "PRODUCTION"

--- a/src/type_definitions.py
+++ b/src/type_definitions.py
@@ -109,6 +109,7 @@ class MigrationConfig(TypedDict):
     batch_size: int
     ssl_verify: bool
     dry_run: bool
+    allow_unsafe_dry_run: NotRequired[bool]
     force: bool
     no_backup: bool
     stop_on_error: bool

--- a/tests/end_to_end/test_complete_migration_workflow.py
+++ b/tests/end_to_end/test_complete_migration_workflow.py
@@ -959,12 +959,19 @@ class TestCompleteMigrationWorkflow:
             mock_file_handle.__exit__.return_value = None
             mock_open.return_value = mock_file_handle
 
-            # Configure for dry run
+            # Configure for dry run. ``users`` does not declare
+            # ``DRY_RUN_SAFE = True`` (PR D startup gate, issue #260),
+            # so this test must explicitly acknowledge that real OP
+            # writes can happen for unsafe components. The test's
+            # intent is exercising the orchestrator's dry-run path, not
+            # the safety gate; pass ``allow_unsafe_dry_run`` so the gate
+            # warns loudly but does not abort.
             with (
                 patch(
                     "src.config.migration_config",
                     {
                         "dry_run": True,
+                        "allow_unsafe_dry_run": True,
                         "no_backup": True,
                     },
                 ),

--- a/tests/unit/test_dry_run_safety_gate.py
+++ b/tests/unit/test_dry_run_safety_gate.py
@@ -26,12 +26,15 @@ can extend the safe-set incrementally without touching the orchestrator.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from src.migration import (
     DRY_RUN_SAFE_COMPONENTS,
     _build_dry_run_banner,
     _dry_run_safety_partition,
+    run_migration,
 )
 
 
@@ -183,3 +186,77 @@ class TestUnsafeComponentClassesStayUnsafe:
         assert getattr(cls, "DRY_RUN_SAFE", False) is False, (
             f"{class_name} does not honour --dry-run; it must NOT carry DRY_RUN_SAFE = True"
         )
+
+
+class TestRunMigrationGateIntegration:
+    """End-to-end gate behaviour: the abort must propagate out of
+    ``run_migration`` as a ``SystemExit`` (not a swallowed ``Exception``).
+
+    Independent code review of #264 noted that the outer ``try/except
+    Exception`` in ``run_migration`` correctly leaves ``BaseException``
+    subclasses alone — but nothing pinned that contract. A future
+    refactor swapping to ``except BaseException`` would silently
+    re-introduce the #260 honesty bug.
+    """
+
+    def test_bare_dry_run_with_unsafe_default_components_aborts(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The critical case: ``j2o migrate --dry-run`` with no
+        ``--components`` and no ``--profile``. Defaults expand to the
+        full sequence, which contains many unsafe components, and the
+        gate must abort. This pins the fix for the regression the
+        independent reviewer found on the first iteration of this PR.
+        """
+        monkeypatch.setattr(
+            "src.migration.config.migration_config",
+            {"dry_run": True, "no_backup": True},
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            # ``components=None`` triggers default expansion in
+            # ``run_migration`` — same path as bare ``--dry-run``.
+            asyncio.run(run_migration(components=None))
+        assert "--allow-unsafe-dry-run" in str(excinfo.value)
+
+    def test_dry_run_with_only_safe_components_does_not_abort(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Setting ``--components`` to only safe ones lets the run pass
+        the gate without ``--allow-unsafe-dry-run``. ``run_migration``
+        will then fail on downstream client setup (no real Jira / OP
+        configured), but the gate's own ``SystemExit`` must NOT fire.
+        """
+        monkeypatch.setattr(
+            "src.migration.config.migration_config",
+            {"dry_run": True, "no_backup": True},
+        )
+        # The outer ``try/except Exception`` in ``run_migration``
+        # swallows non-BaseException failures; assert it returns
+        # normally rather than aborting via the gate's SystemExit.
+        result = asyncio.run(run_migration(components=["projects"]))
+        # If the gate had aborted, SystemExit would have propagated and
+        # we'd never reach this assert.
+        assert result is not None
+
+    def test_dry_run_with_allow_unsafe_flag_does_not_abort(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``--allow-unsafe-dry-run`` lets the run pass the gate even
+        when unsafe components are in scope.
+        """
+        monkeypatch.setattr(
+            "src.migration.config.migration_config",
+            {
+                "dry_run": True,
+                "allow_unsafe_dry_run": True,
+                "no_backup": True,
+            },
+        )
+        # Same shape as the previous test: the gate must NOT abort.
+        # Downstream failure inside ``run_migration`` is irrelevant —
+        # only the gate's own ``SystemExit`` would be a regression here.
+        result = asyncio.run(run_migration(components=["work_packages_skeleton"]))
+        assert result is not None

--- a/tests/unit/test_dry_run_safety_gate.py
+++ b/tests/unit/test_dry_run_safety_gate.py
@@ -1,0 +1,185 @@
+"""Startup gate that keeps ``--dry-run`` honest.
+
+Issue #260 background
+---------------------
+The orchestrator printed a confident WARNING — *"no changes will be made to
+OpenProject"* — at the top of every ``--dry-run`` run. In reality only 5 of
+~41 components honoured the flag; the rest wrote to OpenProject regardless.
+The reporter trusted the WARNING and got 10 890 real work-package creation
+attempts.
+
+PR D introduces a startup gate (Phase 1 of the hybrid plan):
+
+    * Each component declares ``DRY_RUN_SAFE: ClassVar[bool]`` on its class.
+      ``BaseMigration`` defaults the attribute to ``False``; the 5 safe
+      components override it to ``True``.
+    * The orchestrator partitions the requested components against the
+      declared safety. Under ``--dry-run`` the run aborts when any unsafe
+      component is in scope — unless the operator opts in with
+      ``--allow-unsafe-dry-run``.
+    * Acknowledged-unsafe runs print a STRONGER warning enumerating the
+      components that will still write.
+
+These tests pin the partitioning + gate behaviour as pure functions so we
+can extend the safe-set incrementally without touching the orchestrator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.migration import (
+    DRY_RUN_SAFE_COMPONENTS,
+    _build_dry_run_banner,
+    _dry_run_safety_partition,
+)
+
+
+class TestDryRunSafetyPartition:
+    def test_partitions_known_safe_and_unsafe_components(self) -> None:
+        safe, unsafe = _dry_run_safety_partition(
+            ["projects", "work_packages_skeleton", "issue_types", "attachments"],
+        )
+        assert safe == ["projects", "issue_types"]
+        assert unsafe == ["work_packages_skeleton", "attachments"]
+
+    def test_returns_empty_lists_for_no_requests(self) -> None:
+        safe, unsafe = _dry_run_safety_partition([])
+        assert safe == []
+        assert unsafe == []
+
+    def test_unknown_components_count_as_unsafe(self) -> None:
+        """A typo or out-of-tree component name must NOT be silently
+        treated as safe — fail-closed is the right default for a flag
+        whose contract is "no changes to OpenProject".
+        """
+        safe, unsafe = _dry_run_safety_partition(["does_not_exist"])
+        assert safe == []
+        assert unsafe == ["does_not_exist"]
+
+
+class TestDryRunBanner:
+    """``_build_dry_run_banner`` returns ``(level, lines, abort)`` —
+    ``abort=True`` means the orchestrator should refuse to run.
+    """
+
+    def test_no_components_means_no_banner_and_no_abort(self) -> None:
+        _level, lines, abort = _build_dry_run_banner(
+            requested=[],
+            allow_unsafe=False,
+        )
+        assert abort is False
+        assert lines == []
+
+    def test_all_safe_emits_clean_warning_no_abort(self) -> None:
+        level, lines, abort = _build_dry_run_banner(
+            requested=["projects", "companies"],
+            allow_unsafe=False,
+        )
+        assert abort is False
+        assert level == "warning"
+        body = " ".join(lines).lower()
+        assert "dry run" in body
+        assert "projects" in body and "companies" in body
+        # The honest-warning case may say "no changes will be made" — but
+        # it must scope that claim to the listed components, not blanket
+        # the whole run as the original buggy banner did.
+        if "no changes will be made" in body:
+            assert "for these components" in body or "to these components" in body
+
+    def test_unsafe_without_opt_in_aborts(self) -> None:
+        level, lines, abort = _build_dry_run_banner(
+            requested=["projects", "work_packages_skeleton", "attachments"],
+            allow_unsafe=False,
+        )
+        assert abort is True
+        assert level == "error"
+        body = "\n".join(lines).lower()
+        assert "work_packages_skeleton" in body
+        assert "attachments" in body
+        # Must suggest the opt-in flag so users know how to proceed.
+        assert "--allow-unsafe-dry-run" in body
+
+    def test_unsafe_with_opt_in_warns_loudly_but_does_not_abort(self) -> None:
+        level, lines, abort = _build_dry_run_banner(
+            requested=["projects", "work_packages_skeleton"],
+            allow_unsafe=True,
+        )
+        assert abort is False
+        assert level == "warning"
+        body = "\n".join(lines).lower()
+        # Must explicitly call out the unsafe ones — silence here would
+        # restore the original honesty bug.
+        assert "work_packages_skeleton" in body
+        assert "will still write" in body or "writes to openproject" in body
+
+
+class TestRegistryClassAttributeDriftGuard:
+    """``DRY_RUN_SAFE_COMPONENTS`` is the orchestrator's view of safety;
+    each safe component also declares ``DRY_RUN_SAFE = True`` on its
+    class. The two must stay in sync — drift here would re-introduce
+    the original honesty bug.
+    """
+
+    def test_registry_matches_class_attributes(self) -> None:
+        from src.application.components.company_migration import CompanyMigration
+        from src.application.components.issue_type_migration import IssueTypeMigration
+        from src.application.components.link_type_migration import LinkTypeMigration
+        from src.application.components.project_migration import ProjectMigration
+        from src.application.components.status_migration import StatusMigration
+
+        declared_via_class = {
+            name
+            for name, cls in {
+                "projects": ProjectMigration,
+                "issue_types": IssueTypeMigration,
+                "link_types": LinkTypeMigration,
+                "companies": CompanyMigration,
+                "status_types": StatusMigration,
+            }.items()
+            if getattr(cls, "DRY_RUN_SAFE", False)
+        }
+        assert declared_via_class == DRY_RUN_SAFE_COMPONENTS
+
+    def test_basemigration_default_is_unsafe(self) -> None:
+        from src.application.components.base_migration import BaseMigration
+
+        assert getattr(BaseMigration, "DRY_RUN_SAFE", None) is False
+
+
+class TestUnsafeComponentClassesStayUnsafe:
+    """A regression guard — picking a handful of high-impact unsafe
+    components and asserting they did NOT accidentally inherit the safe
+    marker. The set is small on purpose; it documents *what was unsafe
+    in the original #260 incident*.
+    """
+
+    @pytest.mark.parametrize(
+        ("module_path", "class_name"),
+        [
+            (
+                "src.application.components.work_package_skeleton_migration",
+                "WorkPackageSkeletonMigration",
+            ),
+            (
+                "src.application.components.attachments_migration",
+                "AttachmentsMigration",
+            ),
+            (
+                "src.application.components.time_entry_migration",
+                "TimeEntryMigration",
+            ),
+            (
+                "src.application.components.admin_scheme_migration",
+                "AdminSchemeMigration",
+            ),
+        ],
+    )
+    def test_class_is_marked_unsafe(self, module_path: str, class_name: str) -> None:
+        import importlib
+
+        mod = importlib.import_module(module_path)
+        cls = getattr(mod, class_name)
+        assert getattr(cls, "DRY_RUN_SAFE", False) is False, (
+            f"{class_name} does not honour --dry-run; it must NOT carry DRY_RUN_SAFE = True"
+        )


### PR DESCRIPTION
## Summary

Closes the final action item from [#260](https://github.com/netresearch/jira-to-openproject/issues/260): `--dry-run` printed *"no changes will be made to OpenProject"* and then proceeded to make 10 890 real WP creation attempts. The flag was honoured by only 5 of ~41 components; everything else wrote regardless. The banner was a lie.

## Approach: Phase 1 of the hybrid plan

(Phase 2 = extend `DRY_RUN_SAFE` to more components incrementally, one PR per component. Not in scope here.)

- **Declarative safety marker.** `BaseMigration.DRY_RUN_SAFE: ClassVar[bool]` defaults to `False`. The 5 components that internally check `config.migration_config["dry_run"]` opt in to `True`: `ProjectMigration`, `IssueTypeMigration`, `LinkTypeMigration`, `CompanyMigration`, `StatusMigration`.
- **Startup gate.** Three pure helpers in `src.migration` — `DRY_RUN_SAFE_COMPONENTS` (frozenset), `_dry_run_safety_partition`, `_build_dry_run_banner` — are wired into the orchestrator's startup. Under `--dry-run`:
  - All-safe → honest WARNING enumerating which components are covered.
  - Any unsafe + no opt-in → ERROR listing the unsafe ones; `SystemExit` aborts the run.
  - Unsafe + `--allow-unsafe-dry-run` → STRONGER WARNING listing exactly which components will still write.
- **CLI flag.** `--allow-unsafe-dry-run` added to `src/main.py`; plumbed through `config.migration_config["allow_unsafe_dry_run"]`; `MigrationConfig` TypedDict updated.
- **Drift guard.** A unit test asserts `DRY_RUN_SAFE_COMPONENTS` matches the `DRY_RUN_SAFE = True` declarations on each safe class — so adding a class marker without updating the orchestrator's frozenset (or vice versa) fails CI immediately.

## What the reporter on [#260](https://github.com/netresearch/jira-to-openproject/issues/260) would see now

```
$ uv run python3.14 -m src.main migrate --dry-run --profile full --no-confirm
ERROR  Refusing to run --dry-run: the following requested components do
       NOT honour the flag and would write to OpenProject:
         - users
         - custom_fields
         - work_packages_skeleton
         - work_packages_content
         - time_entries
         - watchers
         ... etc
       Either restrict the run to dry-run-safe components (companies,
       issue_types, link_types, projects, status_types), or pass
       --allow-unsafe-dry-run to acknowledge that real writes will still
       happen for the components above.
```

Exit code 1; no 10 890 surprise creations.

## Test plan

- [x] 13 new unit tests in `tests/unit/test_dry_run_safety_gate.py`:
  - **Partition** (3): known safe/unsafe split, empty input, unknown components fall to unsafe (fail-closed).
  - **Banner** (4): no-op for empty requested, all-safe scoped warning, unsafe + no opt-in aborts and suggests the flag, unsafe + opt-in warns loudly and lists offenders.
  - **Drift guard** (2): frozenset ↔ class attributes match; `BaseMigration` default is `False`.
  - **Unsafe-stays-unsafe regression guard** (4 parametrised): `WorkPackageSkeletonMigration`, `AttachmentsMigration`, `TimeEntryMigration`, `AdminSchemeMigration` must NOT carry the safe marker.
- [x] All 1871 unit tests pass.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy` clean on all touched modules.

## Follow-up (Phase 2)

Adding a component to the safe-set is now a 3-line change: add `DRY_RUN_SAFE = True` on the class, add the name to `DRY_RUN_SAFE_COMPONENTS`, and update the drift-guard test. Good candidates for follow-up PRs (no design call needed): the various read-only / mapping-only components that already short-circuit OP writes — needs per-component audit.