### PR TITLE
fix(content): preserve original Jira comment dates on migrated journals (#260)

### DIFF
--- a/src/application/components/work_package_content_migration.py
+++ b/src/application/components/work_package_content_migration.py
@@ -70,6 +70,22 @@ if TYPE_CHECKING:
     from jira.resources import Issue
 
 
+def _coerce_comment_timestamp(value: Any) -> str | None:
+    """Coerce a Jira comment timestamp to ``str`` while preserving ``None``.
+
+    The Jira SDK sometimes returns ``datetime`` objects for ``comment.created``
+    instead of ISO strings; a raw ``datetime`` would break ``json.dumps`` of the
+    bulk activity payload.  Mirrors
+    ``work_package_skeleton_migration._stringify_optional_timestamp``: ``None``
+    and empty strings stay ``None`` (never the literal ``"None"``).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    return str(value)
+
+
 @register_entity_types("work_packages_content")
 class WorkPackageContentMigration(BaseMigration):
     """Phase 2: Populate work package content with link resolution.
@@ -562,7 +578,7 @@ class WorkPackageContentMigration(BaseMigration):
                         "user_id": author_id,
                         "jira_comment_id": jira_comment_id,
                         # Preserve the original Jira comment date (#260).
-                        "created_at": getattr(comment, "created", None),
+                        "created_at": _coerce_comment_timestamp(getattr(comment, "created", None)),
                     },
                 )
                 migrated += 1
@@ -723,7 +739,7 @@ class WorkPackageContentMigration(BaseMigration):
                             "jira_comment_id": jira_comment_id,
                             # Preserve the original Jira comment date (#260) so the
                             # journal is back-dated instead of stamped with NOW.
-                            "created_at": getattr(comment, "created", None),
+                            "created_at": _coerce_comment_timestamp(getattr(comment, "created", None)),
                         }
                     )
         except Exception:

--- a/src/application/components/work_package_content_migration.py
+++ b/src/application/components/work_package_content_migration.py
@@ -561,6 +561,8 @@ class WorkPackageContentMigration(BaseMigration):
                         "comment": {"raw": converted_body},
                         "user_id": author_id,
                         "jira_comment_id": jira_comment_id,
+                        # Preserve the original Jira comment date (#260).
+                        "created_at": getattr(comment, "created", None),
                     },
                 )
                 migrated += 1
@@ -719,6 +721,9 @@ class WorkPackageContentMigration(BaseMigration):
                             "comment": converted_body,
                             "user_id": author_id,
                             "jira_comment_id": jira_comment_id,
+                            # Preserve the original Jira comment date (#260) so the
+                            # journal is back-dated instead of stamped with NOW.
+                            "created_at": getattr(comment, "created", None),
                         }
                     )
         except Exception:
@@ -795,12 +800,12 @@ class WorkPackageContentMigration(BaseMigration):
             except Exception as e:
                 self.logger.debug("Bulk custom field update failed: %s", e)
 
-        # Batch 3: Comments (using bulk_create_work_package_activities)
-        # Each entry in item["comments"] is a dict with keys:
-        #   "comment": str, "user_id": int, "jira_comment_id": str|None.
-        # We forward all three: user_id preserves authorship; jira_comment_id
-        # enables provenance-based idempotency so re-runs skip already-migrated
-        # comments instead of duplicating them.
+        # Batch 3: Comments (using bulk_create_work_package_activities).
+        # Each entry in item["comments"] carries comment text, user_id,
+        # jira_comment_id and created_at. We forward all four: user_id preserves
+        # authorship; jira_comment_id enables provenance-based idempotency so
+        # re-runs skip already-migrated comments instead of duplicating them;
+        # created_at back-dates the journal to the original Jira comment time (#260).
         all_comments = []
         for item in collected_items:
             for comment_entry in item["comments"]:
@@ -810,6 +815,8 @@ class WorkPackageContentMigration(BaseMigration):
                         "comment": comment_entry["comment"],
                         "user_id": comment_entry["user_id"],
                         "jira_comment_id": comment_entry.get("jira_comment_id"),
