### PR TITLE
docs: correct agile board/sprint mapping and record its rationale

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-**j2o** is a Python 3.14 migration toolset that moves project management data from Jira Server 9.x to OpenProject 15+/16.x — users, projects, work packages, custom fields, statuses, workflows, attachments, Tempo time logs, agile boards, and reporting artefacts. It is a 41-module ETL pipeline with a FastAPI dashboard.
+**j2o** is a Python 3.14 migration toolset that moves project management data from Jira Server 9.x to OpenProject 17.3+ — users, projects, work packages, custom fields, statuses, workflows, attachments, Tempo time logs, agile boards, and reporting artefacts. It is a 41-module ETL pipeline with a FastAPI dashboard.
 
 **Precedence:** The **closest AGENTS.md** to changed files wins. Root holds global defaults only.
 
@@ -143,7 +143,7 @@ Cross-cutting modules are **intentionally outside** the contract and may be impo
 
 ## Codebase state
 - Python 3.14+, `uv` package manager, Docker Compose test profile
-- Target: Jira Server 9.x → OpenProject 15+/16.x
+- Target: Jira Server 9.x → OpenProject 17.3+ (currently tested against 17.3)
 - OpenProject 15+ requires `journal_notes`/`journal_user` + `save!` pattern (not `journals.create!`)
 - `J2O_FORCE_RAILS_RUNNER=1` bypasses tmux console for `rails runner` mode
 - 41 migration modules, 307 projects migrated, 65K+ work packages

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A robust, modular migration toolset for transferring project management data fro
 - **Attachment Migration:** Issue attachments → Work package files
 - **Time Log Migration:** Tempo worklogs → OpenProject time entries
 - **Workflow Automation:** Jira workflow transitions → OpenProject workflow entries per type/role
