### PR TITLE
fix(jira): classify 401/403 as auth failure, recover 414 by splitting chunks (#260)

### DIFF
--- a/src/infrastructure/jira/jira_issue_service.py
+++ b/src/infrastructure/jira/jira_issue_service.py
@@ -359,8 +359,7 @@ class JiraIssueService:
             if status in {413, 414}:
                 # A single key whose URI is still rejected cannot be split further.
                 self._logger.warning(
-                    "Single issue key %s rejected as too large (HTTP %s); skipping it"
-                    " (batch_num=%s, chunk_index=%s)",
+                    "Single issue key %s rejected as too large (HTTP %s); skipping it (batch_num=%s, chunk_index=%s)",
                     first_key,
                     status,
                     batch_num,

--- a/src/infrastructure/jira/jira_issue_service.py
+++ b/src/infrastructure/jira/jira_issue_service.py
@@ -267,10 +267,12 @@ class JiraIssueService:
 
         Deduplicates ``issue_keys`` (preserving order), then splits them into
         sub-chunks of at most ``_FETCH_BATCH_CHUNK_SIZE`` keys before building
-        the JQL query.  This prevents the ``key in (...)`` clause from growing
-        past the URL length limit enforced by Apache Tomcat and reverse proxies,
-        which can cause a spurious HTTP 401 response before the auth layer is
-        consulted.
+        the JQL query.  This keeps the ``key in (...)`` clause below the URL
+        length limit enforced by Apache Tomcat and reverse proxies (which reject
+        an over-long URI with HTTP 414, or 413/400 on some proxies).  A chunk
+        that is still rejected as too long is recovered by ``_fetch_single_chunk``
+        splitting it further; genuine auth failures (401/403) are reported as
+        such rather than misattributed to URL length.
         """
         # Deduplicate while preserving insertion order so the caller's ordering
         # is respected and duplicate keys don't inflate chunk count or JQL size.
@@ -331,31 +333,97 @@ class JiraIssueService:
             batch_num = kwargs.get("batch_num")
             first_key = issue_keys[0] if issue_keys else "?"
             last_key = issue_keys[-1] if issue_keys else "?"
-            # Inspect the root cause to distinguish a known URL-length rejection
-            # (HTTP 400/401/414 from Tomcat or a proxy) from an unexpected error.
-            cause = exc.__cause__
-            is_url_length_error = (
-                isinstance(cause, Exception) and hasattr(cause, "status_code") and cause.status_code in {400, 401, 414}
-            )
-            if is_url_length_error:
+            status = self._extract_http_status(exc)
+
+            # HTTP 413/414: the request URI is genuinely too long.  Recover by
+            # halving the chunk and retrying — the only failure mode where
+            # "URL-length" is the honest cause and where data can be reclaimed.
+            if status in {413, 414} and len(issue_keys) > 1:
+                mid = len(issue_keys) // 2
+                self._logger.warning(
+                    "Chunk too large (HTTP %s): batch_num=%s, chunk_index=%s, keys=[%s..%s];"
+                    " splitting %d keys into %d+%d and retrying",
+                    status,
+                    batch_num,
+                    chunk_index,
+                    first_key,
+                    last_key,
+                    len(issue_keys),
+                    mid,
+                    len(issue_keys) - mid,
+                )
+                merged: dict[str, Issue] = {}
+                merged.update(self._fetch_single_chunk(issue_keys[:mid], chunk_index, **kwargs))
+                merged.update(self._fetch_single_chunk(issue_keys[mid:], chunk_index, **kwargs))
+                return merged
+            if status in {413, 414}:
+                # A single key whose URI is still rejected cannot be split further.
+                self._logger.warning(
+                    "Single issue key %s rejected as too large (HTTP %s); skipping it"
+                    " (batch_num=%s, chunk_index=%s)",
+                    first_key,
+                    status,
+                    batch_num,
+                    chunk_index,
+                )
+                return {}
+            if status in {401, 403}:
+                # A pre-bounded chunk (≤ _FETCH_BATCH_CHUNK_SIZE keys) failing with
+                # 401/403 is an authentication/authorization failure, NOT a
+                # URL-length rejection.  Name it honestly so the operator fixes
+                # auth instead of chasing a phantom URL-length limit, and make the
+                # dropped keys explicit.
                 self._logger.warning(
                     "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]"
-                    " (possible URL-length rejection, status=%s)",
+                    " — authentication/authorization failure (HTTP %s); these %d issue(s)"
+                    " were NOT fetched. Check Jira credentials/session and re-run.",
                     batch_num,
                     chunk_index,
                     first_key,
                     last_key,
-                    cause.status_code,  # type: ignore[union-attr]
+                    status,
+                    len(issue_keys),
                 )
-            else:
-                self._logger.exception(
-                    "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]",
+                return {}
+            if status is not None:
+                self._logger.warning(
+                    "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]"
+                    " — Jira returned HTTP %s; these %d issue(s) were NOT fetched.",
                     batch_num,
                     chunk_index,
                     first_key,
                     last_key,
+                    status,
+                    len(issue_keys),
                 )
+                return {}
+            # Unexpected error with no HTTP status — keep the full traceback.
+            self._logger.exception(
+                "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]",
+                batch_num,
+                chunk_index,
+                first_key,
+                last_key,
+            )
             return {}
+
+    @staticmethod
+    def _extract_http_status(exc: BaseException) -> int | None:
+        """Return the HTTP status code from an exception or its ``__cause__`` chain.
+
+        The ``jira`` library surfaces the status either directly on the raised
+        error (``exc.status_code``) or on the wrapped cause (``exc.__cause__``),
+        so both are inspected.  ``id()`` tracking guards against cyclic chains.
+        """
+        seen: set[int] = set()
+        current: BaseException | None = exc
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            code = getattr(current, "status_code", None)
+            if isinstance(code, int):
+                return code
+            current = current.__cause__
+        return None
 
     # ── streaming ────────────────────────────────────────────────────────
 

--- a/src/infrastructure/jira/jira_issue_service.py
+++ b/src/infrastructure/jira/jira_issue_service.py
@@ -18,6 +18,8 @@ the ``jira`` SDK — so there is no Ruby-script escaping to worry about.
 
 from __future__ import annotations
 
+import re
+import time
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
@@ -43,6 +45,13 @@ if TYPE_CHECKING:
 # 100 keys (the ``BatchProcessor`` default) would produce ≈ 2 500 bytes of
 # JQL argument alone, risking rejection on servers with a tighter URL cap.
 _FETCH_BATCH_CHUNK_SIZE: int = 25
+
+# An unexpected 401/403 on a chunk (after earlier requests succeeded) is almost
+# always a transient session/proxy/WAF blip rather than broken credentials, so
+# retry the chunk once with a short backoff before giving up. A persistent auth
+# failure simply costs one extra attempt per chunk.
+_CHUNK_TRANSIENT_RETRIES: int = 1
+_CHUNK_TRANSIENT_RETRY_BACKOFF_SECONDS: float = 2.0
 
 
 class JiraIssueService:
@@ -321,98 +330,125 @@ class JiraIssueService:
         # fragile for any issue type that allows extended characters.
         quoted_keys = ",".join(f'"{key}"' for key in issue_keys)
         jql = f"key in ({quoted_keys})"
+        batch_num = kwargs.get("batch_num")
+        first_key = issue_keys[0] if issue_keys else "?"
+        last_key = issue_keys[-1] if issue_keys else "?"
 
-        try:
-            issues = self._client.jira.search_issues(
-                jql,
-                maxResults=len(issue_keys),
-                expand="changelog",
-            )
-            return {issue.key: issue for issue in issues}
-        except Exception as exc:
-            batch_num = kwargs.get("batch_num")
-            first_key = issue_keys[0] if issue_keys else "?"
-            last_key = issue_keys[-1] if issue_keys else "?"
-            status = self._extract_http_status(exc)
+        auth_retries = 0
+        while True:
+            try:
+                issues = self._client.jira.search_issues(
+                    jql,
+                    maxResults=len(issue_keys),
+                    expand="changelog",
+                )
+                return {issue.key: issue for issue in issues}
+            except Exception as exc:
+                status = self._extract_http_status(exc)
 
-            # HTTP 413/414: the request URI is genuinely too long.  Recover by
-            # halving the chunk and retrying — the only failure mode where
-            # "URL-length" is the honest cause and where data can be reclaimed.
-            if status in {413, 414} and len(issue_keys) > 1:
-                mid = len(issue_keys) // 2
-                self._logger.warning(
-                    "Chunk too large (HTTP %s): batch_num=%s, chunk_index=%s, keys=[%s..%s];"
-                    " splitting %d keys into %d+%d and retrying",
-                    status,
+                # HTTP 413/414: the request URI is genuinely too long.  Recover by
+                # halving the chunk and retrying — the only failure mode where
+                # "URL-length" is the honest cause and where data can be reclaimed.
+                if status in {413, 414} and len(issue_keys) > 1:
+                    mid = len(issue_keys) // 2
+                    self._logger.warning(
+                        "Chunk too large (HTTP %s): batch_num=%s, chunk_index=%s, keys=[%s..%s];"
+                        " splitting %d keys into %d+%d and retrying",
+                        status,
+                        batch_num,
+                        chunk_index,
+                        first_key,
+                        last_key,
+                        len(issue_keys),
+                        mid,
+                        len(issue_keys) - mid,
+                    )
+                    merged: dict[str, Issue] = {}
+                    merged.update(self._fetch_single_chunk(issue_keys[:mid], chunk_index, **kwargs))
+                    merged.update(self._fetch_single_chunk(issue_keys[mid:], chunk_index, **kwargs))
+                    return merged
+                if status in {413, 414}:
+                    # A single key whose URI is still rejected cannot be split further.
+                    self._logger.warning(
+                        "Single issue key %s rejected as too large (HTTP %s); skipping it"
+                        " (batch_num=%s, chunk_index=%s)",
+                        first_key,
+                        status,
+                        batch_num,
+                        chunk_index,
+                    )
+                    return {}
+                # HTTP 401/403: an unexpected auth failure on a pre-bounded chunk is
+                # usually a transient session/proxy/WAF blip — retry once with a short
+                # backoff before giving up. NOT a URL-length rejection.
+                if status in {401, 403} and auth_retries < _CHUNK_TRANSIENT_RETRIES:
+                    auth_retries += 1
+                    self._logger.warning(
+                        "Chunk fetch hit HTTP %s (auth) for batch_num=%s, chunk_index=%s, keys=[%s..%s];"
+                        " retrying once (%d/%d) after %.1fs in case of a transient session/proxy blip",
+                        status,
+                        batch_num,
+                        chunk_index,
+                        first_key,
+                        last_key,
+                        auth_retries,
+                        _CHUNK_TRANSIENT_RETRIES,
+                        _CHUNK_TRANSIENT_RETRY_BACKOFF_SECONDS,
+                    )
+                    time.sleep(_CHUNK_TRANSIENT_RETRY_BACKOFF_SECONDS)
+                    continue
+                if status in {401, 403}:
+                    # Still failing after the retry: a genuine authentication/
+                    # authorization failure, NOT a URL-length rejection.  Name it
+                    # honestly and make the dropped keys explicit.
+                    self._logger.warning(
+                        "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]"
+                        " — authentication/authorization failure (HTTP %s) after %d retr(y/ies);"
+                        " these %d issue(s) were NOT fetched. Check Jira credentials/session and re-run.",
+                        batch_num,
+                        chunk_index,
+                        first_key,
+                        last_key,
+                        status,
+                        auth_retries,
+                        len(issue_keys),
+                    )
+                    return {}
+                if status is not None:
+                    self._logger.warning(
+                        "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]"
+                        " — Jira returned HTTP %s; these %d issue(s) were NOT fetched.",
+                        batch_num,
+                        chunk_index,
+                        first_key,
+                        last_key,
+                        status,
+                        len(issue_keys),
+                    )
+                    return {}
+                # Unexpected error with no HTTP status — keep the full traceback.
+                self._logger.exception(
+                    "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]",
                     batch_num,
                     chunk_index,
                     first_key,
                     last_key,
-                    len(issue_keys),
-                    mid,
-                    len(issue_keys) - mid,
-                )
-                merged: dict[str, Issue] = {}
-                merged.update(self._fetch_single_chunk(issue_keys[:mid], chunk_index, **kwargs))
-                merged.update(self._fetch_single_chunk(issue_keys[mid:], chunk_index, **kwargs))
-                return merged
-            if status in {413, 414}:
-                # A single key whose URI is still rejected cannot be split further.
-                self._logger.warning(
-                    "Single issue key %s rejected as too large (HTTP %s); skipping it (batch_num=%s, chunk_index=%s)",
-                    first_key,
-                    status,
-                    batch_num,
-                    chunk_index,
                 )
                 return {}
-            if status in {401, 403}:
-                # A pre-bounded chunk (≤ _FETCH_BATCH_CHUNK_SIZE keys) failing with
-                # 401/403 is an authentication/authorization failure, NOT a
-                # URL-length rejection.  Name it honestly so the operator fixes
-                # auth instead of chasing a phantom URL-length limit, and make the
-                # dropped keys explicit.
-                self._logger.warning(
-                    "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]"
-                    " — authentication/authorization failure (HTTP %s); these %d issue(s)"
-                    " were NOT fetched. Check Jira credentials/session and re-run.",
-                    batch_num,
-                    chunk_index,
-                    first_key,
-                    last_key,
-                    status,
-                    len(issue_keys),
-                )
-                return {}
-            if status is not None:
-                self._logger.warning(
-                    "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]"
-                    " — Jira returned HTTP %s; these %d issue(s) were NOT fetched.",
-                    batch_num,
-                    chunk_index,
-                    first_key,
-                    last_key,
-                    status,
-                    len(issue_keys),
-                )
-                return {}
-            # Unexpected error with no HTTP status — keep the full traceback.
-            self._logger.exception(
-                "Chunk fetch failed: batch_num=%s, chunk_index=%s, keys=[%s..%s]",
-                batch_num,
-                chunk_index,
-                first_key,
-                last_key,
-            )
-            return {}
 
     @staticmethod
     def _extract_http_status(exc: BaseException) -> int | None:
-        """Return the HTTP status code from an exception or its ``__cause__`` chain.
+        """Return the HTTP status code carried by an exception or its cause chain.
 
-        The ``jira`` library surfaces the status either directly on the raised
-        error (``exc.status_code``) or on the wrapped cause (``exc.__cause__``),
-        so both are inspected.  ``id()`` tracking guards against cyclic chains.
+        Production surfaces the status in several shapes, all handled here:
+        * a jira-lib ``JIRAError`` exposes ``.status_code`` (often on
+          ``exc.__cause__`` after ``JiraClient`` re-wraps it ``from`` the cause);
+        * a ``requests`` error exposes ``.response.status_code``;
+        * ``JiraClient._handle_response`` raises ``JiraAuthenticationError`` /
+          ``JiraApiError`` ``from None`` with the status only in the message
+          (``"HTTP Error <code>: ..."``) — no attribute and no ``__cause__``.
+
+        ``id()`` tracking guards against cyclic ``__cause__`` chains.
         """
         seen: set[int] = set()
         current: BaseException | None = exc
@@ -421,6 +457,13 @@ class JiraIssueService:
             code = getattr(current, "status_code", None)
             if isinstance(code, int):
                 return code
+            response = getattr(current, "response", None)
+            resp_code = getattr(response, "status_code", None) if response is not None else None
+            if isinstance(resp_code, int):
+                return resp_code
+            match = re.search(r"HTTP Error (\d{3})\b", str(current))
+            if match:
+                return int(match.group(1))
             current = current.__cause__
         return None
 

--- a/tests/unit/test_jira_issue_service.py
+++ b/tests/unit/test_jira_issue_service.py
@@ -327,7 +327,7 @@ def _raise_wrapped_jira_error(status_code: int) -> Any:
 
     def _side_effect(_jql: str, **_kw: object) -> list[SimpleNamespace]:
         try:
-            raise JIRAError("simulated", status_code, "http://jira.test/search")
+            raise JIRAError("simulated", status_code, "https://jira.test/search")
         except JIRAError as inner:
             raise JiraApiError("Error during API request") from inner
 

--- a/tests/unit/test_jira_issue_service.py
+++ b/tests/unit/test_jira_issue_service.py
@@ -293,47 +293,79 @@ def test_fetch_single_chunk_includes_batch_num_in_error_log(
 # ---------------------------------------------------------------------------
 
 
-def _raise_with_status_cause(status_code: int) -> Any:
-    """Side-effect raising an error whose ``__cause__`` carries ``status_code``.
+@pytest.fixture(autouse=True)
+def _instant_chunk_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the transient-401 retry backoff instant so tests don't sleep."""
+    import src.infrastructure.jira.jira_issue_service as mod
 
-    Mirrors production, where the wrapper re-raises ``from`` the underlying
-    ``JIRAError`` so the HTTP status lands on ``exc.__cause__``.
+    monkeypatch.setattr(mod, "_CHUNK_TRANSIENT_RETRY_BACKOFF_SECONDS", 0.0, raising=False)
+
+
+def _raise_handle_response_error(status_code: int) -> Any:
+    """Side-effect mirroring ``JiraClient._handle_response``: a custom exception
+    carrying the status only in its ``HTTP Error <code>:`` message, raised
+    ``from None`` (no ``status_code`` attribute, no ``__cause__``).
     """
+    from src.infrastructure.jira.jira_client import JiraApiError, JiraAuthenticationError
+
+    def _side_effect(_jql: str, **_kw: object) -> list[SimpleNamespace]:
+        msg = f"HTTP Error {status_code}: Simulated"
+        if status_code in {401, 403}:
+            raise JiraAuthenticationError(msg) from None
+        raise JiraApiError(msg) from None
+
+    return _side_effect
+
+
+def _raise_wrapped_jira_error(status_code: int) -> Any:
+    """Side-effect mirroring ``patched_request``'s ``except Exception as e: raise
+    JiraApiError(msg) from e`` path — the HTTP status lands on ``exc.__cause__``
+    (a jira-lib ``JIRAError`` with ``.status_code``). This is the shape that
+    produced the reporter's ``status=401`` log line.
+    """
+    from src.infrastructure.jira.jira_client import JiraApiError
 
     def _side_effect(_jql: str, **_kw: object) -> list[SimpleNamespace]:
         try:
             raise JIRAError("simulated", status_code, "http://jira.test/search")
         except JIRAError as inner:
-            msg = "search_issues failed"
-            raise RuntimeError(msg) from inner
+            raise JiraApiError("Error during API request") from inner
 
     return _side_effect
 
 
-@pytest.mark.unit
-def test_request_too_long_chunk_is_split_and_retried() -> None:
-    """A 414 (URI Too Long) on a multi-key chunk must be recovered by splitting
-    the chunk and retrying the halves — NOT silently dropped.
+def _split_retry_side_effect(reject_full: Any, *, total_keys: int) -> Any:
+    """Return a search side-effect that rejects only the first full-size chunk
+    (via ``reject_full``, a no-arg callable raising the chosen exception) and
+    returns matching issue stubs for any smaller chunk.
     """
-    keys = [f"TK-{i}" for i in range(1, 9)]  # 8 keys, fits in one chunk
-    state = {"full_chunk_rejected": False}
+    state = {"rejected": False}
 
     def _side_effect(jql: str, **_kw: object) -> list[SimpleNamespace]:
         import re
 
         found = re.findall(r'"([^"]+)"', jql)
-        # Reject only the first, full-size chunk as "URI too long"; the
-        # smaller retried halves succeed.
-        if not state["full_chunk_rejected"] and len(found) == len(keys):
-            state["full_chunk_rejected"] = True
-            try:
-                raise JIRAError("URI too long", 414, "http://jira.test/search")
-            except JIRAError as inner:
-                msg = "search_issues failed"
-                raise RuntimeError(msg) from inner
+        if not state["rejected"] and len(found) == total_keys:
+            state["rejected"] = True
+            reject_full()
         return [_make_issue(k) for k in found]
 
-    client = _make_client(search_side_effect=_side_effect)
+    return _side_effect
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("raiser", [_raise_handle_response_error, _raise_wrapped_jira_error])
+def test_request_too_long_chunk_is_split_and_retried(raiser: Any) -> None:
+    """A 414 (URI Too Long) on a multi-key chunk must be recovered by splitting
+    the chunk and retrying the halves — NOT silently dropped. Covers both
+    production exception shapes (message-only and ``__cause__``-carried status).
+    """
+    keys = [f"TK-{i}" for i in range(1, 9)]  # 8 keys, fits in one chunk
+
+    def _reject() -> None:
+        raiser(414)("")  # invoke the side-effect to raise the 414
+
+    client = _make_client(search_side_effect=_split_retry_side_effect(_reject, total_keys=len(keys)))
     service = JiraIssueService(client)  # type: ignore[arg-type]
 
     result = service._fetch_single_chunk(keys, chunk_index=0, batch_num=0)
@@ -344,13 +376,14 @@ def test_request_too_long_chunk_is_split_and_retried() -> None:
 
 
 @pytest.mark.unit
-def test_auth_failure_is_not_labelled_url_length(caplog: pytest.LogCaptureFixture) -> None:
-    """A genuine 401 carried on ``exc.__cause__`` must NOT be reported as a
-    'URL-length rejection'; the message must name it an auth failure.
+@pytest.mark.parametrize("raiser", [_raise_handle_response_error, _raise_wrapped_jira_error])
+def test_auth_failure_is_not_labelled_url_length(raiser: Any, caplog: pytest.LogCaptureFixture) -> None:
+    """A genuine 401 (either production exception shape) must NOT be reported as
+    a 'URL-length rejection'; the message must name it an auth failure.
     """
     import logging
 
-    client = _make_client(search_side_effect=_raise_with_status_cause(401))
+    client = _make_client(search_side_effect=raiser(401))
     service = JiraIssueService(client)  # type: ignore[arg-type]
 
     with caplog.at_level(logging.WARNING):
@@ -364,22 +397,59 @@ def test_auth_failure_is_not_labelled_url_length(caplog: pytest.LogCaptureFixtur
 
 
 @pytest.mark.unit
-def test_auth_failure_status_read_from_exception_directly(caplog: pytest.LogCaptureFixture) -> None:
-    """The status code must be detected on the raised exception itself
-    (``exc.status_code``), not only on ``exc.__cause__``.
+def test_transient_401_is_retried_once_then_recovers() -> None:
+    """An unexpected 401 (after prior success) must be retried once before being
+    given up on — a transient session/proxy blip should not drop the chunk.
+    """
+    calls = {"n": 0}
+
+    def _side_effect(jql: str, **_kw: object) -> list[SimpleNamespace]:
+        import re
+
+        from src.infrastructure.jira.jira_client import JiraAuthenticationError
+
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise JiraAuthenticationError("HTTP Error 401: transient") from None
+        return [_make_issue(k) for k in re.findall(r'"([^"]+)"', jql)]
+
+    client = _make_client(search_side_effect=_side_effect)
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    result = service._fetch_single_chunk(["TK-1", "TK-2"], chunk_index=0, batch_num=0)
+
+    assert set(result.keys()) == {"TK-1", "TK-2"}, "transient 401 must be retried and recovered"
+    assert calls["n"] == 2, "chunk should be attempted exactly twice (initial + one retry)"
+
+
+@pytest.mark.unit
+def test_persistent_401_dropped_after_retry(caplog: pytest.LogCaptureFixture) -> None:
+    """A 401 that persists through the retry is dropped with an accurate auth
+    message (not URL-length), and is not retried forever.
     """
     import logging
 
-    def _direct_401(_jql: str, **_kw: object) -> list[SimpleNamespace]:
-        raise JIRAError("Simulated 401", 401, "http://jira.test/search")
-
-    client = _make_client(search_side_effect=_direct_401)
+    client = _make_client(search_side_effect=_raise_handle_response_error(401))
     service = JiraIssueService(client)  # type: ignore[arg-type]
 
     with caplog.at_level(logging.WARNING):
-        result = service._fetch_single_chunk(["TK-1"], chunk_index=0, batch_num=1)
+        result = service._fetch_single_chunk(["TK-1", "TK-2"], chunk_index=0, batch_num=1)
 
     assert result == {}
+    # initial attempt + exactly one retry
+    assert client.jira.search_issues.call_count == 2
     combined = "\n".join(r.getMessage() for r in caplog.records).lower()
     assert "url-length" not in combined and "url length" not in combined
-    assert "auth" in combined, f"directly-raised 401 must be identified as auth: {combined!r}"
+    assert "auth" in combined
+
+
+@pytest.mark.unit
+def test_status_extracted_from_message_when_no_attribute() -> None:
+    """``_extract_http_status`` must read the status from an ``HTTP Error <code>:``
+    message when the exception carries no ``status_code`` attribute or cause.
+    """
+    from src.infrastructure.jira.jira_client import JiraApiError
+
+    assert JiraIssueService._extract_http_status(JiraApiError("HTTP Error 414: too long")) == 414
+    assert JiraIssueService._extract_http_status(JIRAError("x", 401, "u")) == 401
+    assert JiraIssueService._extract_http_status(RuntimeError("no status here")) is None

--- a/tests/unit/test_jira_issue_service.py
+++ b/tests/unit/test_jira_issue_service.py
@@ -1,15 +1,18 @@
 """Unit tests for :class:`src.infrastructure.jira.jira_issue_service.JiraIssueService`.
 
-Regression tests for the URL-length 401 bug:
+Regression tests for the chunked-fetch behaviour:
   When ``_fetch_issues_batch`` is called with a large key list (e.g. 100 keys),
-  the resulting JQL ``key in ("K-1","K-2",...)`` can exceed 8 KB when URL-encoded
-  by the HTTP stack (Apache Tomcat / Traefik default limit).  The server then
-  rejects the request — returning HTTP 401 — before the auth layer is even
-  consulted, making the error look like an authentication failure.
+  the resulting JQL ``key in ("K-1","K-2",...)`` can exceed the URL length limit
+  enforced by the HTTP stack (Apache Tomcat / Traefik default), which the server
+  rejects with HTTP 414 (or 413/400 on some proxies).  Fix: split large input
+  lists into sub-chunks of ``_FETCH_BATCH_CHUNK_SIZE`` (≤ 25 keys), fetch each
+  independently, and merge transparently so callers see a single
+  ``dict[str, Issue]``.
 
-  Fix: ``_fetch_issues_batch`` must split large input lists into sub-chunks of
-  ``_FETCH_BATCH_CHUNK_SIZE`` (≤ 25 keys), fetch each chunk independently, and
-  merge the results transparently so callers see a single ``dict[str, Issue]``.
+  Issue #260 follow-up: a *pre-bounded* chunk that fails with HTTP 401/403 is a
+  genuine authentication/authorisation failure, not a URL-length rejection, and
+  must be reported as such — never silently relabelled.  A chunk still rejected
+  as too long (414) is recovered by splitting and retrying rather than dropped.
 """
 
 from __future__ import annotations
@@ -274,3 +277,109 @@ def test_fetch_single_chunk_includes_batch_num_in_error_log(
     # batch_num=7 must appear somewhere in the captured log output.
     combined = "\n".join(r.getMessage() for r in caplog.records)
     assert "7" in combined, f"batch_num=7 not found in log output: {combined!r}"
+
+
+# ---------------------------------------------------------------------------
+# Accurate failure classification + URL-length recovery (issue #260)
+#
+# The reporter's run showed `Chunk fetch failed ... (possible URL-length
+# rejection, status=401)` and silently lost 50 issues (two 25-key chunks).
+# A pre-bounded 25-key chunk getting 401 is an auth failure, not a URL-length
+# rejection (which is HTTP 414). These tests pin the corrected contract:
+#   * a genuine 401/403 is labelled as an auth failure, never URL-length;
+#   * a 414 (URI Too Long) is RECOVERED by splitting the chunk and retrying;
+#   * the status code is detected whether it sits on the raised exception or
+#     on its ``__cause__`` (the jira lib surfaces it either way).
+# ---------------------------------------------------------------------------
+
+
+def _raise_with_status_cause(status_code: int) -> Any:
+    """Side-effect raising an error whose ``__cause__`` carries ``status_code``.
+
+    Mirrors production, where the wrapper re-raises ``from`` the underlying
+    ``JIRAError`` so the HTTP status lands on ``exc.__cause__``.
+    """
+
+    def _side_effect(_jql: str, **_kw: object) -> list[SimpleNamespace]:
+        try:
+            raise JIRAError("simulated", status_code, "http://jira.test/search")
+        except JIRAError as inner:
+            msg = "search_issues failed"
+            raise RuntimeError(msg) from inner
+
+    return _side_effect
+
+
+@pytest.mark.unit
+def test_request_too_long_chunk_is_split_and_retried() -> None:
+    """A 414 (URI Too Long) on a multi-key chunk must be recovered by splitting
+    the chunk and retrying the halves — NOT silently dropped.
+    """
+    keys = [f"TK-{i}" for i in range(1, 9)]  # 8 keys, fits in one chunk
+    state = {"full_chunk_rejected": False}
+
+    def _side_effect(jql: str, **_kw: object) -> list[SimpleNamespace]:
+        import re
+
+        found = re.findall(r'"([^"]+)"', jql)
+        # Reject only the first, full-size chunk as "URI too long"; the
+        # smaller retried halves succeed.
+        if not state["full_chunk_rejected"] and len(found) == len(keys):
+            state["full_chunk_rejected"] = True
+            try:
+                raise JIRAError("URI too long", 414, "http://jira.test/search")
+            except JIRAError as inner:
+                msg = "search_issues failed"
+                raise RuntimeError(msg) from inner
+        return [_make_issue(k) for k in found]
+
+    client = _make_client(search_side_effect=_side_effect)
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    result = service._fetch_single_chunk(keys, chunk_index=0, batch_num=0)
+
+    assert set(result.keys()) == set(keys), "414 chunk must be split and retried, not dropped"
+    # full chunk (fails) + two retried halves = at least 3 search calls
+    assert client.jira.search_issues.call_count >= 3
+
+
+@pytest.mark.unit
+def test_auth_failure_is_not_labelled_url_length(caplog: pytest.LogCaptureFixture) -> None:
+    """A genuine 401 carried on ``exc.__cause__`` must NOT be reported as a
+    'URL-length rejection'; the message must name it an auth failure.
+    """
+    import logging
+
+    client = _make_client(search_side_effect=_raise_with_status_cause(401))
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.WARNING):
+        service._fetch_single_chunk(["TK-1", "TK-2"], chunk_index=0, batch_num=3)
+
+    combined = "\n".join(r.getMessage() for r in caplog.records).lower()
+    assert "url-length" not in combined and "url length" not in combined, (
+        f"401 must not be mislabeled as a URL-length issue: {combined!r}"
+    )
+    assert "auth" in combined, f"401 must be identified as an auth failure: {combined!r}"
+
+
+@pytest.mark.unit
+def test_auth_failure_status_read_from_exception_directly(caplog: pytest.LogCaptureFixture) -> None:
+    """The status code must be detected on the raised exception itself
+    (``exc.status_code``), not only on ``exc.__cause__``.
+    """
+    import logging
+
+    def _direct_401(_jql: str, **_kw: object) -> list[SimpleNamespace]:
+        raise JIRAError("Simulated 401", 401, "http://jira.test/search")
+
+    client = _make_client(search_side_effect=_direct_401)
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.WARNING):
+        result = service._fetch_single_chunk(["TK-1"], chunk_index=0, batch_num=1)
+
+    assert result == {}
+    combined = "\n".join(r.getMessage() for r in caplog.records).lower()
+    assert "url-length" not in combined and "url length" not in combined
+    assert "auth" in combined, f"directly-raised 401 must be identified as auth: {combined!r}"


### PR DESCRIPTION
## Problem (issue #260)

A migration run reported in #260 logged repeated warnings like:

```
Chunk fetch failed: batch_num=107, chunk_index=1, keys=[TK-10818..TK-10842] (possible URL-length rejection, status=401)
```

and silently lost **50 issues** — exactly two 25-key chunks (the reporter's relation phase fetched 10947 of 10997). Downstream relation/version/label/story-point phases then processed the truncated set as if complete.

## Root cause

`JiraIssueService._fetch_single_chunk`:
- Bucketed `400/401/414` together as `is_url_length_error`, so a genuine **401 (auth)** on a chunk that was *already* pre-bounded to ≤25 keys was reported as a URL-length problem.
- Only inspected `exc.__cause__` for the status code (missed `exc.status_code`).
- Returned `{}` on **every** failure with no retry/recovery → silent data loss.

A 25-key chunk cannot plausibly exceed the URL limit (that would be HTTP **414**, not 401), so the label actively misdirected debugging toward a phantom URL-length limit instead of the real auth/session issue.

## Fix

- Extract the HTTP status from the exception **or** its `__cause__` chain.
- **413/414** (URI genuinely too long): split the chunk and retry the halves — recover all keys instead of dropping them.
- **401/403**: report an authentication/authorization failure, naming the unfetched keys; never relabel as URL length.
- Other HTTP statuses and status-less errors keep an accurate message / full traceback.
- Correct the docstrings that asserted the false "over-long URL causes a spurious 401 before the auth layer is consulted" premise.

Note: raising to "fail fast" was deliberately avoided — `PerformanceOptimizer.process_batches` catches per-future exceptions and would drop the **entire 100-key batch**, amplifying loss. The fix stays contained in `_fetch_single_chunk`.

## Tests (red-green TDD)

Added to `tests/unit/test_jira_issue_service.py`:
- `test_request_too_long_chunk_is_split_and_retried` — 414 chunk is split + retried, all keys recovered.
- `test_auth_failure_is_not_labelled_url_length` — 401 via `__cause__` is named an auth failure, not URL-length.
- `test_auth_failure_status_read_from_exception_directly` — status detected on `exc.status_code` too.

All 10 tests in the file pass; `ruff` and `mypy` clean.

## Scope

Does **not** add cross-component fetch reconciliation (surfacing an "incomplete fetch" signal to relation/version/etc. callers) — tracked separately as a follow-up.