+                        # Forward the original Jira comment date (#260).
+                        "created_at": comment_entry.get("created_at"),
                     },
                 )
 

--- a/src/infrastructure/openproject/openproject_work_package_content_service.py
+++ b/src/infrastructure/openproject/openproject_work_package_content_service.py
@@ -350,12 +350,9 @@ J2O_DATA
           wp.save!
           created_at_raw = {ruby_created_at}
           if created_at_raw && !created_at_raw.to_s.strip.empty?
-            begin
-              ts = Time.parse(created_at_raw.to_s)
-              j = wp.journals.last
-              j.update_columns(created_at: ts, updated_at: ts) if j
-            rescue ArgumentError
-            end
+            ts = Time.zone.parse(created_at_raw.to_s)
+            j = wp.journals.last
+            j.update_columns(created_at: ts, updated_at: ts) if j && ts
           end
           {{ id: wp.journals.last.id, status: 'created' }}
           {ruby_idempotency_close}
@@ -533,15 +530,13 @@ J2O_DATA
               # bypasses callbacks/validations to set the historical timestamp
               # OpenProject displays as the comment date. validity_period is left
               # as OpenProject set it (used only for historical baseline queries).
+              # Time.zone.parse returns nil (not an exception) for unparseable
+              # input, so a bad date simply leaves the journal's default timestamp.
               raw_created = item['created_at']
               if raw_created && !raw_created.to_s.strip.empty?
-                begin
-                  ts = Time.parse(raw_created.to_s)
-                  j = wp.journals.last
-                  j.update_columns(created_at: ts, updated_at: ts) if j
-                rescue ArgumentError
-                  # Unparseable date — leave the journal at its default timestamp.
-                end
+                ts = Time.zone.parse(raw_created.to_s)
+                j = wp.journals.last
+                j.update_columns(created_at: ts, updated_at: ts) if j && ts
               end
               results[:created] += 1
             rescue => e

--- a/src/infrastructure/openproject/openproject_work_package_content_service.py
+++ b/src/infrastructure/openproject/openproject_work_package_content_service.py
@@ -311,6 +311,10 @@ J2O_DATA
         raw_user_id = activity_data.get("user_id")
         ruby_user_id = int(raw_user_id) if raw_user_id is not None else "nil"
 
+        # Original Jira comment date (#260) as a Ruby string literal (or nil).
+        raw_created_at = activity_data.get("created_at")
+        ruby_created_at = f"'{escape_ruby_single_quoted(str(raw_created_at))}'" if raw_created_at else "nil"
+
         # Build the idempotency check expression for Ruby.
         # When jira_comment_id is present we grep existing journals for the
         # provenance marker; if found we evaluate to a 'skipped' hash without
@@ -344,6 +348,15 @@ J2O_DATA
           wp.journal_notes = '{escaped_comment}'
           wp.journal_user = user
           wp.save!
+          created_at_raw = {ruby_created_at}
+          if created_at_raw && !created_at_raw.to_s.strip.empty?
+            begin
+              ts = Time.parse(created_at_raw.to_s)
+              j = wp.journals.last
+              j.update_columns(created_at: ts, updated_at: ts) if j
+            rescue ArgumentError
+            end
+          end
           {{ id: wp.journals.last.id, status: 'created' }}
           {ruby_idempotency_close}
         rescue => e
@@ -449,6 +462,9 @@ J2O_DATA
                     "comment": comment_with_marker,
                     "user_id": act.get("user_id"),
                     "jira_comment_id": jira_comment_id,
+                    # Original Jira comment date (#260); the Ruby back-dates the
+                    # journal so OpenProject shows the real authoring time.
+                    "created_at": act.get("created_at"),
                 },
             )
 
@@ -512,6 +528,21 @@ J2O_DATA
               wp.journal_notes = comment_text
               wp.journal_user = user
               wp.save!