-- **Agile Boards & Sprints:** Jira boards → OpenProject saved queries with sprint (version) mapping
+- **Agile Boards & Sprints:** Jira boards → OpenProject saved queries, sprints → versions (not OpenProject's native boards/sprints — see [Entity Mapping §11](docs/ENTITY_MAPPING.md#11-agile-migration))
 - **Admin Schemes:** Jira role memberships → OpenProject project memberships
 - **Reporting Artefacts:** Jira saved filters & dashboards → OpenProject queries and wiki summaries
 

--- a/docs/ENTITY_MAPPING.md
+++ b/docs/ENTITY_MAPPING.md
@@ -1,7 +1,7 @@
 # Jira to OpenProject Entity Mapping Reference
 
-**Version**: 2.0
-**Last Updated**: 2025-12-11
+**Version**: 2.1
+**Last Updated**: 2026-07-28
 
 This document provides a comprehensive mapping of how Jira entities are transformed into OpenProject entities during migration.
 
@@ -23,7 +23,7 @@ This document provides a comprehensive mapping of how Jira entities are transfor
 | **Resolution** | Custom Field Value | `resolutions` | On "Resolution" CF |
 | **Component** | Custom Field Value | `components` | On "Component" CF |
 | **Version** | Version | `versions` | Release tracking |
-| **Sprint** | Version (Sprint type) | `sprint_epic` | Agile planning |
+| **Sprint** | Version | `agile_boards` + `sprint_epic` | Not OpenProject's native Sprint object — see [§11](#11-agile-migration) |
 | **Epic** | Work Package (Epic type) | `sprint_epic` | Hierarchy parent |
 | **Label** | Tag | `labels` / `native_tags` | Categorization |
 | **Attachment** | Attachment | `attachments` | File transfer |
@@ -33,7 +33,7 @@ This document provides a comprehensive mapping of how Jira entities are transfor
 | **Link Type** | Relation Type | `link_types` | Relation taxonomy |
 | **Watcher** | Watcher | `watchers` | Notification |
 | **Vote** | Custom Field Value | `votes_reactions` | On "Votes" CF |
-| **Board** | Saved Query | `agile_boards` | Kanban/Scrum views |
+| **Board** | Saved Query | `agile_boards` | Filters/columns not reproduced — see [§11](#11-agile-migration) |
 | **Filter** | Saved Query | `reporting` | Saved searches |
 | **Dashboard** | Wiki Page | `reporting` | Project overview |
 | **Role Membership** | Project Membership | `admin_schemes` | Access control |
@@ -352,31 +352,92 @@ outwardIssue: PROJ-2         ──→  to_id: WP#2
 
 ### 11. Agile Migration
 
+#### Jira Sprint → OpenProject Version
+
 ```
 Jira Sprint                       OpenProject Version
 ──────────────────────────────    ──────────────────────────────
 name: "Sprint 1"             ──→  name: "Sprint 1"
-startDate: "2024-01-01"      ──→  start_date
-endDate: "2024-01-14"        ──→  effective_date (end)
-state: "active"              ──→  status: "open"
 goal: "..."                  ──→  description
+startDate: "2024-01-01"      ──→  start_date
+endDate: "2024-01-14"        ──→  due_date
+state: "closed"              ──→  status: "closed" (any other state → "open")
+—                            ──→  sharing: "none"
 ```
 
+The version itself is created by `agile_boards` (`AgileBoardMigration`), which
+also writes the `sprint` mapping. `sprint_epic` (`SprintEpicMigration`) then
+applies the sprint to the work packages:
+
+| Jira | OpenProject | Notes |
+|------|-------------|-------|
+| Issue's sprint | `work_package.version_id` | Only the **first** sprint that resolves via the `sprint` mapping |
+| Issue's sprint(s) | CF "Sprint" (text) | **All** names, de-duplicated, sorted, comma-separated |
+
+An issue that belonged to several sprints therefore keeps every sprint name in
+the "Sprint" custom field, but is assigned to only one version.
+
+#### Jira Board → OpenProject Saved Query
+
 ```
-Jira Board                        OpenProject Saved Query
+Jira Board                        OpenProject Query
 ──────────────────────────────    ──────────────────────────────
-name: "Scrum Board"          ──→  name: "Scrum Board"
-type: "scrum"                ──→  filters (sprint-based)
-columns: [...]               ──→  columns configuration
+name: "Scrum Board"          ──→  name: "[Board] Scrum Board"
+type / filter JQL / statuses ──→  description (plain text)
+—                            ──→  filters: []  (not derived)
+—                            ──→  columns: []  (not derived)
+—                            ──→  is_public: true
 ```
 
-**Component**: `sprint_epic` (`SprintEpicMigration`), `agile_boards` (`AgileBoardMigration`)
+The board type, its original JQL and its column/status list are recorded in the
+query description for reference only — they are **not** translated into query
+filters or column configuration. The resulting query lists the project's work
+packages with OpenProject's default filters.
+
+#### Why boards and sprints are not mapped 1:1
+
+**Sprint → Version** matched OpenProject's own data model when this mapping was
+written: in the Backlogs module a sprint *was* a version. OpenProject 17.3
+(2026-04-15) changed that — sprints became independent objects "no longer linked
+to versions". Since this toolset now targets OpenProject 17.3+ (see `README.md`),
+the version-based mapping is a legacy shape.
+
+**Board → Saved Query** is a lowest-common-denominator choice driven by
+OpenProject's Enterprise gating:
+
+- *Basic boards* are part of the Community edition since OpenProject 12.1, but a
+  basic board is only a set of manually ordered lists — moving a card there does
+  not change the work package.
+- *Action boards* (status/Kanban, assignee, version, subproject, parent-child) —
+  the ones that carry the semantics of a Jira board column — remain an Enterprise
+  add-on.
+
+A saved query works on every edition; a faithful board → board migration needs an
+Enterprise target for anything beyond a basic board.
+
+**Planned change** (agreed in [#260](https://github.com/netresearch/jira-to-openproject/issues/260#issuecomment-5100423937),
+not yet implemented): map sprints to native OpenProject sprints and boards to
+boards, keeping board → saved query as an optional fallback for Community
+targets.
+
+**References**:
+- [OpenProject 17.3 release notes](https://www.openproject.org/docs/release-notes/17-3-0/) — sprints as independent objects
+- [Agile boards in the Community edition](https://www.openproject.org/blog/agile-boards-for-community/) — basic vs. action boards
+- [Boards user guide](https://www.openproject.org/docs/user-guide/agile-boards/)
+
+**Component**: `agile_boards` (`AgileBoardMigration`), `sprint_epic` (`SprintEpicMigration`)
 
 ---
 
 ## Migration Execution Order
 
-The recommended migration sequence ensures dependencies are satisfied:
+The recommended migration sequence ensures dependencies are satisfied. The
+executable order is `DEFAULT_COMPONENT_SEQUENCE` in
+`src/application/components/registry.py`; where the two differ, the registry
+wins. Known divergence: the registry runs `agile_boards` and `sprint_epic`
+*before* `work_packages_skeleton`, so on a cold full run `sprint_epic` finds an
+empty `work_package` mapping and applies no version assignments, parent links or
+"Sprint" custom-field values.
 
 ```
 1. FOUNDATION
@@ -409,8 +470,8 @@ The recommended migration sequence ensures dependencies are satisfied:
    └── versions       # Depends on: projects
    └── components     # Depends on: projects
    └── labels         # Depends on: work_packages
-   └── sprint_epic    # Depends on: projects, work_packages
-   └── agile_boards   # Depends on: sprint_epic
+   └── agile_boards   # Depends on: projects — creates the sprint versions + board queries
+   └── sprint_epic    # Depends on: agile_boards (sprint mapping), work_packages
 
 7. RELATIONSHIPS
    └── relations      # Depends on: work_packages

--- a/docs/MIGRATION_COMPONENTS.md
+++ b/docs/MIGRATION_COMPONENTS.md
@@ -47,8 +47,8 @@ The j2o migration tool consists of 40+ specialized migration components, each ha
 | RelationMigration | `relations` | Stable | Yes | Issue links |
 | WatcherMigration | `watchers` | Stable | Yes | Notifications |
 | **Agile** |
-| SprintEpicMigration | `sprint_epic` | Stable | Yes | Sprints/Epics |
-| AgileBoardMigration | `agile_boards` | Stable | Yes | Board views |
+| SprintEpicMigration | `sprint_epic` | Stable | Yes | Sprint/Epic links on WPs |
+| AgileBoardMigration | `agile_boards` | Stable | Yes | Board queries + sprint versions |
 | VersionsMigration | `versions` | Stable | Yes | Release tracking |
 | AffectsVersionsMigration | `affects_versions` | Stable | Yes | Version links |
 | **Labels & Tags** |
@@ -498,35 +498,43 @@ Migrates Jira issue link types to OpenProject relation types.
 
 ### SprintEpicMigration
 
-**Location**: `src/migrations/sprint_epic_migration.py`
+**Location**: `src/application/components/sprint_epic_migration.py`
 
-Migrates Jira sprints and epics.
+Applies Jira sprint membership and Epic Links to already-migrated work packages.
+The sprint versions themselves are created by `AgileBoardMigration`.
 
 **Features**:
-- Sprint → Version mapping
-- Epic → Work package type
-- Sprint dates and goals
-- Epic hierarchies
+- Epic Link → `parent_id` hierarchy on the child work package
+- Sprint → `version_id` on the work package, resolved via the `sprint` mapping
+  (first matching sprint only)
+- Sprint → "Sprint" text custom field, holding all sprint names comma-separated
 
-**Dependencies**: ProjectMigration, WorkPackageMigration
+**Dependencies**: ProjectMigration, WorkPackageMigration, AgileBoardMigration
+(provides the `sprint` mapping)
 
-**Related**: AgileBoardMigration
+**Related**: AgileBoardMigration, [Entity Mapping §11](ENTITY_MAPPING.md#11-agile-migration)
 
 ---
 
 ### AgileBoardMigration
 
-**Location**: `src/migrations/agile_board_migration.py`
+**Location**: `src/application/components/agile_board_migration.py`
 
-Migrates Jira agile boards to OpenProject saved queries.
+Creates one OpenProject saved query per Jira board and one OpenProject version
+per Jira sprint. Handles the entity types `agile_boards` and `sprints`.
 
 **Features**:
-- Board → Saved query mapping
-- Sprint filters
-- Column configuration
-- Quick filters
+- Board → public saved query named `[Board] <name>`; board type, original JQL and
+  column/status list go into the query **description** only — filters and columns
+  are left empty
+- Sprint → project version (name, goal → description, start/due date, open/closed
+  status), persisted in the `sprint` mapping for `SprintEpicMigration`
 
-**Dependencies**: ProjectMigration, SprintEpicMigration
+**Not** mapped to OpenProject's native boards or (since 17.3) native sprints —
+see [Entity Mapping §11](ENTITY_MAPPING.md#11-agile-migration) for the reasoning
+and the planned change.
+
+**Dependencies**: ProjectMigration
 
 **Example Usage**:
 ```bash


### PR DESCRIPTION
## Summary

- Corrects `docs/ENTITY_MAPPING.md` §11, which described an agile mapping the code does not implement
- Records why Jira boards/sprints are not mapped 1:1, asked for in #260
- Aligns `AGENTS.md` with the OpenProject 17.3+ target already stated in `README.md` and `src/AGENTS.md`

## Changes

**Mapping corrected to match the code** (`agile_board_migration.py`, `sprint_epic_migration.py`):

| Documented before | Actual |
|---|---|
| sprint end → `effective_date` | `due_date` (no `effective_date` anywhere in `src/`) |
| query named `<board name>` | `[Board] <board name>` |
| board type → `filters (sprint-based)`, `columns → columns configuration` | `filters: []`, `columns: []`; type/JQL/statuses go into the query description only |
| Sprint handled by `sprint_epic` | version created by `agile_boards`; `sprint_epic` sets `version_id` (first match only) and the "Sprint" text CF |

**Rationale added**, with sources: sprint → version matched OpenProject's own data model until [17.3](https://www.openproject.org/docs/release-notes/17-3-0/) made sprints independent objects; board → saved query is edition-independent, while [action boards](https://www.openproject.org/blog/agile-boards-for-community/) remain an Enterprise add-on. Includes the planned change agreed in #260 (sprint → sprint, board → board, saved query as optional fallback).

**Dependency direction flipped** — both docs had `agile_boards` depending on `sprint_epic`; `DEFAULT_COMPONENT_SEQUENCE` runs it the other way, and `sprint_epic` consumes the `sprint` mapping `agile_boards` writes. The registry is now named as the authoritative order, with the ordering divergence tracked in #302.

**Component sections** in `docs/MIGRATION_COMPONENTS.md` rewritten, including their `src/migrations/` → `src/application/components/` paths. The remaining ~51 stale `src/migrations/` references in other sections are out of scope here.

## Type of Change

- [x] Documentation update

## Testing

- [x] Documentation-only change; no code paths touched
- [x] Every corrected claim verified against the source (`agile_board_migration.py:176-265`, `sprint_epic_migration.py:186-360`, `registry.py:86-168`, `openproject_project_setup_service.py:239-300`)

## Checklist

- [x] My code follows the project's coding style
- [x] I have updated documentation (if applicable)
- [x] I have checked for security implications

## Related Issues

Relates to #260, #302
