### PR TITLE
fix(skeleton): publish work-package mapping to shared facade (#260)

### DIFF
--- a/src/application/components/work_package_skeleton_migration.py
+++ b/src/application/components/work_package_skeleton_migration.py
@@ -280,6 +280,37 @@ class WorkPackageSkeletonMigration(BaseMigration):
             self._last_save_succeeded = False
         return self._last_save_succeeded
 
+    def _finalize_mapping(self) -> None:
+        """Persist the mapping to disk and publish it to the shared facade.
+
+        Per-batch progress uses the direct ``_save_mapping`` disk write for
+        crash-resilient incremental saves. At the END of the run we also
+        publish through ``config.mappings.set_mapping`` once so the
+        process-wide facade cache reflects the final mapping.
+
+        Without this, facade consumers (attachments, attachment_provenance,
+        attachment_recovery, wp_metadata_backfill, watchers) kept reading an
+        empty ``work_package`` mapping even though skeleton had written 10k+
+        entries to disk: ``config.mappings`` is a singleton whose per-stem
+        cache is seeded empty at startup (``migration.py`` calls
+        ``get_all_mappings()`` before any component) and never re-reads disk
+        (GitHub #260). Components that read the JSON file directly
+        (work_packages_content, time_entries) were unaffected, which is what
+        made the failure look so selective.
+
+        The disk write stays authoritative (the ``run()`` post-condition
+        keys off ``_last_save_succeeded``); a facade-publish hiccup is logged
+        but must not abort an otherwise-successful migration.
+        """
+        self._save_mapping()
+        try:
+            config.mappings.set_mapping("work_package", self.work_package_mapping)
+        except Exception as e:
+            self.logger.warning(
+                "Failed to publish work package mapping to the config.mappings facade (disk save is authoritative): %s",
+                e,
+            )
+
     def _get_projects_to_migrate(self) -> list[dict[str, Any]]:
         """Get list of Jira projects to migrate based on filter."""
         projects = self.jira_client.get_projects()
@@ -999,8 +1030,9 @@ class WorkPackageSkeletonMigration(BaseMigration):
                 project_results["failed"],
             )
 