+              # Back-date the journal to the original Jira comment date (#260).
+              # journal_notes/save! stamps created_at = NOW; update_columns
+              # bypasses callbacks/validations to set the historical timestamp
+              # OpenProject displays as the comment date. validity_period is left
+              # as OpenProject set it (used only for historical baseline queries).
+              raw_created = item['created_at']
+              if raw_created && !raw_created.to_s.strip.empty?
+                begin
+                  ts = Time.parse(raw_created.to_s)
+                  j = wp.journals.last
+                  j.update_columns(created_at: ts, updated_at: ts) if j
+                rescue ArgumentError
+                  # Unparseable date — leave the journal at its default timestamp.
+                end
+              end
               results[:created] += 1
             rescue => e
               results[:failed] += 1

--- a/tests/unit/test_work_package_content_comment_dates.py
+++ b/tests/unit/test_work_package_content_comment_dates.py
@@ -188,7 +188,15 @@ class TestBulkCreateBackdatesJournal:
     def test_created_at_in_json_payload(self) -> None:
         svc, captured = self._svc_capturing_script()
         svc.bulk_create_work_package_activities(
-            [{"work_package_id": 5040, "comment": "Hi", "user_id": 100, "jira_comment_id": "1", "created_at": _JIRA_CREATED}]
+            [
+                {
+                    "work_package_id": 5040,
+                    "comment": "Hi",
+                    "user_id": 100,
+                    "jira_comment_id": "1",
+                    "created_at": _JIRA_CREATED,
+                }
+            ]
         )
         payload = _extract_j2o_payload(captured[0])
         assert payload[0]["created_at"] == _JIRA_CREATED

--- a/tests/unit/test_work_package_content_comment_dates.py
+++ b/tests/unit/test_work_package_content_comment_dates.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import inspect
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -134,6 +135,29 @@ class TestCollectCapturesCommentDate:
 
         assert collected["comments"][0]["created_at"] is None
 
+    def test_datetime_created_is_coerced_to_str(self, tmp_path: Path, _mock_mappings: None) -> None:
+        """The Jira SDK sometimes returns a ``datetime`` for ``comment.created``.
+        It must be coerced to a string so the bulk JSON payload stays
+        ``json.dumps``-serialisable (a raw datetime would raise TypeError).
+        """
+        mig = _build_mig(tmp_path)
+        issue = MagicMock()
+        issue.key = "PROJ-1"
+        issue.fields.description = None
+        issue.raw = {"fields": {}}
+        dt = datetime(2023, 10, 15, 10, 0, 0, tzinfo=UTC)
+        mig.jira_client.jira.comments.return_value = [
+            _make_comment("alice", "First", comment_id="1", created=dt),
+        ]
+        mig.jira_client.get_issue_watchers.return_value = []
+
+        collected = mig._collect_content_for_issue(issue, wp_id=5040)
+
+        created_at = collected["comments"][0]["created_at"]
+        assert isinstance(created_at, str), f"datetime must be coerced to str, got {type(created_at)}"
+        # The whole comments payload must be JSON-serialisable (the bulk path).
+        json.dumps(collected["comments"])
+
 
 # ---------------------------------------------------------------------------
 # 2. _bulk_process_collected_content forwards the comment date to the op client
@@ -212,7 +236,7 @@ class TestBulkCreateBackdatesJournal:
         # comment date (guarded by presence of created_at).
         assert "created_at" in source, "bulk script never references created_at"
         assert "update_columns" in source, "bulk script must update_columns the journal's created_at"
-        assert "Time.parse" in source, "bulk script must parse the ISO comment date"
+        assert "Time.zone.parse" in source, "bulk script must parse the ISO comment date"
 
 
 # ---------------------------------------------------------------------------
@@ -245,4 +269,4 @@ class TestSingleCommentPathBackdates:
         )
         assert "created_at" in source, "single script never references created_at"
         assert "update_columns" in source, "single script must update_columns the journal's created_at"
-        assert "Time.parse" in source, "single script must parse the ISO comment date"
+        assert "Time.zone.parse" in source, "single script must parse the ISO comment date"

