### PR TITLE
fix(timestamps): preserve WP created_at/updated_at in legacy rails path (#260)

### DIFF
--- a/src/utils/enhanced_timestamp_migrator.py
+++ b/src/utils/enhanced_timestamp_migrator.py
@@ -578,7 +578,7 @@ class EnhancedTimestampMigrator:
             return result
 
         if use_rails:
-            # Queue Rails operation for immutable field setting
+            # Queue Rails operation for journal-side timestamp setting.
             rails_op = {
                 "type": "set_created_at",
                 "jira_key": work_package_data.get("jira_key", "unknown"),
@@ -586,9 +586,11 @@ class EnhancedTimestampMigrator:
                 "original_value": created_data["raw_value"],
             }
             result["rails_operation"] = rails_op
-        else:
-            # Set via API (may not work for immutable fields)
-            work_package_data["created_at"] = normalized_utc
+        # Always populate the payload field too (issue #260): the queued Rails op
+        # only updates the v1 *journal* row, while the bulk-create script sets the
+        # ``work_packages`` row's ``created_at`` from ``wp_data['created_at']`` via
+        # ``update_columns``.  Without this the WP keeps the migration-run time.
+        work_package_data["created_at"] = normalized_utc
 
         return result
 
@@ -613,7 +615,7 @@ class EnhancedTimestampMigrator:
             return result
 
         if use_rails:
-            # Queue Rails operation for setting update timestamp
+            # Queue Rails operation for setting update timestamp.
             rails_op = {
                 "type": "set_updated_at",
                 "jira_key": work_package_data.get("jira_key", "unknown"),
@@ -621,9 +623,10 @@ class EnhancedTimestampMigrator:
                 "original_value": updated_data["raw_value"],
             }
             result["rails_operation"] = rails_op
-        else:
-            # Set via API
-            work_package_data["updated_at"] = normalized_utc
+        # Always populate the payload field too (issue #260) so the bulk-create
+        # script's ``update_columns`` can set the ``work_packages`` row's
+        # ``updated_at`` instead of leaving the migration-run time.
+        work_package_data["updated_at"] = normalized_utc
 
         return result
 

--- a/tests/unit/test_enhanced_timestamp_migrator.py
+++ b/tests/unit/test_enhanced_timestamp_migrator.py
@@ -495,6 +495,69 @@ class TestEnhancedTimestampMigrator:
             assert "warnings" in result
             # The method should find the creation timestamp and not generate warnings
 
+    def test_migrate_creation_timestamp_with_rails_also_populates_payload(
+        self,
+        migrator_with_mocks,
+    ) -> None:
+        """With ``use_rails=True`` the normalized creation timestamp must ALSO be
+        written into ``work_package_data['created_at']`` (issue #260).
+
+        The queued ``set_created_at`` Rails op only updates the v1 *journal* row;
+        the only code that sets the ``work_packages`` row's ``created_at`` is the
+        bulk-create script's ``update_columns``, which reads ``wp_data['created_at']``.
+        If the payload field is left unset, the WP row keeps the migration-run time.
+        """
+
+        class MockJiraIssue:
+            def __init__(self, fields):
+                self.fields = type("MockFields", (), fields)()
+
+        mock_issue = MockJiraIssue({"created": "2023-10-15T10:00:00.000Z"})
+        work_package = {"id": 123}
+
+        with patch.object(migrator_with_mocks, "_normalize_timestamp") as mock_normalize:
+            mock_normalize.return_value = "2023-10-15T10:00:00+00:00"
+            extracted = migrator_with_mocks._extract_all_timestamps(mock_issue)
+            result = migrator_with_mocks._migrate_creation_timestamp(
+                extracted,
+                work_package,
+                use_rails=True,
+            )
+
+        # The Rails op is still queued (unchanged) ...
+        assert result["rails_operation"] is not None
+        assert result["rails_operation"]["type"] == "set_created_at"
+        # ... AND the payload carries the timestamp so update_columns can apply it.
+        assert work_package["created_at"] == "2023-10-15T10:00:00+00:00"
+
+    def test_migrate_update_timestamp_with_rails_also_populates_payload(
+        self,
+        migrator_with_mocks,
+    ) -> None:
+        """With ``use_rails=True`` the normalized update timestamp must ALSO be
+        written into ``work_package_data['updated_at']`` (issue #260).
+        """
+
+        class MockJiraIssue:
+            def __init__(self, fields):
+                self.fields = type("MockFields", (), fields)()
+
+        mock_issue = MockJiraIssue({"updated": "2023-10-15T12:00:00.000Z"})
+        work_package = {"id": 123}
+
+        with patch.object(migrator_with_mocks, "_normalize_timestamp") as mock_normalize:
+            mock_normalize.return_value = "2023-10-15T12:00:00+00:00"
+            extracted = migrator_with_mocks._extract_all_timestamps(mock_issue)
+            result = migrator_with_mocks._migrate_update_timestamp(
+                extracted,
+                work_package,
+                use_rails=True,
+            )
+
+        assert result["rails_operation"] is not None
+        assert result["rails_operation"]["type"] == "set_updated_at"
+        assert work_package["updated_at"] == "2023-10-15T12:00:00+00:00"
+
     def test_migrate_creation_timestamp_without_rails(
         self,
         migrator_with_mocks,


### PR DESCRIPTION
## Problem (issue #260, latent)

`EnhancedTimestampMigrator.migrate_timestamps(use_rails_for_immutable=True)` queued a `set_created_at`/`set_updated_at` Rails op but **never wrote the value into `work_package_data`**. The queued op only updates the **v1 journal** row; the sole code that sets the **`work_packages`** row's `created_at`/`updated_at` is the bulk-create script's `update_columns`, which reads `wp_data['created_at']`. With the key missing, the WP row kept the migration-run time.

## Scope / impact

This path is used **only** by the legacy `work_packages` component (`migration.py:500`), which is **not in any profile** (`full`/default use `work_packages_skeleton` + `work_packages_content`). The **skeleton path was already correct** — it sets `created_at` directly in its payload. So this is a latent-bug hardening of the legacy shim (reachable via `--components work_packages`), **not** the fix for the reporter's observed symptom (that is comment-journal dates in the content phase — separate PR).

## Fix

In `_migrate_creation_timestamp` / `_migrate_update_timestamp`, populate `work_package_data['created_at']`/`['updated_at']` **unconditionally**; the Rails op is still queued unchanged. The default skeleton path doesn't call this method, so it's unaffected.

## Tests (red-green TDD)

- `test_migrate_creation_timestamp_with_rails_also_populates_payload`
- `test_migrate_update_timestamp_with_rails_also_populates_payload`

Both assert the Rails op is still queued **and** the payload field is now set. Full file (45 tests) green; `ruff`/`mypy` clean.