### PR TITLE
fix: stop silent data loss across six migration components (#260)

### DIFF
--- a/src/application/components/customfields_generic_migration.py
+++ b/src/application/components/customfields_generic_migration.py
@@ -76,7 +76,18 @@ class CustomFieldsGenericMigration(BaseMigration):  # noqa: D101
         # Use existing CF mapping to decide names/types
         cf_mapping = self.mappings.get_mapping("custom_field") or {}
 
-        values_by_wp: dict[int, list[tuple[str, str]]] = {}
+        # Production wp_map is keyed by the numeric Jira ID with the human key
+        # nested under ``jira_key``; ``issues`` is keyed by the human key. Index
+        # entries by their human key so the lookup below works for both the
+        # production (numeric-ID) and legacy/test (human-key) mapping shapes
+        # instead of silently skipping every issue (#260).
+        entry_by_jira_key: dict[str, Any] = {}
+        for outer_key, raw in wp_map.items():
+            inner_key = self._inner_jira_key(outer_key, raw)
+            if inner_key is not None:
+                entry_by_jira_key[inner_key] = raw
+
+        values_by_wp: dict[int, list[tuple[str, str, str]]] = {}
         wp_to_project: dict[int, int] = {}  # Track project ID for each WP
         for jira_key, issue in issues.items():
             # Walk raw ``fields`` for dynamic ``customfield_*`` attributes —
@@ -85,7 +96,7 @@ class CustomFieldsGenericMigration(BaseMigration):  # noqa: D101
             fields = getattr(issue, "fields", None)
             if not fields:
                 continue
-            raw_entry = wp_map.get(jira_key)
+            raw_entry = entry_by_jira_key.get(jira_key)
             if raw_entry is None:
                 continue
             try:
@@ -116,12 +127,14 @@ class CustomFieldsGenericMigration(BaseMigration):  # noqa: D101
                 norm_value = self._to_string_value(cf_value)
                 if not norm_value:
                     continue
-                values_by_wp.setdefault(wp_id, []).append((op_name, op_type))
+                values_by_wp.setdefault(wp_id, []).append((op_name, op_type, norm_value))
 
         return ComponentResult(success=True, data={"values_by_wp": values_by_wp, "wp_to_project": wp_to_project})
 
     def _load(self, mapped: ComponentResult) -> ComponentResult:
-        values_by_wp: dict[int, list[tuple[str, str]]] = (mapped.data or {}).get("values_by_wp", {})  # type: ignore[assignment]
+        from src.infrastructure.openproject.openproject_client import escape_ruby_single_quoted
+
+        values_by_wp: dict[int, list[tuple[str, str, str]]] = (mapped.data or {}).get("values_by_wp", {})  # type: ignore[assignment]
         wp_to_project: dict[int, int] = (mapped.data or {}).get("wp_to_project", {})  # type: ignore[assignment]
         if not values_by_wp:
             return ComponentResult(success=True, updated=0)
@@ -136,7 +149,7 @@ class CustomFieldsGenericMigration(BaseMigration):  # noqa: D101
             project_id = wp_to_project.get(wp_id)
             # Deduplicate CF names for this WP
             seen: set[str] = set()
-            for name, field_format in cf_specs:
+            for name, field_format, value in cf_specs:
                 if name in seen:
                     continue
                 seen.add(name)
@@ -145,15 +158,15 @@ class CustomFieldsGenericMigration(BaseMigration):  # noqa: D101
                     # Track project for selective enablement
                     if project_id:
                         cf_to_projects.setdefault(cf_id, set()).add(project_id)
-                    # Set CF value from mapping; re-lookup actual value by WP/Jira key not available here,
-                    # so apply a placeholder behavior is not possible. Instead, re-extracting values again
-                    # would be redundant in tests; we set a non-empty string already normalized earlier.
-                    # Since execute_query requires actual value, use a minimal no-op if missing.
-                    # Here we store an empty string would be skipped above, so set 'set' to preserve flow.
+                    # Write the actual normalized Jira value extracted in ``_extract``
+                    # (#260: previously a literal 'set' placeholder was written,
+                    # discarding the real value).
+                    escaped_value = escape_ruby_single_quoted(value)
                     set_script = (
                         "wp = WorkPackage.find(%d); cf = CustomField.find(%d); "
-                        "cv = wp.custom_value_for(cf); if cv; cv.value = (cv.value.presence || 'set'); cv.save; else; wp.custom_field_values = { cf.id => 'set' }; end; wp.save!; true"
-                        % (wp_id, cf_id)
+                        "cv = wp.custom_value_for(cf); if cv; cv.value = '%s'; cv.save!; "
+                        "else; wp.custom_field_values = { cf.id => '%s' }; end; wp.save!; true"
+                        % (wp_id, cf_id, escaped_value, escaped_value)
                     )
                     ok = self.op_client.execute_query(set_script)
                     if ok:

--- a/src/application/components/watcher_migration.py
+++ b/src/application/components/watcher_migration.py
@@ -80,14 +80,17 @@ class WatcherMigration(BaseMigration):
         """Map a typed watcher to an OP user id.
 
         Probes the user mapping using (in order): ``account_id``,
-        ``name``, ``email_address``, ``display_name`` — matching the
+        ``name``, ``key``, ``email_address``, ``display_name`` — matching the
         pattern used in :class:`AttachmentProvenanceMigration`. Cloud
-        instances primarily key on ``account_id``; Server/DC on ``name``.
+        instances primarily key on ``account_id``; Server/DC user mappings are
+        stored under the internal ``key`` (e.g. ``JIRAUSER18400``), which
+        differs from ``name`` for renamed/inactive accounts (#260).
         """
         user_map = self.mappings.get_mapping("user") or {}
         for probe in (
             watcher.account_id,
             watcher.name,
+            watcher.key,
             watcher.email_address,
             watcher.display_name,
         ):

--- a/src/application/components/work_package_content_migration.py
+++ b/src/application/components/work_package_content_migration.py
@@ -774,6 +774,7 @@ class WorkPackageContentMigration(BaseMigration):
             "descriptions_updated": 0,
             "custom_fields_updated": 0,
             "comments_migrated": 0,
+            "comments_failed": 0,
             "watchers_added": 0,
         }
 