--- a/tests/unit/test_work_package_content_comment_dates.py
+++ b/tests/unit/test_work_package_content_comment_dates.py
@@ -30,58 +30,26 @@ from unittest.mock import MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Helpers (mirroring tests/unit/test_work_package_content_comment_idempotency.py)
-# ---------------------------------------------------------------------------
-
-
-def _build_mig(tmp_path: Path):
-    from src.application.components.work_package_content_migration import (
-        WorkPackageContentMigration,
-    )
-
-    jira = MagicMock()
-    op = MagicMock()
-    mig = WorkPackageContentMigration(jira_client=jira, op_client=op)
-    mig.data_dir = tmp_path
-    mig.work_package_mapping_file = tmp_path / mig.WORK_PACKAGE_MAPPING_FILE
-    mig.attachment_mapping_file = tmp_path / mig.ATTACHMENT_MAPPING_FILE
-    return mig
+# Reuse the shared content-migration builders rather than re-defining them.
+from tests.unit.test_work_package_content_comment_idempotency import _build_mig, _make_comment
 
 
 @pytest.fixture
-def _mock_mappings(monkeypatch: pytest.MonkeyPatch):
+def _mock_mappings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub ``config.mappings`` so the migration's lookups don't touch global state.
+
+    These comment-date tests assert on timestamps, not on resolved ids, so an
+    empty mapping (``get_mapping`` returns ``{}`` for any name) is sufficient.
+    """
     import src.config as cfg
 
-    class DummyMappings:
-        def __init__(self) -> None:
-            self._m = {
-                "project": {"PROJ": {"openproject_id": 11}},
-                "user": {"alice": {"openproject_id": 201}},
-                "custom_field": {},
-            }
-
-        def get_mapping(self, name: str):
-            return self._m.get(name, {})
-
-        def set_mapping(self, name: str, value):
-            self._m[name] = value
-
-    monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+    monkeypatch.setattr(cfg, "mappings", SimpleNamespace(get_mapping=lambda _name: {}), raising=False)
 
 
-def _make_comment(author_name: str, body: str, comment_id: str = "cid-1", created: str | None = None):
-    c = MagicMock()
-    c.body = body
-    c.id = comment_id
+def _comment_with_date(author: str, body: str, created: object, comment_id: str = "1") -> MagicMock:
+    """A Jira comment stub (via the shared ``_make_comment``) with ``.created`` set."""
+    c = _make_comment(author, body, comment_id=comment_id)
     c.created = created
-    c.author = SimpleNamespace(
-        name=author_name,
-        displayName=author_name.capitalize(),
-        emailAddress=f"{author_name}@example.com",
-        accountId=None,
-        key=None,
-    )
     return c
 
 
@@ -108,7 +76,7 @@ class TestCollectCapturesCommentDate:
         issue.fields.description = None
         issue.raw = {"fields": {}}
         mig.jira_client.jira.comments.return_value = [
-            _make_comment("alice", "First", comment_id="1", created=_JIRA_CREATED),
+            _comment_with_date("alice", "First", _JIRA_CREATED),
         ]
         mig.jira_client.get_issue_watchers.return_value = []
 
@@ -147,7 +115,7 @@ class TestCollectCapturesCommentDate:
         issue.raw = {"fields": {}}
         dt = datetime(2023, 10, 15, 10, 0, 0, tzinfo=UTC)
         mig.jira_client.jira.comments.return_value = [
-            _make_comment("alice", "First", comment_id="1", created=dt),
+            _comment_with_date("alice", "First", dt),
         ]
         mig.jira_client.get_issue_watchers.return_value = []
 
@@ -250,7 +218,7 @@ class TestSingleCommentPathBackdates:
         issue = MagicMock()
         issue.key = "PROJ-1"
         mig.jira_client.jira.comments.return_value = [
-            _make_comment("alice", "First", comment_id="1", created=_JIRA_CREATED),
+            _comment_with_date("alice", "First", _JIRA_CREATED),
         ]
         # Avoid link-resolution surprises: return body unchanged.
         mig._convert_jira_links = lambda body, jira_key=None: body  # type: ignore[method-assign]

--- a/tests/unit/test_work_package_content_comment_dates.py
+++ b/tests/unit/test_work_package_content_comment_dates.py
@@ -1,0 +1,240 @@
+"""Comment journals must preserve the original Jira comment date (issue #260).
+
+Issue #260 background
+---------------------
+A user reported that migrated comments do not preserve their original
+date/time. The default profile migrates comments in the CONTENT phase
+(``WorkPackageContentMigration``), which collected each comment's body,
+author and Jira id but **dropped the comment's ``created`` timestamp**. The
+Rails helper then created the journal with ``wp.journal_notes = ...; wp.save!``,
+so ActiveRecord stamped ``journals.created_at = Time.now`` (the migration run
+time) — the value OpenProject shows as the comment date.
+
+These tests pin the corrected contract end-to-end:
+  1. ``_collect_content_for_issue`` captures ``created_at`` from ``comment.created``.
+  2. ``_bulk_process_collected_content`` forwards ``created_at`` to the op client.
+  3. ``bulk_create_work_package_activities`` puts ``created_at`` in the JSON payload
+     AND the Ruby script back-dates the new journal (``update_columns`` created_at).
+  4. The single-comment path (``_populate_comments`` →
+     ``create_work_package_activity``) does the same.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers (mirroring tests/unit/test_work_package_content_comment_idempotency.py)
+# ---------------------------------------------------------------------------
+
+
+def _build_mig(tmp_path: Path):
+    from src.application.components.work_package_content_migration import (
+        WorkPackageContentMigration,
+    )
+
+    jira = MagicMock()
+    op = MagicMock()
+    mig = WorkPackageContentMigration(jira_client=jira, op_client=op)
+    mig.data_dir = tmp_path
+    mig.work_package_mapping_file = tmp_path / mig.WORK_PACKAGE_MAPPING_FILE
+    mig.attachment_mapping_file = tmp_path / mig.ATTACHMENT_MAPPING_FILE
+    return mig
+
+
+@pytest.fixture
+def _mock_mappings(monkeypatch: pytest.MonkeyPatch):
+    import src.config as cfg
+
+    class DummyMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "project": {"PROJ": {"openproject_id": 11}},
+                "user": {"alice": {"openproject_id": 201}},
+                "custom_field": {},
+            }
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+        def set_mapping(self, name: str, value):
+            self._m[name] = value
+
+    monkeypatch.setattr(cfg, "mappings", DummyMappings(), raising=False)
+
+
+def _make_comment(author_name: str, body: str, comment_id: str = "cid-1", created: str | None = None):
+    c = MagicMock()
+    c.body = body
+    c.id = comment_id
+    c.created = created
+    c.author = SimpleNamespace(
+        name=author_name,
+        displayName=author_name.capitalize(),
+        emailAddress=f"{author_name}@example.com",
+        accountId=None,
+        key=None,
+    )
+    return c
+
+
+def _extract_j2o_payload(script: str) -> list[dict]:
+    """Pull the JSON embedded between the ``J2O_DATA`` heredoc markers."""
+    start = script.find("\n", script.find("J2O_DATA")) + 1
+    end = script.find("J2O_DATA", start)
+    return json.loads(script[start:end].strip())
+
+
+_JIRA_CREATED = "2023-10-15T10:00:00.000+0000"
+
+
+# ---------------------------------------------------------------------------
+# 1. _collect_content_for_issue captures the comment date
+# ---------------------------------------------------------------------------
+
+
+class TestCollectCapturesCommentDate:
+    def test_created_at_captured_from_comment(self, tmp_path: Path, _mock_mappings: None) -> None:
+        mig = _build_mig(tmp_path)
+        issue = MagicMock()
+        issue.key = "PROJ-1"
+        issue.fields.description = None
+        issue.raw = {"fields": {}}
+        mig.jira_client.jira.comments.return_value = [
+            _make_comment("alice", "First", comment_id="1", created=_JIRA_CREATED),
+        ]
+        mig.jira_client.get_issue_watchers.return_value = []
+
+        collected = mig._collect_content_for_issue(issue, wp_id=5040)
+
+        assert collected["comments"][0]["created_at"] == _JIRA_CREATED
+
+    def test_created_at_none_when_comment_has_no_created(self, tmp_path: Path, _mock_mappings: None) -> None:
+        mig = _build_mig(tmp_path)
+        issue = MagicMock()
+        issue.key = "PROJ-1"
+        issue.fields.description = None
+        issue.raw = {"fields": {}}
+        comment = MagicMock(spec=["body", "author", "id"])
+        comment.body = "No date"
+        comment.id = "1"
+        comment.author = SimpleNamespace(
+            name="alice", displayName="Alice", emailAddress="a@e.com", accountId=None, key=None
+        )
+        mig.jira_client.jira.comments.return_value = [comment]
+        mig.jira_client.get_issue_watchers.return_value = []
+
+        collected = mig._collect_content_for_issue(issue, wp_id=1)
+
+        assert collected["comments"][0]["created_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# 2. _bulk_process_collected_content forwards the comment date to the op client
+# ---------------------------------------------------------------------------
+
+
+class TestBulkProcessForwardsCommentDate:
+    def test_created_at_forwarded(self, tmp_path: Path, _mock_mappings: None) -> None:
+        mig = _build_mig(tmp_path)
+        collected_items = [
+            {
+                "wp_id": 5040,
+                "jira_key": "PROJ-1",
+                "description_update": None,
+                "custom_field_updates": {},
+                "comments": [
+                    {"comment": "First", "user_id": 201, "jira_comment_id": "1", "created_at": _JIRA_CREATED},
+                ],
+                "watchers": [],
+            }
+        ]
+        mig.op_client.bulk_create_work_package_activities.return_value = {"created": 1, "skipped": 0, "failed": 0}
+
+        mig._bulk_process_collected_content(collected_items)
+
+        activities = mig.op_client.bulk_create_work_package_activities.call_args[0][0]
+        assert activities[0]["created_at"] == _JIRA_CREATED
+
+
+# ---------------------------------------------------------------------------
+# 3. bulk_create_work_package_activities — date in payload + script back-dates journal
+# ---------------------------------------------------------------------------
+
+
+class TestBulkCreateBackdatesJournal:
+    def _svc_capturing_script(self):
+        from src.infrastructure.openproject.openproject_work_package_content_service import (
+            OpenProjectWorkPackageContentService,
+        )
+
+        mock_client = MagicMock()
+        mock_client.logger = MagicMock()
+        captured: list[str] = []
+
+        def capture(script: str):
+            captured.append(script)
+            return {"created": 1, "skipped": 0, "failed": 0, "success": True}
+
+        mock_client.execute_query_to_json_file.side_effect = capture
+        return OpenProjectWorkPackageContentService(mock_client), captured
+
+    def test_created_at_in_json_payload(self) -> None:
+        svc, captured = self._svc_capturing_script()
+        svc.bulk_create_work_package_activities(
+            [{"work_package_id": 5040, "comment": "Hi", "user_id": 100, "jira_comment_id": "1", "created_at": _JIRA_CREATED}]
+        )
+        payload = _extract_j2o_payload(captured[0])
+        assert payload[0]["created_at"] == _JIRA_CREATED
+
+    def test_ruby_script_backdates_journal_created_at(self) -> None:
+        source = inspect.getsource(
+            __import__(
+                "src.infrastructure.openproject.openproject_work_package_content_service",
+                fromlist=["OpenProjectWorkPackageContentService"],
+            ).OpenProjectWorkPackageContentService.bulk_create_work_package_activities
+        )
+        # The script must, after save!, set the new journal's created_at from the
+        # comment date (guarded by presence of created_at).
+        assert "created_at" in source, "bulk script never references created_at"
+        assert "update_columns" in source, "bulk script must update_columns the journal's created_at"
+        assert "Time.parse" in source, "bulk script must parse the ISO comment date"
+
+
+# ---------------------------------------------------------------------------
+# 4. Single-comment path forwards + back-dates
+# ---------------------------------------------------------------------------
+
+
+class TestSingleCommentPathBackdates:
+    def test_populate_comments_forwards_created_at(self, tmp_path: Path, _mock_mappings: None) -> None:
+        mig = _build_mig(tmp_path)
+        issue = MagicMock()
+        issue.key = "PROJ-1"
+        mig.jira_client.jira.comments.return_value = [
+            _make_comment("alice", "First", comment_id="1", created=_JIRA_CREATED),
+        ]
+        # Avoid link-resolution surprises: return body unchanged.
+        mig._convert_jira_links = lambda body, jira_key=None: body  # type: ignore[method-assign]
+
+        mig._populate_comments(issue, wp_id=5040)
+
+        activity = mig.op_client.create_work_package_activity.call_args[0][1]
+        assert activity["created_at"] == _JIRA_CREATED
+
+    def test_single_ruby_script_backdates_journal(self) -> None:
+        source = inspect.getsource(
+            __import__(
+                "src.infrastructure.openproject.openproject_work_package_content_service",
+                fromlist=["OpenProjectWorkPackageContentService"],
+            ).OpenProjectWorkPackageContentService.create_work_package_activity
+        )
+        assert "created_at" in source, "single script never references created_at"
+        assert "update_columns" in source, "single script must update_columns the journal's created_at"
+        assert "Time.parse" in source, "single script must parse the ISO comment date"


### PR DESCRIPTION
## Problem (issue #260)

A user reported that migrated **comments don't preserve their original date/time**. Confirmed by tracing the default/`full` profile (skeleton + content):

- The content phase collected each comment's body, author and Jira id but **dropped `comment.created`** ([`work_package_content_migration.py:560`](https://github.com/netresearch/jira-to-openproject/blob/main/src/application/components/work_package_content_migration.py#L560), [`:717`](https://github.com/netresearch/jira-to-openproject/blob/main/src/application/components/work_package_content_migration.py#L717)).
- The Rails helper created the journal via `wp.journal_notes = ...; wp.save!` with **no `created_at`** ([`openproject_work_package_content_service.py:344`](https://github.com/netresearch/jira-to-openproject/blob/main/src/infrastructure/openproject/openproject_work_package_content_service.py#L344), [`:511`](https://github.com/netresearch/jira-to-openproject/blob/main/src/infrastructure/openproject/openproject_work_package_content_service.py#L511)) → ActiveRecord stamped `journals.created_at = NOW`, which is the value OpenProject displays as the comment date.

(The WP "Created on" itself is correct — the skeleton phase sets `work_packages.created_at` via `update_columns`. This PR is specifically the **comment/journal** date.)

## Fix

Carry `comment.created` through the whole content-phase chain and back-date the journal after creation:

- `_collect_content_for_issue` / `_populate_comments` capture `created_at`.
- `_bulk_process_collected_content` forwards it to the op client.
- `bulk_create_work_package_activities` and `create_work_package_activity` include `created_at` in the payload and, after `save!`, run `journal.update_columns(created_at:, updated_at:)` — guarded by a parseable date, falling back to the default timestamp on `ArgumentError`.

`validity_period` is intentionally left as OpenProject set it: it drives historical baseline queries, not the displayed comment date, and rewriting it per journal risks the per-journable non-overlap exclusion constraint.

## Tests (red-green TDD)

`tests/unit/test_work_package_content_comment_dates.py` (7 tests) pin the chain end-to-end: capture → forward → JSON payload → generated Ruby contains the `update_columns`/`Time.parse` back-dating, for both the bulk and single-comment paths. 72 tests across the content/skeleton suites pass; `ruff`/`mypy` clean. Both generated Ruby scripts pass `ruby -c` (the single script's only standalone-`ruby -c` complaint is a **pre-existing** bare-hash in the idempotency branch that parses fine under the production execute wrapper).

## Verification limit

The back-dating runs on a live OpenProject 17 Rails console and **cannot be exercised by unit tests** — they cover the Python data-flow and the generated-script content. Runtime confirmation should come from the reporter's clean re-run.