-        # Final save
-        self._save_mapping()
+        # Final save: persist to disk AND publish to the shared config.mappings
+        # facade so downstream facade consumers see the mapping (GitHub #260).
+        self._finalize_mapping()
 
         self.logger.success(
             "Skeleton migration complete: %d created, %d skipped, %d failed",

--- a/tests/unit/test_skeleton_mapping_facade_publish.py
+++ b/tests/unit/test_skeleton_mapping_facade_publish.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Regression test for the work-package mapping facade hand-off (issue #260).
+
+GitHub issue #260: after ``work_packages_skeleton`` created ~11k work
+packages, every *facade* consumer (attachments, attachment_provenance,
+attachment_recovery, wp_metadata_backfill, watchers) failed with
+``missing_work_package_mapping`` — while ``work_packages_content`` and
+``time_entries`` (which read the JSON file directly) loaded all entries.
+
+Root cause: a dual source of truth. ``_save_mapping`` writes
+``work_package_mapping.json`` directly to disk and never publishes through
+``config.mappings``. The shared ``config.mappings`` facade is a process-wide
+singleton whose per-stem cache is seeded EMPTY at startup
+(``migration.py`` calls ``get_all_mappings()`` before any component runs)
+and never re-reads disk. So facade consumers kept seeing ``{}``.
+
+Fix: at the end of the run the skeleton publishes the mapping through
+``config.mappings.set_mapping("work_package", …)`` once, refreshing the
+cache so every facade reader sees the data.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.config as cfg
+from src.application.components.attachments_migration import compute_wp_lookup_by_jira_key
+from src.infrastructure.persistence.mapping_repo import JsonFileMappingRepository
+from src.mappings.mappings import Mappings
+
+
+def _build_skeleton(tmp_path: Path):
+    """Construct WorkPackageSkeletonMigration redirected to ``tmp_path``."""
+    from src.application.components.work_package_skeleton_migration import (
+        WorkPackageSkeletonMigration,
+    )
+
+    mig = WorkPackageSkeletonMigration(jira_client=MagicMock(), op_client=MagicMock())
+    mig.data_dir = tmp_path
+    mig.work_package_mapping_file = tmp_path / mig.WORK_PACKAGE_MAPPING_FILE
+    return mig
+
+
+def test_skeleton_publishes_mapping_to_shared_facade(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#260: facade consumers must see the mapping skeleton persisted.
+
+    Uses a real :class:`Mappings` over a real :class:`JsonFileMappingRepository`
+    so the production cache-staleness is reproduced exactly.
+    """
+    facade = Mappings(repo=JsonFileMappingRepository(tmp_path))
+    monkeypatch.setattr(cfg, "mappings", facade, raising=False)
+
+    # Reproduce migration.py: get_all_mappings() runs before any component and
+    # seeds an EMPTY 'work_package' override (the file does not exist yet).
+    facade.get_all_mappings()
+    assert facade.get_mapping("work_package") == {}
+
+    mapping = {
+        "1001": {"jira_key": "PROJ-1", "openproject_id": 5001, "project_key": "PROJ"},
+        "1002": {"jira_key": "PROJ-2", "openproject_id": 5002, "project_key": "PROJ"},
+    }
+    mig = _build_skeleton(tmp_path)
+    mig.work_package_mapping = dict(mapping)
+
+    # A direct disk write — what _save_mapping does per batch — is invisible to
+    # the already-seeded facade cache. This is the #260 bug.
+    mig._save_mapping()
+    assert json.loads(mig.work_package_mapping_file.read_text(encoding="utf-8")) == mapping
+    assert facade.get_mapping("work_package") == {}, "disk write alone must not be expected to reach the facade"
+
+    # Finalizing the run publishes through the facade so consumers see it.
+    mig._finalize_mapping()
+
+    published = facade.get_mapping("work_package")
+    assert published == mapping
+
+    # And the actual attachments consumer helper now resolves the lookup
+    # instead of returning {} (which produced missing_work_package_mapping).
+    lookup = compute_wp_lookup_by_jira_key(facade)
+    assert lookup == {"PROJ-1": 5001, "PROJ-2": 5002}
+
+
+def test_finalize_mapping_preserves_save_success_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_finalize_mapping`` must still set ``_last_save_succeeded`` (run() guard)."""
+    facade = Mappings(repo=JsonFileMappingRepository(tmp_path))
+    monkeypatch.setattr(cfg, "mappings", facade, raising=False)
+
+    mig = _build_skeleton(tmp_path)
+    mig.work_package_mapping = {"1001": {"jira_key": "PROJ-1", "openproject_id": 5001}}
+
+    mig._finalize_mapping()
+
+    assert mig._last_save_succeeded is True
+    assert mig.work_package_mapping_file.exists()
+
+
+def test_finalize_mapping_survives_facade_publish_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A facade publish error must not abort the run; the disk save is authoritative."""
+    facade = MagicMock()
+    facade.set_mapping.side_effect = RuntimeError("repo unavailable")
+    monkeypatch.setattr(cfg, "mappings", facade, raising=False)
+
+    mig = _build_skeleton(tmp_path)
+    mig.work_package_mapping = {"1001": {"jira_key": "PROJ-1", "openproject_id": 5001}}
+
+    # Must not raise despite set_mapping blowing up.
+    mig._finalize_mapping()
+
+    assert mig._last_save_succeeded is True
+    assert mig.work_package_mapping_file.exists()


### PR DESCRIPTION
## Summary
- Fixes `missing_work_package_mapping` failures in `attachments`, `attachment_provenance`, `attachment_recovery`, `wp_metadata_backfill`, and `watchers` from #260 — even though the skeleton created all ~11k work packages and `work_packages_content` / `time_entries` loaded them fine.
- The skeleton now publishes the finished mapping through the shared `config.mappings` facade, not just to disk.

## Changes
**Dual source of truth.** `_save_mapping` writes `work_package_mapping.json` directly to disk and never publishes through `config.mappings`. That facade is a process-wide singleton whose per-stem cache is **seeded empty at startup** (`migration.py` calls `get_all_mappings()` before any component runs) and **never re-reads disk**. So:
- consumers that read the JSON file directly (`work_packages_content`, `time_entries`) saw all entries;
- consumers that go through the facade (`attachments` via `compute_wp_lookup_by_jira_key`, `watchers`, `attachment_provenance`, `attachment_recovery`, `wp_metadata_backfill`) kept reading the cached empty `{}` → `missing_work_package_mapping`.

This PR adds `_finalize_mapping()`, called once at the end of the run. It keeps the per-batch direct disk write (crash-resilient incremental progress) **and** publishes the final mapping through `config.mappings.set_mapping("work_package", …)`, refreshing the shared cache so every consumer sees it.

Design notes:
- Per-batch saves are deliberately **not** routed through the facade — `set_mapping` deep-copies the payload, so doing it on every flush would be O(n²) over the growing 10k-entry dict. One publish at the end is enough (all facade consumers run after the skeleton).
- The disk write stays authoritative: `run()`'s post-condition keys off `_last_save_succeeded`, and a facade-publish hiccup is logged but does not abort an otherwise-successful migration.
- Rejected alternatives: making every facade consumer read the file directly (~20 sites, deepens the split) and cache-invalidation on the facade (changes shared caching for all stems, breaks the stable-identity contract).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Unit tests pass (`pytest tests/unit/`) — full unit suite green (1877 passed)
- New regression test `tests/unit/test_skeleton_mapping_facade_publish.py` wires a **real** `Mappings` over a real `JsonFileMappingRepository`, seeds the empty startup cache exactly as `migration.py` does, then asserts the actual attachments consumer (`compute_wp_lookup_by_jira_key`) resolves the lookup after finalize. Also covers `_last_save_succeeded` preservation and survival of a facade-publish failure.

## Checklist
- [x] My code follows the project's coding style (ruff check + format clean)
- [x] I have added tests that prove my fix works
- [x] All new and existing tests pass
- [x] I have checked for security implications (none)

## Related Issues
Relates to #260