@@ -840,8 +841,26 @@ class WorkPackageContentMigration(BaseMigration):
             try:
                 result = self.op_client.bulk_create_work_package_activities(all_comments)
                 results["comments_migrated"] = result.get("created", 0)
+                # Surface the Rails-side failure count instead of discarding it —
+                # previously only ``created`` was read, so dropped comments
+                # (e.g. all but the first per WP) looked like a clean success (#260).
+                failed = int(result.get("failed", 0) or 0)
+                results["comments_failed"] = failed
+                if failed or result.get("success") is False:
+                    self.logger.warning(
+                        "Bulk comment creation: %d created, %d failed (success=%s) — "
+                        "failed comments were dropped; check the OpenProject Rails errors. "
+                        "First errors: %s",
+                        result.get("created", 0),
+                        failed,
+                        result.get("success"),
+                        (result.get("errors") or [])[:3],
+                    )
             except Exception as e:
-                self.logger.debug("Bulk comment creation failed: %s", e)
+                # A thrown bulk call drops the whole batch of comments; record
+                # and warn rather than swallowing it at debug level (#260).
+                self.logger.warning("Bulk comment creation failed (%d comments dropped): %s", len(all_comments), e)
+                results["comments_failed"] = len(all_comments)
 
         # Batch 4: Watchers (using bulk_add_watchers)
         if os.environ.get("J2O_SKIP_WATCHERS"):
@@ -920,6 +939,7 @@ class WorkPackageContentMigration(BaseMigration):
             "descriptions_updated": 0,
             "custom_fields_updated": 0,
             "comments_migrated": 0,
+            "comments_failed": 0,
             "watchers_added": 0,
             "projects": {},
         }
@@ -966,6 +986,7 @@ class WorkPackageContentMigration(BaseMigration):
                     results["descriptions_updated"] += batch_results["descriptions_updated"]
                     results["custom_fields_updated"] += batch_results["custom_fields_updated"]
                     results["comments_migrated"] += batch_results["comments_migrated"]
+                    results["comments_failed"] += batch_results.get("comments_failed", 0)
                     results["watchers_added"] += batch_results["watchers_added"]
 
                     self.logger.info(
@@ -983,6 +1004,7 @@ class WorkPackageContentMigration(BaseMigration):
                 results["descriptions_updated"] += batch_results["descriptions_updated"]
                 results["custom_fields_updated"] += batch_results["custom_fields_updated"]
                 results["comments_migrated"] += batch_results["comments_migrated"]
+                results["comments_failed"] += batch_results.get("comments_failed", 0)
                 results["watchers_added"] += batch_results["watchers_added"]
 
                 self.logger.info(
@@ -1020,6 +1042,12 @@ class WorkPackageContentMigration(BaseMigration):
             results["comments_migrated"],
             results["watchers_added"],
         )
+        if results["comments_failed"]:
+            self.logger.warning(
+                "Content migration dropped %d comment(s) across all projects — these were NOT "
+                "migrated (#260). Review the per-batch bulk-comment warnings above and re-run.",
+                results["comments_failed"],
+            )
 
         return results
 
@@ -1059,6 +1087,7 @@ class WorkPackageContentMigration(BaseMigration):
                     "total_failed": migration_results["total_failed"],
                     "descriptions_updated": migration_results["descriptions_updated"],
                     "comments_migrated": migration_results["comments_migrated"],
+                    "comments_failed": migration_results.get("comments_failed", 0),
                 },
             )
         except Exception as e:

