### PR TITLE
fix(custom-field): isolate CF-id creation from console buffer contamination (#260)

### DIFF
--- a/src/infrastructure/openproject/openproject_custom_field_service.py
+++ b/src/infrastructure/openproject/openproject_custom_field_service.py
@@ -94,13 +94,26 @@ class OpenProjectCustomFieldService:
 
         escaped = escape_ruby_single_quoted(name)
         escaped_format = escape_ruby_single_quoted(field_format)
-        script = (
-            f"cf = CustomField.find_by(type: 'WorkPackageCustomField', name: '{escaped}'); "
-            f"if !cf; cf = CustomField.new(name: '{escaped}', field_format: '{escaped_format}', "
-            f"is_required: false, is_for_all: false, type: 'WorkPackageCustomField'); cf.save; end; cf.id"
-        )
-        result = self._client.execute_query(script)
-        return int(result) if result else 0
+        # Route through the isolated JSON path (Ruby writes the result to a
+        # container file read back via ``cat`` + ``json.loads``), exactly like
+        # the sibling ``ensure_work_package_custom_field``. The raw
+        # ``execute_query`` transport returns the unfiltered tmux pane tail —
+        # irb continuation prompts plus stale ``--EXEC`` / ``# j2o:`` residue
+        # from earlier calls — which fed garbage into ``int(result)`` and
+        # crashed five CF-creating components (GitHub #260). ``as_json`` keeps
+        # the id structurally isolated from any console noise.
+        ruby = f"""
+          cf = CustomField.find_by(type: 'WorkPackageCustomField', name: '{escaped}')
+          if !cf
+            cf = CustomField.new(name: '{escaped}', field_format: '{escaped_format}', is_required: false, is_for_all: false, type: 'WorkPackageCustomField')
+            cf.save
+          end
+          cf && cf.as_json(only: [:id])
+        """
+        result = self._client.execute_json_query(ruby)
+        if isinstance(result, dict) and result.get("id"):
+            return int(result["id"])
+        return 0
 
     def enable_custom_field_for_projects(
         self,

--- a/tests/unit/test_ensure_wp_custom_field_id_console_isolation.py
+++ b/tests/unit/test_ensure_wp_custom_field_id_console_isolation.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Regression tests for ``OpenProjectCustomFieldService.ensure_wp_custom_field_id``.
+
+GitHub issue #260: creating a WorkPackage custom field crashed five
+migration components (resolutions, labels, security_levels,
+affects_versions, votes_reactions) with::
+
+    ValueError: invalid literal for int() with base 10:
+      'open-project(prod):2920> # j2o: ... func=get_work_package_types ...'
+
+Root cause: ``ensure_wp_custom_field_id`` called the *raw* console
+transport (``execute_query`` -> ``_send_command_to_tmux``), which returns
+the unfiltered tmux pane tail — irb continuation prompts and stale
+``--EXEC`` / ``# j2o:`` residue from a *previous* call — and then did a
+naked ``int(result)`` on that text. The prompt-stripping filter added in
+74b16bc is only wired into the marker-based ``execute()`` path, never the
+raw ``execute_query`` path this method used.
+
+Fix: route through the isolated ``execute_json_query`` (Ruby writes the id
+to a container file that is read back via ``cat`` + ``json.loads``) exactly
+like the sibling ``ensure_work_package_custom_field`` — pane contamination
+can no longer reach the integer conversion.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from src.infrastructure.exceptions import RecordNotFoundError
+from src.infrastructure.openproject.openproject_custom_field_service import (
+    OpenProjectCustomFieldService,
+)
+
+# The verbatim contaminated buffer from issue #260 (resolutions run). A naked
+# ``int()`` of this raises ``ValueError`` — which is exactly the crash.
+CONTAMINATED_CONSOLE_OUTPUT = (
+    "open-project(prod):2920> # j2o: infrastructure/openproject/"
+    "openproject_status_type_service func=get_work_package_types "
+    "ts=2026-05-29T19:52:28Z pid=5789\n\n"
+    "open-project(prod):2921>\nopen-project(prod):2922>"
+)
+
+
+class _FakeClient:
+    """Minimal stand-in for ``OpenProjectClient`` for the service under test.
+
+    ``find_record`` raises so the method takes the *create* path. The two
+    console entry points are tracked so a test can assert which transport
+    the production code chose:
+
+    * ``execute_query`` is the *raw, contamination-prone* path. It returns
+      the issue-#260 buffer, so any code path that still calls it and then
+      does ``int(...)`` reproduces the crash.
+    * ``execute_json_query`` is the *isolated* path; it returns a clean dict.
+    """
+
+    def __init__(self, json_result: Any) -> None:
+        self.logger = logging.getLogger("test.ensure_wp_cf")
+        self._json_result = json_result
+        self.execute_query_calls: list[str] = []
+        self.execute_json_query_calls: list[str] = []
+
+    def find_record(self, _model: str, _query: dict[str, Any]) -> dict[str, Any]:
+        msg = "not found"
+        raise RecordNotFoundError(msg)
+
+    def execute_query(self, script: str, timeout: int | None = None) -> str:
+        self.execute_query_calls.append(script)
+        return CONTAMINATED_CONSOLE_OUTPUT
+
+    def execute_json_query(self, query: str, timeout: int | None = None) -> Any:
+        self.execute_json_query_calls.append(query)
+        return self._json_result
+
+
+def test_contaminated_console_buffer_does_not_break_cf_id_resolution() -> None:
+    """#260: a stale/garbled pane must not crash CF-id resolution.
+
+    With the fix the method reads the id from the isolated JSON path; the
+    contaminated ``execute_query`` buffer is never fed to ``int()``.
+    """
+    client = _FakeClient(json_result={"id": 42})
+    service = OpenProjectCustomFieldService(client)
+
+    cf_id = service.ensure_wp_custom_field_id("J2O Resolution", "string")
+
+    assert cf_id == 42
+    assert isinstance(cf_id, int)
+    # The fix must use the isolated JSON path, not the raw pane transport.
+    assert client.execute_json_query_calls, "expected the isolated execute_json_query path to be used"
+    assert not client.execute_query_calls, "raw execute_query must not be used for CF-id resolution"
+
+
+def test_cf_id_is_int_even_when_json_returns_string_id() -> None:
+    """The id is coerced to ``int`` (Rails ``as_json`` may emit it as text)."""
+    client = _FakeClient(json_result={"id": "57"})
+    service = OpenProjectCustomFieldService(client)
+
+    assert service.ensure_wp_custom_field_id("J2O Labels", "text") == 57
+
+
+@pytest.mark.parametrize("json_result", [None, {}, {"id": None}, {"id": 0}, False])
+def test_creation_failure_returns_zero_not_raise(json_result: Any) -> None:
+    """Genuine creation failure returns 0 — the contract callers rely on.
+
+    Components such as ``LabelsMigration`` / ``VotesMigration`` guard with
+    ``if not cf_id: return ComponentResult(success=False, ...)``. The fix
+    must preserve that falsy-on-failure contract rather than raising.
+    """
+    client = _FakeClient(json_result=json_result)
+    service = OpenProjectCustomFieldService(client)
+
+    assert service.ensure_wp_custom_field_id("J2O Votes", "int") == 0


### PR DESCRIPTION
## Summary
- Fixes the `ValueError: invalid literal for int() with base 10: 'open-project(prod):…'` crash that killed five CF-creating components (resolutions, labels, security_levels, affects_versions, votes_reactions) on the first live non-dry-run migration in #260.
- Routes `ensure_wp_custom_field_id` through the isolated `execute_json_query` path instead of the raw tmux transport + naked `int()`.

## Changes
`ensure_wp_custom_field_id` ran its CF-creation script through `execute_query` → `_send_command_to_tmux`, which returns the **unfiltered tmux pane tail** — irb continuation prompts (`open-project(prod):NNNN*`) plus stale `--EXEC` / `# j2o:` residue echoed from an *earlier* console call — and then did a naked `int(result)` on that text.

The prompt-stripping filter `filter_console_output_lines` (added in `74b16bc` for exactly this CF-id symptom) is wired only into the marker-based `execute()` path, **never** into the raw `execute_query` path this method used — so the same failure resurfaced on the path that fix missed.

The fix mirrors the sibling `ensure_work_package_custom_field`: build the CF via `cf.as_json(only: [:id])` and read it back through `execute_json_query`, where Ruby writes the result to a container file that is `cat`-piped + `json.loads`-parsed. Console noise can no longer reach the integer conversion.

Preserved deliberately:
- the `is_for_all: false` invariant (per-project enablement — covered by `test_base_ensure_wp_custom_field_uses_is_for_all_false`);
- the falsy-on-failure (`return 0`) contract that callers such as `LabelsMigration` / `VotesMigration` rely on (`if not cf_id: return ComponentResult(success=False, …)`).

Scope is the one outlier method; `execute_query` / `_send_command_to_tmux` are untouched (large blast radius, and the marker path is already guarded by the `74b16bc` filter).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Unit tests pass (`pytest tests/unit/`) — full unit suite green (1881 passed)
- New regression test `tests/unit/test_ensure_wp_custom_field_id_console_isolation.py` drives the **real** method with the verbatim #260 contaminated buffer; it reproduced the crash before the fix and passes after. Also covers string→int id coercion and the falsy-on-failure `return 0` contract.

## Checklist
- [x] My code follows the project's coding style (ruff check + format clean)
- [x] I have added tests that prove my fix works
- [x] All new and existing tests pass
- [x] I have checked for security implications (none — same Ruby semantics, isolated transport)

## Related Issues
Relates to #260