--- a/src/infrastructure/jira/jira_issue_service.py
+++ b/src/infrastructure/jira/jira_issue_service.py
@@ -300,6 +300,28 @@ class JiraIssueService:
                 **kwargs,
             )
             merged.update(chunk_result)
+
+        # Reconcile requested-vs-returned so a dropped chunk is never silent at
+        # the batch level (#260).  A genuine 401/403 chunk drop is non-fatal by
+        # design (per-chunk WARNING above), but a partial result previously
+        # looked complete to callers.  Surface the gap with a single summary so
+        # operators can see issues went unfetched.  Note: missing keys can also
+        # be issues deleted in Jira (``key in (...)`` JQL omits them silently),
+        # so the message names both causes rather than asserting an error.
+        missing = [k for k in unique_keys if k not in merged]
+        if missing:
+            sample = ", ".join(missing[:10])
+            self._logger.warning(
+                "Issue fetch reconciliation (batch_num=%s): requested %d key(s), received %d; "
+                "%d key(s) were not returned by Jira — either deleted in Jira, or dropped by a "
+                "fetch error (see the per-chunk warnings above). Missing sample: [%s%s]",
+                kwargs.get("batch_num"),
+                len(unique_keys),
+                len(merged),
+                len(missing),
+                sample,
+                "" if len(missing) <= 10 else ", …",
+            )
         return merged
 
     def _fetch_single_chunk(
@@ -547,6 +569,10 @@ class JiraIssueService:
             return [
                 {
                     "name": getattr(watcher, "name", None),
+                    # Server/DC internal user key (e.g. JIRAUSER18400); the user
+                    # mapping is keyed by it, so it must be carried for watcher
+                    # resolution (#260).
+                    "key": getattr(watcher, "key", None),
                     "accountId": getattr(watcher, "accountId", None),
                     "displayName": getattr(watcher, "displayName", None),
                     "emailAddress": getattr(watcher, "emailAddress", None),

--- a/src/infrastructure/jira/jira_project_service.py
+++ b/src/infrastructure/jira/jira_project_service.py
@@ -14,6 +14,7 @@ there is no Ruby-script escaping to worry about.
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlsplit
 
 from src.infrastructure.jira.jira_client import (
     HTTP_NOT_FOUND,
@@ -169,6 +170,28 @@ class JiraProjectService:
             self._logger.exception(error_msg)
             raise JiraApiError(error_msg) from e
 
+    @staticmethod
+    def _role_detail_path(role_url: str) -> str:
+        """Reduce a Jira role URL to a base-relative request path.
+
+        Jira's project role-list returns *absolute* role URLs. ``_make_request``
+        unconditionally prepends the client base URL, so the role URL must be
+        stripped to its path (plus query) first. A naive ``startswith(base_url)``
+        strip fails whenever the scheme/host/port differ (https base vs http
+        behind a TLS-terminating proxy, an explicit port, or case differences),
+        leaving the absolute URL intact and producing ``/http://…`` — a path
+        Jira answers with an HTML 200 (#260). ``urlsplit().path`` is empty for a
+        bare host and equals the input for an already-relative path, so taking
+        the path unconditionally is host-independent and handles both shapes.
+        """
+        parts = urlsplit(role_url)
+        path = parts.path
+        if parts.query:
+            path = f"{path}?{parts.query}"
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return path
+
     def get_project_roles(self, project_key: str) -> list[dict[str, Any]]:
         """Retrieve Jira project roles and their actors for a project."""
         if not project_key:
@@ -192,11 +215,7 @@ class JiraProjectService:
                 if not isinstance(role_url, str):
                     continue
 
-                detail_path = role_url
-                if role_url.startswith(client.base_url):
-                    detail_path = role_url[len(client.base_url) :]
-                if not detail_path.startswith("/"):
-                    detail_path = f"/{detail_path}"
+                detail_path = self._role_detail_path(role_url)
 
                 try:
                     detail_response = client._make_request(detail_path)

--- a/src/infrastructure/openproject/openproject_rails_runner_service.py
+++ b/src/infrastructure/openproject/openproject_rails_runner_service.py
@@ -339,7 +339,12 @@ class OpenProjectRailsRunnerService:
         """
         try:
             _ts = int(__import__("time").time())
-            container_file = f"/tmp/j2o_query_{_ts}_{os.getpid()}.json"
+            # Append a per-call random token so two calls within the same
+            # wall-clock second in the same process never collide on the
+            # tempfile path and read back each other's stale JSON — which
+            # surfaced as "Unexpected response when ensuring reporting
+            # project" (a stale groups list) during the #260 run.
+            container_file = f"/tmp/j2o_query_{_ts}_{os.getpid()}_{secrets.token_hex(8)}.json"
             return self._client.execute_large_query_to_json_file(
                 query,
                 container_file=container_file,

--- a/src/infrastructure/openproject/openproject_work_package_content_service.py
+++ b/src/infrastructure/openproject/openproject_work_package_content_service.py
@@ -521,6 +521,13 @@ J2O_DATA
               comment_text = item['comment'].to_s
               next if comment_text.empty?
 
+              # The same WorkPackage object is reused for every comment of this
+              # WP (pre-fetched once into `wps`). Reload it so each comment
+              # starts from fresh persisted state — reusing the stale in-memory
+              # object (cached journals association / lock_version) made the
+              # 2nd+ save fail, so only the first comment per WP persisted (#260).
+              wp.reload
+
               # OpenProject 15+ journal creation - use journal_notes/journal_user
               wp.journal_notes = comment_text
               wp.journal_user = user

--- a/src/models/jira/watcher.py
+++ b/src/models/jira/watcher.py
@@ -26,6 +26,11 @@ class JiraWatcher(BaseModel):
     name: str | None = None
     """Server/DC login (``name``) — the legacy username-based identifier."""
 
+    key: str | None = None
+    """Server/DC internal user key (e.g. ``JIRAUSER18400``). Differs from
+    ``name`` for renamed/inactive accounts and is the key the user mapping is
+    stored under, so it must be carried for resolution (#260)."""
+
     account_id: str | None = Field(default=None, alias="accountId")
     """Cloud ``accountId`` for the watcher, when present."""
 
@@ -53,13 +58,16 @@ class JiraWatcher(BaseModel):
         else:
             data = {
                 "name": getattr(raw, "name", None),
+                "key": getattr(raw, "key", None),
                 "accountId": getattr(raw, "accountId", None),
                 "displayName": getattr(raw, "displayName", None),
                 "emailAddress": getattr(raw, "emailAddress", None),
                 "active": getattr(raw, "active", True),
             }
         instance = cls.model_validate(data)
-        if not (instance.name or instance.account_id or instance.email_address or instance.display_name):
+        if not (
+            instance.name or instance.key or instance.account_id or instance.email_address or instance.display_name
+        ):
             return None
         return instance
 

--- a/tests/unit/test_customfields_generic_migration.py
+++ b/tests/unit/test_customfields_generic_migration.py
@@ -88,3 +88,65 @@ def test_customfields_generic_migration_extracts_and_sets_cf():
     ld = mig._load(mp)
     assert ld.success is True
     assert ld.updated >= 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #260: production work_package mappings are keyed by the *numeric Jira
+# ID* with the human-readable key nested under ``jira_key`` — not by the human
+# key directly (the legacy/test shape above).  The component iterates issues by
+# human key, so a ``wp_map.get(human_key)`` lookup against an ID-keyed map
+# returns ``None`` for every issue and silently skips them all.
+# ---------------------------------------------------------------------------
+
+
+def _set_production_wp_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Override the autouse mapping with the production-shaped wp_map.
+
+    Outer key = numeric Jira ID; the human key lives under ``jira_key``.
+    """
+    import src.config as cfg
+
+    class ProdMappings:
+        def __init__(self) -> None:
+            self._m = {
+                "work_package": {
+                    "144952": {"jira_key": "PRJ-1", "openproject_id": 20001},
+                },
+                "custom_field": {
+                    "customfield_10011": {
+                        "jira_id": "customfield_10011",
+                        "jira_name": "Text Field",
+                        "openproject_name": "Text Field",
+                        "openproject_type": "text",
+                    },
+                },
+            }
+
+        def get_mapping(self, name: str):
+            return self._m.get(name, {})
+
+    monkeypatch.setattr(cfg, "mappings", ProdMappings(), raising=False)
+
+
+def test_extract_matches_numeric_id_keyed_wp_map(monkeypatch: pytest.MonkeyPatch):
+    """A numeric-ID-keyed wp_map must still resolve the issue's human key."""
+    _set_production_wp_map(monkeypatch)
+    mig = CustomFieldsGenericMigration(jira_client=DummyJira(), op_client=DummyOp())  # type: ignore[arg-type]
+    ex = mig._extract()
+    values_by_wp = (ex.data or {}).get("values_by_wp", {})
+    assert values_by_wp, "production-shaped (numeric-ID) wp_map must not skip every issue"
+    assert 20001 in values_by_wp
+
+
+def test_load_writes_actual_cf_value_not_placeholder(monkeypatch: pytest.MonkeyPatch):
+    """The real Jira CF value must reach the Ruby set-script, not 'set'."""
+    _set_production_wp_map(monkeypatch)
+    op = DummyOp()
+    mig = CustomFieldsGenericMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    ld = mig._load(mig._map(mig._extract()))
+    assert ld.updated >= 1
+    set_scripts = [q for q in op.queries if "custom_field_values" in q or "custom_value_for" in q]
+    assert set_scripts, "expected a CF value-setting script to be issued"
+    joined = "\n".join(set_scripts)
+    assert "Free text" in joined, "actual Jira CF value must be written, not discarded"
+    assert "=> 'set'" not in joined, "placeholder 'set' must not replace the real value"

--- a/tests/unit/test_jira_issue_service.py
+++ b/tests/unit/test_jira_issue_service.py
@@ -453,3 +453,98 @@ def test_status_extracted_from_message_when_no_attribute() -> None:
     assert JiraIssueService._extract_http_status(JiraApiError("HTTP Error 414: too long")) == 414
     assert JiraIssueService._extract_http_status(JIRAError("x", 401, "u")) == 401
     assert JiraIssueService._extract_http_status(RuntimeError("no status here")) is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #260: dropped chunks must be reconciled (not silently lost at the
+# batch level).  The team deliberately keeps a dropped chunk non-fatal
+# (returns {} + per-chunk WARNING), but the *overall* fetch previously gave
+# no requested-vs-returned summary, so a partial result looked complete.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_issues_batch_logs_reconciliation_when_chunk_dropped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+    import re
+
+    keys_a = [f"OK-{i}" for i in range(1, 26)]
+    keys_b = [f"FAIL-{i}" for i in range(1, 26)]
+    all_keys = keys_a + keys_b
+    call_count = 0
+
+    def _search(jql: str, **_kw: object) -> list[SimpleNamespace]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return [_make_issue(k) for k in re.findall(r'"([^"]+)"', jql)]
+        raise JIRAError("Simulated 401", 401, "https://jira.test/search?jql=...")
+
+    client = _make_client(search_side_effect=_search)
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.WARNING):
+        result = service._fetch_issues_batch(all_keys)
+
+    # Partial-result contract preserved: first chunk present, second dropped.
+    assert len(result) == 25
+    # The gap must be surfaced loudly with a reconciliation summary naming the
+    # count of unreturned keys — never a mislabelled URL-length problem.
+    msgs = " ".join(r.getMessage() for r in caplog.records)
+    assert "reconciliation" in msgs.lower(), msgs
+    assert "25" in msgs, msgs
+    assert "url" not in msgs.lower() or "url-length" not in msgs.lower()
+
+
+@pytest.mark.unit
+def test_fetch_issues_batch_no_reconciliation_log_when_complete(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When every requested key is returned, no reconciliation warning fires."""
+    import logging
+    import re
+
+    keys = [f"OK-{i}" for i in range(1, 11)]
+
+    def _search(jql: str, **_kw: object) -> list[SimpleNamespace]:
+        return [_make_issue(k) for k in re.findall(r'"([^"]+)"', jql)]
+
+    client = _make_client(search_side_effect=_search)
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.WARNING):
+        result = service._fetch_issues_batch(keys)
+
+    assert len(result) == 10
+    assert not any("reconciliation" in r.getMessage().lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Issue #260: get_issue_watchers must carry the Server/DC ``key`` so watchers
+# resolve against a user mapping keyed by that internal key.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_issue_watchers_includes_server_dc_key() -> None:
+    client = _make_client()
+    client.jira.watchers.return_value = SimpleNamespace(
+        watchers=[
+            SimpleNamespace(
+                name="anne.geissler",
+                key="JIRAUSER18400",
+                accountId=None,
+                displayName="Anne G",
+                emailAddress=None,
+                active=True,
+            ),
+        ],
+    )
+    service = JiraIssueService(client)  # type: ignore[arg-type]
+
+    result = service.get_issue_watchers("TK-1")
+
+    assert result[0]["key"] == "JIRAUSER18400"
+    assert result[0]["name"] == "anne.geissler"

--- a/tests/unit/test_jira_non_json_response.py
+++ b/tests/unit/test_jira_non_json_response.py
@@ -381,3 +381,37 @@ class TestProjectRolesSkipsOnHtml:
         assert roles == []
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert warnings, "expected a WARNING-level log entry on project-roles unavailability"
+
+
+class TestRoleDetailPath:
+    """Issue #260: Jira's role-list returns absolute role URLs. The detail
+    request must use only the *path*, never the whole URL re-prefixed onto the
+    client base — which produced ``/http://jira.../role/10100`` (HTML 200) when
+    scheme/host/port differed (e.g. https base vs http behind a proxy).
+    """
+
+    def _path(self, role_url: str) -> str:
+        from src.infrastructure.jira.jira_project_service import JiraProjectService
+
+        return JiraProjectService._role_detail_path(role_url)
+
+    def test_absolute_url_with_matching_base_becomes_relative(self) -> None:
+        assert self._path("https://jira.local/rest/api/2/project/1/role/10100") == "/rest/api/2/project/1/role/10100"
+
+    def test_scheme_or_host_mismatch_does_not_double_prefix(self) -> None:
+        path = self._path("https://jira-proxy.domain.tld:8443/rest/api/2/project/10001/role/10100")
+        assert path == "/rest/api/2/project/10001/role/10100"
+        assert not path.startswith("/http"), "must not embed an absolute URL in the path"
+
+    def test_port_mismatch_does_not_double_prefix(self) -> None:
+        path = self._path("https://jira.local:8443/rest/api/2/project/1/role/2")
+        assert path == "/rest/api/2/project/1/role/2"
+
+    def test_relative_url_is_kept(self) -> None:
+        assert self._path("/rest/api/2/project/1/role/2") == "/rest/api/2/project/1/role/2"
+
+    def test_query_string_is_preserved(self) -> None:
+        assert (
+            self._path("https://jira.x/rest/api/2/project/1/role/2?expand=actors")
+            == "/rest/api/2/project/1/role/2?expand=actors"
+        )

--- a/tests/unit/test_models_jira_watcher.py
+++ b/tests/unit/test_models_jira_watcher.py
@@ -59,7 +59,32 @@ def test_from_any_active_defaults_to_true_when_missing() -> None:
 
 def test_from_any_extra_keys_are_ignored() -> None:
     watcher = JiraWatcher.from_any(
-        {"name": "dave", "self": "https://j.example.com/rest/api/2/user", "key": "ignored-extra"},
+        {"name": "dave", "self": "https://j.example.com/rest/api/2/user", "timeZone": "UTC"},
     )
     assert watcher is not None
     assert watcher.name == "dave"
+
+
+def test_from_any_captures_server_dc_key_from_dict() -> None:
+    """Jira Server/DC watcher rows carry a ``key`` (e.g. JIRAUSER18400) that
+    differs from ``name`` for renamed/inactive accounts. It must be captured
+    so the watcher can be resolved against a key-keyed user mapping (#260).
+    """
+    watcher = JiraWatcher.from_any({"key": "JIRAUSER18400", "name": "anne.geissler"})
+    assert watcher is not None
+    assert watcher.key == "JIRAUSER18400"
+    assert watcher.name == "anne.geissler"
+
+
+def test_from_any_captures_key_from_sdk_like_object() -> None:
+    obj = SimpleNamespace(key="JIRAUSER18400", name="anne.geissler")
+    watcher = JiraWatcher.from_any(obj)
+    assert watcher is not None
+    assert watcher.key == "JIRAUSER18400"
+
+
+def test_from_any_resolves_when_only_key_present() -> None:
+    """A row with only ``key`` is a usable identifier, not skipped."""
+    watcher = JiraWatcher.from_any({"key": "JIRAUSER18400"})
+    assert watcher is not None
+    assert watcher.key == "JIRAUSER18400"

--- a/tests/unit/test_rails_runner_tempfile_unique.py
+++ b/tests/unit/test_rails_runner_tempfile_unique.py
@@ -1,0 +1,43 @@
+"""Issue #260: the Rails query tempfile name must be unique per call.
+
+``execute_query_to_json_file`` writes the Ruby result to a container tempfile
+and reads it back. The name was ``/tmp/j2o_query_{int(time.time())}_{pid}.json``
+— second-resolution time plus PID, with no random component. Two calls landing
+in the same wall-clock second in the same process produced the *same* path, so
+a later call could read back the *previous* call's stale JSON (e.g. a groups
+list where a project was expected → "Unexpected response when ensuring
+reporting project"). A per-call random token makes the path collision-free.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.infrastructure.openproject.openproject_rails_runner_service import (
+    OpenProjectRailsRunnerService,
+)
+
+
+def _service_capturing_container_path() -> OpenProjectRailsRunnerService:
+    client = MagicMock()
+    client.logger = MagicMock()
+    # Echo back the container_file the service generated so the test can inspect it.
+    client.execute_large_query_to_json_file.side_effect = lambda query, container_file, timeout=None: container_file
+    return OpenProjectRailsRunnerService(client)
+
+
+def test_same_second_calls_get_unique_container_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    import time as _time
+
+    # Freeze wall-clock to a single second to force the historically-colliding case.
+    monkeypatch.setattr(_time, "time", lambda: 1000.0)
+
+    svc = _service_capturing_container_path()
+    path1 = svc.execute_query_to_json_file("query one")
+    path2 = svc.execute_query_to_json_file("query two")
+
+    assert "j2o_query_" in path1
+    assert path1.endswith(".json")
+    assert path1 != path2, "same-second calls must not collide on the container tempfile path"

--- a/tests/unit/test_watcher_migration.py
+++ b/tests/unit/test_watcher_migration.py
@@ -103,6 +103,35 @@ def test_skip_reasons_user_unmapped(
     assert res.details["created"] == 1
 
 
+def test_watcher_resolves_via_server_dc_key(
+    monkeypatch: pytest.MonkeyPatch,
+    _map_store,
+    tmp_path,
+):
+    """On Jira Server/DC the user mapping is keyed by the Jira ``key``
+    (e.g. JIRAUSER18400), which differs from ``name`` for renamed/inactive
+    accounts. The resolver must probe ``key`` so such watchers map instead of
+    being skipped as ``user_unmapped`` (#260).
+    """
+    _map_store.set_mapping("user", {"JIRAUSER18400": {"openproject_id": 7}})
+    op = DummyOpClient()
+
+    class DummyJira:
+        def get_issue_watchers(self, key: str):
+            # name differs from the Jira key, which is how the map is keyed.
+            return [{"key": "JIRAUSER18400", "name": "anne.geissler"}]
+
+    wm = WatcherMigration(jira_client=DummyJira(), op_client=op)  # type: ignore[arg-type]
+    cache_dir = tmp_path / "data"
+    cache_dir.mkdir()
+    (cache_dir / "jira_issues_cache.json").write_text('{"J1": {"key": "J1"}}')
+    wm.data_dir = cache_dir
+
+    res = wm.run()
+    assert res.success
+    assert op.added == [(10, 7)], res.details
+
+
 def test_skip_reasons_wp_unmapped(
     monkeypatch: pytest.MonkeyPatch,
     _map_store,

--- a/tests/unit/test_work_package_content_comment_loss.py
+++ b/tests/unit/test_work_package_content_comment_loss.py
@@ -1,0 +1,67 @@
+"""Issue #260: only the first comment per work package was migrated.
+
+Two compounding defects dropped comments silently:
+
+1. The Rails ``bulk_create_work_package_activities`` helper pre-fetches each
+   WorkPackage once and reuses that same in-memory object for *every* comment
+   of that WP. Without a ``reload`` between saves the second-and-later saves of
+   a WP fail (stale association/version state); the bare ``rescue`` counts them
+   as ``failed`` and drops them.
+2. The Python caller read only ``result["created"]`` and discarded the Rails
+   ``failed``/``success`` counts, so the run reported success while comments
+   were lost.
+
+These tests pin both halves of the fix.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+# Reuse the shared content-migration builder rather than re-defining it.
+from tests.unit.test_work_package_content_comment_idempotency import _build_mig
+
+
+def test_bulk_ruby_reloads_wp_before_each_comment_save() -> None:
+    """The Ruby loop must reload each WP so it doesn't reuse a stale object."""
+    from src.infrastructure.openproject.openproject_work_package_content_service import (
+        OpenProjectWorkPackageContentService,
+    )
+
+    source = inspect.getsource(OpenProjectWorkPackageContentService.bulk_create_work_package_activities)
+    assert "wp.reload" in source, (
+        "each comment must call wp.reload so the loop doesn't reuse a stale "
+        "in-memory object — otherwise only the first comment per WP persists (#260)"
+    )
+
+
+def test_bulk_process_surfaces_partial_comment_failures(tmp_path: Path) -> None:
+    """A Rails partial failure (created=1, failed=2) must be surfaced, not
+    silently reduced to ``comments_migrated=1``.
+    """
+    mig = _build_mig(tmp_path)
+    collected_items = [
+        {
+            "wp_id": 5040,
+            "jira_key": "PROJ-1",
+            "description_update": None,
+            "custom_field_updates": {},
+            "comments": [
+                {"comment": f"c{i}", "user_id": 1, "jira_comment_id": str(i), "created_at": None} for i in range(1, 4)
+            ],
+            "watchers": [],
+        },
+    ]
+    mig.op_client.bulk_create_work_package_activities.return_value = {
+        "created": 1,
+        "skipped": 0,
+        "failed": 2,
+        "success": False,
+        "errors": [{"wp_id": 5040, "error": "stale object"}],
+    }
+
+    results = mig._bulk_process_collected_content(collected_items)
+
+    assert results["comments_migrated"] == 1
+    assert results["comments_failed"] == 2, "dropped comments must be surfaced, not silently discarded"


### PR DESCRIPTION
## Summary

A `--profile full` migration reported **success** while silently losing data ([#260](https://github.com/netresearch/jira-to-openproject/issues/260)). This fixes six independent defects, each of which dropped data without failing the run. Every fix is covered by a failing-first (TDD) test; the full unit suite is green (1918 passed).

## Type of Change
- [x] Bug fix (non-breaking)

## Root causes & fixes

1. **Comments — only the first comment per work package survived.** The Rails `bulk_create_work_package_activities` helper pre-fetched each `WorkPackage` once and reused that same in-memory object for every comment, so the 2nd+ save failed on stale association/lock state and the bare `rescue` dropped it. The Python caller read only `result["created"]`, discarding the Rails `failed`/`success` counts.
   *Fix:* `wp.reload` per comment in Ruby; surface `comments_failed` through `_bulk_process_collected_content` → `_migrate_content` → `ComponentResult.details`, with a loud WARNING on drops.

2. **Custom fields (generic) — every issue skipped, values discarded.** `_extract` looked up `wp_map` by the human Jira key, but the production `wp_map` is keyed by the numeric Jira ID (human key nested under `jira_key`) → every issue skipped (the `Loaded 0` log lines). The normalized value was also computed then discarded, writing the literal placeholder `'set'`.
   *Fix:* index entries by their human key (handles both the numeric-ID and legacy/human-key shapes) and write the real value.

3. **Chunked issue fetch — dropped chunks were silent at the batch level.** A dropped chunk is non-fatal by design (per-chunk WARNING), but the overall fetch gave no requested-vs-returned summary, so a partial result looked complete.
   *Fix:* reconcile in `_fetch_issues_batch` and log a WARNING naming the count of unreturned keys — preserving the deliberate non-abort contract.

4. **Watchers — Server/DC users never resolved.** The user mapping is keyed by the Jira internal `key` (`JIRAUSER…`), but the resolver never probed `key` and `get_issue_watchers` stripped it from its payload, so renamed/inactive accounts always missed.
   *Fix:* carry `key` on `JiraWatcher` and in the watcher payload, and add it to the resolver probe ladder.

5. **Group provenance — stale tempfile read-back.** The Rails query tempfile name used second-resolution time + PID with no random component, so two calls in the same second read back each other's stale JSON (a groups list where a project was expected → "Unexpected response when ensuring reporting project").
   *Fix:* append a per-call random token to the tempfile name.

6. **Project roles (admin_schemes) — malformed `/http://…` URL.** Jira returns absolute role URLs; the base-URL strip used a case/scheme/port-sensitive `startswith`, so a mismatch (https base vs http behind a proxy) left the absolute URL intact and `_make_request` re-prefixed it → HTML 200, roles skipped.
   *Fix:* extract the path with `urlsplit` (host-independent).

## Testing
- [x] Failing-first unit tests added for all six fixes (`test_work_package_content_comment_loss.py`, `test_customfields_generic_migration.py`, `test_jira_issue_service.py`, `test_models_jira_watcher.py` + `test_watcher_migration.py`, `test_rails_runner_tempfile_unique.py`, `test_jira_non_json_response.py::TestRoleDetailPath`)
- [x] Full unit suite green (1918 passed); `ruff check`, `ruff format --check`, and `mypy` clean

## Notes for reviewers
- The exact OpenProject-internal reason the 2nd+ comment save failed (#1) is not provable from this repo; `wp.reload` defensively fixes the stale-state class of failure and the loss is no longer silent. A live OpenProject run is the surest confirmation before closing the issue.
- In the reporter's logs every chunk-fetch 401 (#3) recovered on retry, so that path didn't cause *their* loss — it's a latent silent-drop. The non-abort behavior was a deliberate decision (with `#260` tests), so this PR makes the gap loud rather than reversing it.

## Related
Fixes #260
